### PR TITLE
Add alpha data for school registers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,10 @@ environment.sh
 raw_addresses
 *.swp
 tmp
+
+_build
+deps
+mix.lock
+
+*.tsv
+*.ods

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SCHOOL_DATA=\
 	data/diocese/dioceses.tsv\
 	data/school-federation/school-federations.tsv\
 	data/school-phase/school-phases.tsv\
+	data/school-trust/school-trusts.tsv\
 	data/school-type/school-types.tsv
 
 ADDRESS_DATA=\
@@ -29,7 +30,18 @@ all:: flake8 $(DATA)
 
 data/school/schools.tsv: bin/schools.py cache/edubase.csv $(MAPS) $(SCHOOL_DATA)
 	@mkdir -p data/school
-	bin/schools.py < cache/edubase.csv > $@
+	[[ -e $@ ]] || bin/schools.py < cache/edubase.csv > $@
+
+data/school-trust/school-trusts.tsv: cache/links mix.deps
+	@mkdir -p data/school-trust
+	[[ -e $@ ]] || mix run -e 'SchoolTrust.trust_tsv' > data/school-trust/tmp.tsv
+	[[ -e $@ ]] || mix run -e 'SchoolTrust.trust_map_tsv' < data/school-trust/tmp.tsv > maps/school-trust.tsv
+	[[ -e $@ ]] || mix run -e 'SchoolTrust.trust_data_tsv' < data/school-trust/tmp.tsv > $@
+	rm -f data/school-trust/tmp.tsv
+
+mix.deps:
+	[[ -e mix.lock ]] || mix deps.get
+	mix compile
 
 # extract school addresses from address-data
 data/address/addresses.tsv:	bin/addresses.py data/school/schools.tsv
@@ -48,6 +60,13 @@ cache/edubase.csv:
 	@mkdir -p cache
 	curl -s $(EDUBASE_URL) | iconv -f ISO-8859-1 -t UTF-8 > $@
 
+cache/links:
+	[[ -e "./cache/links.xhtml?printable=1&urn=402378" ]] || \
+	  ( \
+		  cd cache && sed 1d edubase.csv | \
+		  awk -F "\"*,\"*" '{ print "http://www.education.gov.uk/edubase/establishment/links.xhtml?printable=1&urn="$$1}' | \
+			xargs -P4 -n 1 curl -S -O \
+		)
 
 init::
 	pip3 install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ EDUBASE_URL=http://www.education.gov.uk/edubase/edubasealldata$(DATE).csv
 
 DATA=\
 	data/school/schools.tsv\
+	data/alpha/school-eng/schools.tsv\
 	$(SCHOOL_DATA)\
 	$(ADDRESS_DATA)
 
@@ -31,6 +32,12 @@ all:: flake8 $(DATA)
 data/school/schools.tsv: bin/schools.py cache/edubase.csv $(MAPS) $(SCHOOL_DATA)
 	@mkdir -p data/school
 	[[ -e $@ ]] || bin/schools.py < cache/edubase.csv > $@
+
+data/alpha/school-eng/schools.tsv: mix.deps data/school/schools.tsv
+	@mkdir -p data/alpha/school-eng
+	[[ -e $@ ]] || mix run -e 'SchoolSubset.schools_in_local_authority("919")' < data/school/schools.tsv > data/alpha/school-eng/tmp.tsv
+	[[ -e $@ ]] || mix run -e 'SchoolSubset.school_tsv("./data/alpha/school-eng/tmp.tsv")' < data/school/schools.tsv > $@
+	rm -f data/alpha/school-eng/tmp.tsv
 
 data/school-trust/school-trusts.tsv: cache/links mix.deps
 	@mkdir -p data/school-trust

--- a/bin/schools.py
+++ b/bin/schools.py
@@ -22,6 +22,7 @@ fields = [
     "school-gender",
     "school-tags",
     # "school-federation",
+    "school-trust",
     "start-date",
     "end-date",
 ]
@@ -53,13 +54,21 @@ def load_names(field, path, name_field='name'):
 
     for row in csv.DictReader(open(path),
                               delimiter='\t', quoting=csv.QUOTE_NONE):
-            names[field][n7e(row[name_field])] = row[field]
+            name_key = n7e(row[name_field])
+            if name_key == '':
+                name_key = row[name_field]
+            value = row[field]
+            names[field][name_key] = value
 
 
 def map_name(field, name):
+
     if not name:
         return ''
     _name = n7e(name)
+    if _name == '':
+        _name = name
+
     if _name in names[field]:
         return names[field][_name]
     log("unknown %s value [%s]" % (field, name))
@@ -112,6 +121,8 @@ if __name__ == '__main__':
     load_names('school-phase', 'data/school-phase/school-phases.tsv')
     load_names('school-phase', 'maps/school-phase.tsv')
 
+    load_names('school-trust', 'maps/school-trust.tsv', 'school')
+
     load_names('school-type', 'data/school-type/school-types.tsv')
     load_names('school-type', 'maps/school-type.tsv')
 
@@ -144,6 +155,8 @@ if __name__ == '__main__':
         item['school-gender'] = map_name('school-gender', row['Gender (name)'])
         item['school-phase'] = map_name('school-phase', row['PhaseOfEducation (name)'])
         item['school-type'] = map_name('school-type', row['TypeOfEstablishment (name)'])
+
+        item['school-trust'] = map_name('school-trust', row['URN'])
 
         item['school-admissions-policy'] = ''
         item['school-authority'] = row['LA (code)']

--- a/bin/schools.py
+++ b/bin/schools.py
@@ -13,7 +13,7 @@ fields = [
     "minimum-age",
     "maximum-age",
     # "headteacher",
-    "website",
+    # "website",
     "denominations",
     "dioceses",
     "school-type",
@@ -155,8 +155,8 @@ if __name__ == '__main__':
         # item['headteacher'] = "%s %s %s" % (
         #     row['HeadTitle (name)'], row['HeadFirstName'], row['HeadLastName'])
 
-        if row["SchoolWebsite"]:
-            item['website'] = fix_http_url(row["SchoolWebsite"])
+        # if row["SchoolWebsite"]:
+        #     item['website'] = fix_http_url(row["SchoolWebsite"])
 
         if item['school'] in address:
             item['address'] = address[item['school']]

--- a/bin/schools.py
+++ b/bin/schools.py
@@ -12,7 +12,7 @@ fields = [
     "school-authority",
     "minimum-age",
     "maximum-age",
-    "headteacher",
+    # "headteacher",
     "website",
     "denominations",
     "dioceses",
@@ -152,8 +152,8 @@ if __name__ == '__main__':
         item['minimum-age'] = fix_age(row['StatutoryLowAge'])
         item['maximum-age'] = fix_age(row['StatutoryHighAge'])
 
-        item['headteacher'] = "%s %s %s" % (
-            row['HeadTitle (name)'], row['HeadFirstName'], row['HeadLastName'])
+        # item['headteacher'] = "%s %s %s" % (
+        #     row['HeadTitle (name)'], row['HeadFirstName'], row['HeadLastName'])
 
         if row["SchoolWebsite"]:
             item['website'] = fix_http_url(row["SchoolWebsite"])

--- a/bin/schools.py
+++ b/bin/schools.py
@@ -21,7 +21,7 @@ fields = [
     "school-admissions-policy",
     "school-gender",
     "school-tags",
-    "school-federation",
+    # "school-federation",
     "start-date",
     "end-date",
 ]
@@ -104,7 +104,7 @@ if __name__ == '__main__':
     load_names('diocese', 'data/diocese/dioceses.tsv')
     load_names('diocese', 'maps/diocese.tsv')
 
-    load_names('school-federation', 'data/school-federation/school-federations.tsv')
+    # load_names('school-federation', 'data/school-federation/school-federations.tsv')
 
     load_names('school-gender', 'data/school-gender/school-genders.tsv')
     load_names('school-gender', 'maps/school-gender.tsv')
@@ -140,7 +140,7 @@ if __name__ == '__main__':
 
         item['denominations'] = map_list('denomination', row['ReligiousCharacter (name)'])
         item['dioceses'] = map_name('diocese', row['Diocese (name)'])
-        item['school-federation'] = map_name('school-federation', row['Federations (name)'])
+        # item['school-federation'] = map_name('school-federation', row['Federations (name)'])
         item['school-gender'] = map_name('school-gender', row['Gender (name)'])
         item['school-phase'] = map_name('school-phase', row['PhaseOfEducation (name)'])
         item['school-type'] = map_name('school-type', row['TypeOfEstablishment (name)'])

--- a/data/alpha/diocese/dioceses.tsv
+++ b/data/alpha/diocese/dioceses.tsv
@@ -1,0 +1,64 @@
+diocese	name	denomination	start-date	end-date
+RC03	Archdiocese of Birmingham	C67		
+RC20	Archdiocese of Cardiff	C67		
+RC11	Archdiocese of Liverpool	C67		
+RC19	Archdiocese of Southwark	C67		
+RC01	Archdiocese of Westminster	C67		
+RC02	Diocese of Arundel and Brighton	C67		
+CE01	Diocese of Bath and Wells	C22		
+CE02	Diocese of Birmingham	C22		
+CE03	Diocese of Blackburn	C22		
+CE04	Diocese of Bradford	C22		
+RC04	Diocese of Brentwood	C67		
+CE05	Diocese of Bristol	C22		
+CE06	Diocese of Canterbury	C22		
+CE07	Diocese of Carlisle	C22		
+CE08	Diocese of Chelmsford	C22		
+CE09	Diocese of Chester	C22		
+CE10	Diocese of Chichester	C22		
+RC05	Diocese of Clifton	C67		
+CE11	Diocese of Coventry	C22		
+CE12	Diocese of Derby	C22		
+CE13	Diocese of Durham	C22		
+RC06	Diocese of East Anglia	C67		
+CE14	Diocese of Ely	C22		
+CE15	Diocese of Exeter	C22		
+CE16	Diocese of Gloucester	C22		
+CE17	Diocese of Guildford	C22		
+RC07	Diocese of Hallam	C67		
+CE18	Diocese of Hereford	C22		
+RC08	Diocese of Hexham and Newcastle	C67		
+RC09	Diocese of Lancaster	C67		
+RC10	Diocese of Leeds	C67		
+CE19	Diocese of Leicester	C22		
+CE20	Diocese of Lichfield	C22		
+CE21	Diocese of Lincoln	C22		
+CE22	Diocese of Liverpool	C22		
+CE23	Diocese of London	C22		
+CE24	Diocese of Manchester	C22		
+RC12	Diocese of Middlesbrough	C67		
+CE25	Diocese of Newcastle	C22		
+RC13	Diocese of Northampton	C67		
+CE26	Diocese of Norwich	C22		
+RC14	Diocese of Nottingham	C67		
+CE27	Diocese of Oxford	C22		
+CE28	Diocese of Peterborough	C22		
+RC15	Diocese of Plymouth	C67		
+CE29	Diocese of Portsmouth	C22		
+RC16	Diocese of Portsmouth	C67		
+CE30	Diocese of Ripon	C22		
+CE31	Diocese of Rochester	C22		
+RC17	Diocese of Salford	C67		
+CE34	Diocese of Salisbury	C22		
+CE35	Diocese of Sheffield	C22		
+RC18	Diocese of Shrewsbury	C67		
+CE36	Diocese of Southwark	C22		
+CE37	Diocese of Southwell	C22		
+CE32	Diocese of St Albans	C22		
+CE33	Diocese of St Edmundsbury and Ipswich	C22		
+CE38	Diocese of Truro	C22		
+CE39	Diocese of Wakefield	C22		
+CE43	Diocese of West Yorkshire and the Dales	C22		
+CE40	Diocese of Winchester	C22		
+CE41	Diocese of Worcester	C22		
+CE42	Diocese of York	C22		

--- a/data/alpha/religious-character/religious-characters.tsv
+++ b/data/alpha/religious-character/religious-characters.tsv
@@ -1,0 +1,161 @@
+religious-charactername	start-date	end-date
+A1	Baha'i		
+B1	Buddhist		
+B2	Mahayana Buddhist		
+B3	New Kadampa Tradition Buddhist		
+B4	Nichiren Buddhist		
+B5	Pure Land Buddhist		
+B6	Theravada Buddhist		
+B7	Tibetan Buddhist		
+B8	Zen Buddhist		
+C1	Christian		
+C2	Amish		
+C3	Anabaptist		
+C4	Anglican		
+C5	Apostolic Pentecostalist		
+C6	Armenian Catholic		
+C7	Armenian Orthodox		
+C8	Baptist		
+C8r	Reformed Baptist		
+C9	Brethren		
+C10	Bulgarian Orthodox		
+C11	Calvinist		
+C12	Catholic		
+C13	Celtic Christian		
+C14	Celtic Orthodox Christian		
+C15	Chinese Evangelical Christian		
+C16	Christadelphian		
+C17	Christian Existentialist		
+C18	Christian Humanist		
+C19	Christian Science		
+C20	Christian Spiritualist		
+C21	Church in Wales		
+C22	Church of England		
+C23	Church of God of Prophecy		
+C24	Church of Ireland		
+C25	Church of Scotland		
+C26	Congregational		
+C27	Coptic Orthodox		
+C28	Eastern Catholic		
+C29	Eastern Orthodox		
+C30	Elim Pentecostalist		
+C31	Ethiopian Orthodox		
+C32	Evangelical		
+C33	Exclusive Brethren		
+C34	Free Church		
+C35	Free Church of Scotland		
+C36	Free Evangelical Presbyterian		
+C37	Free Methodist		
+C38	Free Presbyterian		
+C39	French Protestant		
+C40	Greek Catholic		
+C41	Greek Orthodox		
+C42	Independent Methodist		
+C43	Indian Orthodox		
+C44	Jehovah's Witness		
+C45	Judaic Christian		
+C46	Lutheran		
+C47	Mennonite		
+C48	Messianic Jew		
+C49	Methodist		
+C50	Moravian		
+C51	Mormon		
+C52	Nazarene Church		
+C53	New Testament Pentacostalist		
+C54	Nonconformist		
+C55	Old Catholic		
+C56	Open Brethren		
+C57	Orthodox Christian		
+C58	Pentecostalist		
+C59	Presbyterian		
+C60	Protestant		
+C61	Plymouth Brethren		
+C62	Quaker		
+C63	Rastafari		
+C64	Reformed Christian		
+C65	Reformed Presbyterian		
+C66	Reformed Protestant		
+C67	Roman Catholic		
+C68	Romanian Orthodox		
+C69	Russian Orthodox		
+C70	Salvation Army Member		
+C71	Scottish Episcopalian		
+C72	Serbian Orthodox		
+C73	Seventh Day Adventist		
+C74	Syrian Orthodox		
+C75	Ukrainian Catholic		
+C76	Ukrainian Orthodox		
+C77	Uniate Catholic		
+C78	Unitarian		
+C79	United Reform		
+C80	Zwinglian		
+C1c	Non-denominational		
+D1	Hindu		
+D2	Advaitin Hindu		
+D3	Arya Samaj Hindu		
+D4	Shakti Hindu		
+D5	Shiva Hindu		
+D6	Vaishnava Hindu		
+E1	Jain		
+F1	Jewish		
+F1c	Charadi Jewish		
+F2	Ashkenazi Jew		
+F3	Haredi Jew		
+F4	Hasidic Jew		
+F5	Liberal Jew		
+F6	Masorti Jew		
+F7	Orthodox Jew		
+F8	Reform Jew		
+G1	Islam		
+G2	Ahmadi		
+G3	Druze		
+G4	Ismaili Muslim		
+G5	Shi'ite Muslim		
+G6	Sunni Deobandi		
+H1	Pagan		
+H2	Asatruar		
+H3	Celtic Pagan		
+H4	Druid		
+H5	Goddess		
+H6	Heathen		
+H7	Occultist		
+H8	Shaman		
+H9	Wiccan		
+I1	Sikh		
+J1	Zoroastrian		
+K1	Agnostic		
+K2	Ancestral Worship		
+K3	Animist		
+K4	Anthroposophist		
+K5	Black Magic		
+K6	Brahma Kumari		
+K7	British Israelite		
+K8	Chondogyo		
+K9	Confucianist		
+K10	Deist		
+K11	Humanist		
+K12	Infinite Way		
+K13	Kabbalist		
+K14	Lightworker		
+K15	New Age Practitioner		
+K16	Native American Religion		
+K17	Pantheist		
+K18	Peyotist		
+K19	Radha Soami		
+K20	Other (Not Listed)		
+K20a	Multi-faith		
+K21	Santeri		
+K22	Satanist		
+K23	Scientologist		
+K24	Secularist		
+K25	Shumei		
+K26	Shinto		
+K27	Spiritualist		
+K28	Swedenborgian		
+K29	Taoist		
+K30	Unitarian-Universalist		
+K31	Universalist		
+K32	Vodun		
+k33	Yoruba		
+L1	Atheist		
+L2	Not Religious		

--- a/data/alpha/school-admissions-policy/school-admissions-policies.tsv
+++ b/data/alpha/school-admissions-policy/school-admissions-policies.tsv
@@ -1,0 +1,5 @@
+school-admissions-policy	name	start-date	end-date
+N	Non-selective		
+C	Comprehensive (secondary)		
+S	Selective (grammar)		
+M	Modern (secondary)		

--- a/data/alpha/school-authority/school-authority.tsv
+++ b/data/alpha/school-authority/school-authority.tsv
@@ -1,0 +1,2 @@
+school-authority	name	organisation
+919		local-authority-eng:HRT

--- a/data/alpha/school-gender/school-genders.tsv
+++ b/data/alpha/school-gender/school-genders.tsv
@@ -1,0 +1,4 @@
+school-gender	name	start-date	end-date
+B	Boys		
+G	Girls		
+M	Mixed		

--- a/data/alpha/school-phase/school-phases.tsv
+++ b/data/alpha/school-phase/school-phases.tsv
@@ -1,0 +1,8 @@
+school-phase	name	start-date	end-date
+ALL	All Through		
+NUR	Nursery		
+PRI	Primary		
+SEC	Secondary		
+16P	16 Plus		
+MDP	Middle Deemed Primary		
+MDS	Middle Deemed Secondary		

--- a/data/alpha/school-trust/school-trusts.tsv
+++ b/data/alpha/school-trust/school-trusts.tsv
@@ -1,0 +1,1042 @@
+school-trust	name	organisation
+15710	Activate Learning Education Trust	company:08707909
+15711	Romero Catholic Academy, The	company:09702162
+15712	St Edmundsbury and Ipswich Diocesan Multi-Academy Trust	company:09499496
+15713	Yorkshire Collaborative Academy Trust	company:09668526
+15715	The Small Schools Multi Academy Trust	company:09613632
+15716	Manor Hall Academy Trust	company:09461655
+15717	Learning for Life Trust	company:09690231
+15718	The Three Saints Academy Trust	company:09626002
+15719	The Warriner Multi Academy Trust	company:09696059
+15720	West Oxford Schools Trust	company:09591931
+15726	Benfleet Schools Trust	company:07561574
+15727	Red Kite Learning Trust	company:07523507
+15728	Consilium Academies	company:09495671
+15729	Batley Multi Academy Trust	company:07732537
+15730	Heart Education Trust, The	company:08286818
+15732	Futures Trust, The	company:08678162
+15747	The Westgate School	company:09583593
+15748	TEES VALLEY EDUCATION	company:09630999
+15750	Warden House Trust	company:09692191
+15751	Excell3 Independent Schools Ltd	company:07654452
+15753	St. James And Emmanuel Academy Trust Ltd	company:08652284
+15754	GEMS Learning Trust	company:08346116
+15755	Floreat Education Academies Trust	company:09007740
+15756	Knowledge School Trust	company:09027131
+15757	The CSIA Trust	company:07551989
+15758	Great Schools Trust, The	company:07641004
+15759	Big Life Schools	company:07945230
+15760	Skinners' Kent Academy, The	company:06912857
+15761	Dulwich Hamlet Educational Trust	company:07531811
+15762	Maiden Erlegh Trust	company:07548754
+15763	The Khalsa Academies Trust Limited	company:07549443
+15764	Chesham Grammar School Academy Trust	company:07697482
+15765	William Howard Trust	company:07698631
+15766	Finham Park Multi-Academy Trust	company:07700317
+15767	Bursley Multi Academy Trust	company:07972070
+15769	New Bridge Multi Academy Trust	company:08131158
+15771	The Challenger Multi Academy Trust	company:09270040
+15772	Carillion Academies Trust	company:09323071
+15773	Compass Academy Trust	company:09323096
+15774	The Moorlands Primary Federation	company:09378112
+15775	Shavington Academy	company:09587693
+15776	Sabden Multi Academy Trust, The	company:09611796
+15777	Russett Learning Trust, The	company:09617195
+15778	Elmwey Learning Trust	company:09625982
+15779	Medway Anglican Schools Trust	company:09628754
+15780	King Edward VI Education Trust	company:09635329
+15781	Cirrus Primary Academy Trust	company:09642581
+15782	Argent Trust	company:09646939
+15784	The Derwent Trust	company:09648418
+15785	St Alban Catholic Academies Trust	company:09660515
+15786	Venn Academy Trust	company:09662303
+15787	Amadeus Primary Academies Trust	company:09662313
+15788	Our Lady of Light Catholic Academy Trust	company:09676023
+15789	Birchwood Academy Trust	company:09679683
+15791	Penlee Academy Trust	company:09683218
+15792	Lincolnshire Wolds Community Trust	company:09691946
+15793	Inspired Learning Multi Academy Trust	company:09692208
+15794	St Mary's Catholic Primary Schools Trust	company:09693822
+15795	Suffolk Academies Trust	company:09702333
+15796	TCAT Multi Academy Trust	company:09709935
+15797	PA Community Trust	company:09718257
+15799	Inspire Education Trust	company:09728614
+15856	EBN Trust	company:07665550
+15858	Baylis Court Trust	company:07662414
+15863	South Newcastle Trust	company:09679560
+15864	The Kite Academy Trust	company:09785186
+15865	The Pathway Academy Trust	company:09782388
+15866	Elston Hall Multi Academy Trust	company:09780473
+15867	Riviera Primary Academy Trust	company:09751294
+15868	Bournemouth Primary MAT	company:09754024
+15870	Sparkle Multi-Academy Trust	company:09741508
+15872	Every Child Matters Academy Trust	company:09700223
+15873	drb Ignite Multi Academy Trust	company:09284055
+15877	Furness Academies Trust	company:06895426
+15878	Leo Academy Trust	company:07543202
+15879	Cornerstone Academy Trust	company:07339625
+15880	The Hamblin Education Trust	company:07484717
+15881	Cheam Academies Network	company:07588097
+15882	Nonsuch and Wallington Education Trust	company:07627961
+15883	The Robert Carre Trust	company:07671174
+15884	The De Ferrers Trust	company:07442789
+15885	The Liverpool Joint Catholic and Church of England Academies Trust	company:07007398
+15886	The Mill Academy	company:08060721
+15888	Pride Multi Academy Trust	company:08582084
+15897	Harlow Inspirational Learning Trust	company:09791050
+15899	Brite Trust	company:09795288
+15900	Rushey Mead Educational Trust	company:09079258
+15901	St Hilda’s Catholic Academy Trust	company:09811711
+15902	WCGS Academy Trust	company:07627302
+15903	The Tenax Schools Trust	company:07542155
+15904	Unity Schools Trust	company:07692130
+15905	The Rivers Multi Academy Trust	company:07697367
+15906	All Saints Multi Academy Trust, Birmingham	company:08255653
+15935	Mercian Educational Trust	company:07698974
+15936	The Collegiate Trust	company:08058921
+15937	EPA Multi Academy Trust (Excellent Partnerships Achieve)	company:07896123
+15950	Lever Academy Trust	company:09677480
+15951	Highfields School	company:09527057
+15952	The Learning for Life Partnership	company:09675372
+15953	The Heath Academy Trust	company:09809895
+15954	Discover Multi Academy Trust	company:09680241
+15958	Haybrook College Trust	company:09606079
+15964	Crewe Multi Academy Trust	company:09379253
+15966	Sovereign Trust	company:09666511
+15967	The Inspire Multi Academy Trust (South West)	company:09916360
+15968	Thedwastre Education Trust	company:09896672
+15969	Rivermead Inclusive Trust	company:09853252
+15970	Spring Common Academy Trust	company:09896071
+15971	All Saints Trust	company:09887971
+15972	Barchelai Academy Trust	company:08326570
+16003	Cascade Multi Academy Trust	company:09913676
+16004	Cockburn Multi Academy Trust	company:09946495
+16005	Cygnus Academies Trust	company:09950137
+16008	Leaders in Learning Multi Academy Trust	company:09482529
+16011	Manor Multi Academy Trust	company:09323792
+16012	Mid-Trent Multi Academy Trust	company:09878928
+16013	Northern Saints Catholic Education Trust	company:09940352
+16015	Abney Trust	company:09912859
+16016	The Blue Kite Academy Trust	company:09889819
+16026	Cathedral Schools Trust	company:06516626
+16028	The Thomas Hardye Multi Academy Trust	company:07677838
+16029	Millfield Community Academy Trust	company:07705438
+16030	RMET	company:07654628
+16031	Bottisham Multi Academy Trust	company:07564749
+16032	Priorslee Multi-Academy Trust	company:07481145
+16033	Brooke Hill Academy Trust Limited	company:07693338
+16034	St George's Church of England Academy	company:07984221
+16035	The Trinity Catholic Multi Academy Trust	company:07890590
+16036	Mid Essex Anglican Academy Trust	company:08524638
+16038	Sheffield UTC Academy Trust, The	company:07652696
+16040	Nexus Education Schools Trust	company:08753719
+16041	Trinity Academy Newcastle	company:08449062
+16042	The Howard Academy Trust	company:09175427
+16043	King's Group Academies	company:09017776
+16045	Holy Trinity Catholic Multi Academy Company	company:10013691
+16046	Leodis Academies Trust	company:07720181
+16049	Roseland Multi Academy Trust, The	company:07557817
+16050	Feversham Education Trust	company:07697587
+16051	Balmoral Learning Trust	company:08083620
+16052	Tudor Park Education Trust	company:07798639
+16054	The Wensum Trust	company:07982312
+16055	Launceston College	company:08150106
+16063	Comenius Trust	company:10049139
+16066	Bolton Impact Trust, The	company:09971348
+16068	River Tees Multi-Academy Trust	company:09861442
+16070	Portico Academy Trust	company:09952066
+16072	Mulberry Academy Trust	company:09648420
+16073	South Bank Multi Academy Trust	company:10067116
+16074	Link Academy Trust	company:10049068
+16075	Aston Tower Multi-Academy Trust	company:10034419
+16076	Kendal Primary Multi Academy Trust	company:09996478
+16077	Chiltern Way Academy Trust	company:10004115
+16078	Talentum Learning Trust, The	company:09999238
+16079	Excellence in Education Trust	company:10035934
+16080	Urbis Academy Trust	company:10035844
+16081	Southgate School Academy Trust	company:10039553
+16084	St Thomas of Canterbury Catholic Academies Trust	company:09980467
+16085	St. Thomas of Canterbury Catholic Multi Academy Trust	company:10034058
+16086	Southfield Trust, The	company:10042321
+16090	Premier Learning Trust Limited	company:10065284
+16091	Key Educational Trust, The	company:07702211
+16092	Chancery Education Trust	company:07671255
+16093	Two Counties Trust, The	company:07972029
+16094	St John the Baptist Catholic Multi Academy Trust	company:07913261
+16095	South Orpington Learning Alliance Multi-Academy Trust	company:07943613
+16096	Odyssey Educational Trust	company:08612100
+16098	Minerva Learning Trust (Dorset) Limited, The	company:08561222
+16099	Northwood Park Educational Trust	company:09341839
+16104	REAch4 Academy Trust	company:09791051
+16108	Leading Learning Trust	company:10028278
+16110	Five Rivers Multi Academy Trust	company:10070417
+16111	Raedwald Trust	company:08702099
+16114	Inspiring Schools Partnership	company:07557634
+16115	Hartismere Family of Schools	company:07341583
+16116	West Somerset Academy Trust	company:07630164
+16119	Sharples School A Multi Academy Trust	company:09677469
+16120	Alexandra Academy Trust	company:09978459
+16122	ACE Schools Multi Academy Trust	company:10038640
+16123	Royal County of Berkshire Schools Trust, The	company:10052450
+16124	Plym Academy Trust	company:10056460
+16125	Nexus Multi Academy Trust	company:10075893
+16126	The Academy for Character and Excellence	company:10098444
+16127	Inspire Education Community Trust	company:10155032
+16139	Cavendish Learning Trust	company:07935515
+16140	Westbourne Academy Trust	company:07626526
+16141	Inspiring Futures Through Learning	company:07698904
+16146	Bronte Academy Trust	company:10201636
+16147	Harbourside Learning Partnership	company:10161526
+16148	Learners' Trust	company:10224802
+16149	Streetsbrook Academy Trust	company:10225404
+16151	The South East Stafford Academy Trust	company:10178490
+16152	Inspiration Academy Trust	company:10174100
+16153	Salisbury Plain Academies	company:10163646
+16157	Orchard Academy Trust	company:08249884
+16158	Palladian Academy Trust	company:08061092
+16159	Brine Multi Academy Trust	company:07344747
+16160	Zest Academies Trust	company:08087508
+16162	Pathfinder Multi Acdemy Trust	company:07559610
+16163	Synergy Multi Academy Trust	company:08198980
+16165	Creative Learning Partnership Trust, The	company:10226712
+16166	Bolton and Farnworth Church of England Primary Multi Academy Trust	company:10261477
+16167	BASE Academy Trust	company:10227910
+16168	Tilian Partnership, The	company:10259334
+16169	VENN Academy Learning Trust	company:10249712
+16170	Warrington Primary Academy Trust	company:10181707
+16171	Consortium Multi-Academy Trust, The	company:10255142
+16172	Whinless Down Academy Trust	company:10253931
+16178	Central Schools Trust	company:08148546
+16179	Inspire Partnership Multi Academy Trust	company:07805262
+16241	Richmond West Schools Trust	company:10081995
+16243	Tove Learning Trust	company:07525820
+16245	Manchester Communication Academy	company:06754335
+16246	Teesside Learning Trust	company:07185357
+16247	South Lincolnshire Academies Trust	company:07559187
+16249	Cambridgeshire Educational Trust	company:07665396
+16250	Wembley High Technology College	company:08137772
+16251	Empower Learning Academy Trust	company:07702119
+16252	Philip Morant School and College Academy Trust, The	company:07803969
+16253	Every Child, Every Day Academy Trust	company:08185432
+16254	Danes Educational Trust	company:07671949
+16255	Canons High School	company:07694362
+16256	Bishop Ramsey Church Of England Academies Trust	company:07724916
+16257	Sigma Trust, The	company:07926573
+16258	Greys Education Centre	company:08156641
+16259	Accord Multi Academy Trust	company:07484308
+2044	Abbey Academies Trust	company:07318714
+2046	Abbey Multi Academy Trust	company:07705552
+2053	Academies Enterprise Trust	company:06625091
+2059	Academy of Lincoln Trust, The	company:07557670
+2060	Academy of Woodlands, The	company:08444770
+2062	Academy Transformation Trust	company:07846852
+2064	Ace Learning	company:08681270
+2067	Acorn Academy Cornwall	company:08418341
+2070	Acorn Education Trust	company:07654902
+2071	Acorn Multi Academy Trust	company:09253218
+2072	Acorn Trust	company:08638158
+2075	Active Learning Trust Limited, The	company:07903002
+2076	Adelaide Academy Trust, The	company:08725920
+2079	Advance Trust	company:08414933
+2081	Adventure Learning Academy Trust	company:08614382
+2082	Aim High Academy Trust	company:08842629
+2083	Airedale Academies Trust	company:07556117
+2095	Aldersley Academies Trust	company:08310900
+2096	Aldridge North West Education Trust	company:05670663
+2100	Aletheia Anglican Academies Trust	company:07801612
+2109	All Saints' Academies Trust	company:08998917
+2111	All Saints Catholic Academy Trust, The	company:07943555
+2112	All Saints Catholic Collegiate	company:08709352
+2122	Alsager Multi Academy Trust	company:08597784
+2128	Ambitions Academies Trust	company:07977940
+2133	Amherst School (Academy) Trust	company:07517121
+2135	Ann Harris Academy Trust, The	company:08741949
+2137	Apollo Schools Trust	company:08641815
+2143	Aquinas Church of England Education Trust Limited	company:07525735
+2147	Sentamu Academy Learning Trust	company:06544825
+2157	ARK Schools	company:05112090
+2161	The Gryphon Trust	company:07546874
+2166	Arthur Terry Learning Partnership, The	company:07730920
+2168	Ascent Academies Trust, The	company:08098007
+2177	Ashley Hill Multi Academy Trust	company:08163445
+2186	Aspirations Academies Trust	company:07867577
+2189	Aspire Academies Trust	company:08187216
+2192	ASPIRE Academy Trust	company:07387540
+2194	Aspire Multi - Academy Trust	company:08840094
+2195	Aston Community Education Trust	company:07577113
+2199	Atlantic Centre of Excellence Multi Academy Trust	company:08782544
+2200	Attwood Academies	company:09148479
+2206	Aurora Academies Trust	company:08107711
+2207	Autism Schools Trust	company:08335297
+2209	Avanti Schools Trust	company:07506598
+2212	Avocet Academy Trust	company:09254238
+2213	Avonbourne International Business and Enterprise Academy Trust	company:08080096
+2231	Barnes Academy Trust	company:09083904
+2232	Barnet City Academy	company:04389132
+2233	The Shared Learning Trust	company:05958361
+2237	Barnhill Partnership Trust, The	company:07719016
+2239	Barnwell Academy Trust	company:08929065
+2248	Basildon Academies, The	company:06308595
+2250	Bath and Wells Diocesan Academies Trust, The	company:08207095
+2255	Bay Education Trust	company:09299975
+2259	Beacon Community College Academy Trust	company:07959980
+2265	Beacon Multi-Academy Trust Limited	company:07835788
+2268	Beaver Road Academy Trust	company:08698831
+2270	Beckfoot Trust	company:08155088
+2275	Bedfordshire East Multi-Academy Trust	company:07546141
+2288	Bellevue Place Education Trust	company:07956784
+2299	Green spring Education Trust	company:07856680
+2305	Bicester Learning Academy	company:09053713
+2307	Biddick Academy Trust	company:08521080
+2311	Biggleswade Academy Trust	company:07928028
+2322	Birmingham City University Academies Trust	company:08497028
+2326	Bishop Anthony Educational Trust, The	company:08762217
+2328	Bishop Cleary Catholic Multi Academy Company	company:08578428
+2332	Bishop Konstant Catholic Academy Trust, The	company:08253770
+2342	Bishop Wheeler Catholic Academy Trust, The	company:08399801
+2348	Blackbird Academy Trust	company:08544741
+2350	Blackpool Multi Academy Trust	company:08597962
+2351	Blandford Education Trust	company:09050439
+2353	Blessed Christopher Wharton Catholic Academy Trust	company:09066969
+2354	Blessed Cyprian Tansi Catholic Academy Trust, The	company:08090890
+2355	Blessed Edward Bamber Catholic Multi Academy Trust, The	company:09111449
+2356	Blessed Peter Snow Catholic Academy Trust	company:09068195
+2358	Blue Bell Hill Academy Trust	company:08554393
+2363	Bluecoat Academies Trust	company:07875164
+2365	Blyth Quays Trust, The	company:08428466
+2368	Bohunt Education Trust	company:07535642
+2376	Boston Witham Academies Federation, The	company:08158309
+2377	Boswells Academy Trust, The	company:07907388
+2386	Bourne Education Trust	company:07768726
+2400	Bradfields Academy	company:08899707
+2404	Bradford Academy Trust	company:05508735
+2406	Bradford College Education Trust	company:06772181
+2408	Bradford Diocesan Academies Trust	company:08258994
+2413	Brampton Manor Trust	company:07540236
+2415	BRandH Academy Limited	company:07698718
+2424	Brentwood Academies Trust	company:07638800
+2425	Brentwood Community Academies Trust	company:09030028
+2430	Bridge Multi-academy Trust	company:07736425
+2434	Bridgwater College Trust	company:08098956
+2437	Bright Futures Educational Trust	company:07695771
+2439	Bright Tribe Trust	company:08144578
+2440	Brighter Academy Trust	company:08557883
+2442	Brighter Futures Academy Trust	company:08175471
+2455	Broadmere and New Monument Multi Academy Trust	company:08407871
+2465	Bromley Educational Trust	company:09028122
+2468	Brook Learning Trust	company:07368292
+2471	Brooke Weston Trust, The	company:02400784
+2497	Burnt Mill Academy Trust	company:07843166
+2504	Burton and South Derbyshire Education Trust	company:09142556
+2507	Bury College Education Trust	company:08769073
+2508	Bury St Edmunds Academy Trust	company:07697600
+2510	Bushey St James Trust	company:07895684
+2514	Byrchall High School Academy Trust	company:08175642
+2516	Cabot Learning Federation	company:06207590
+2522	Calthorpe Teaching Academy Trust	company:09064864
+2526	Cambridge Meridian Academies Trust	company:07552498
+2528	Cambridge Primary Education Trust	company:08304433
+2535	Canary Wharf College Ltd	company:07413883
+2539	Canterbury Academy, The	company:07345430
+2543	Cardinal Hume Academies Trust, The	company:08148675
+2548	Carmel Education Trust	company:07808732
+2563	Castle Partnership Academy Trust, The	company:08066451
+2564	Castle Partnership Trust, The	company:07657731
+2565	Castle Phoenix Trust	company:08331385
+2567	Castle School Education Trust	company:08397975
+2572	Castleford Academy Trust	company:07547039
+2573	Castleman Academy Trust	company:09101036
+2575	Catalyst Academies Trust	company:08407989
+2577	Catch22 Multi Academies Trust Limited	company:08299181
+2579	Catholic Academy Trust in East Berkshire, The	company:08561153
+2580	Catholic Academy Trust in Havant, The	company:07721932
+2581	Catholic Academy Trust in South Hampshire, The	company:07723349
+2582	Catholic Academy Trust in Southampton, The	company:07714121
+2584	Rutland And District Schools' Federation	company:07552631
+2592	Central Academy Trust	company:07685645
+2594	Central Learning Partnership Trust	company:07827368
+2597	CFBT Schools Trust	company:07468210
+2605	Change Schools Partnership	company:08182064
+2609	Chapel Street Community Schools Trust	company:07885963
+2611	Charles Darwin Academy Trust	company:07554396
+2622	Chatham & Clarendon Grammar School Federation, The	company:07455452
+2627	Laurus Trust, The	company:07907463
+2639	Cheney School Academy Trust	company:08319810
+2643	Cherry Tree Academy Trust Marham	company:09106277
+2644	River Learning Trust	company:07966500
+2646	Chester Catholic Academies Partnership, The	company:08375925
+2647	Chester Diocesan Academies Trust	company:08451787
+2650	Chesterton Academy Trust	company:08786812
+2657	Children of Success Schools Trust	company:08438964
+2658	Children's Academy Trust Ltd	company:09061804
+2659	Chilford Hundred Education Trust	company:07482650
+2661	Chiltern Learning Trust	company:07559901
+2662	Chingford Academies Trust	company:08179498
+2665	Chipping Norton School Academy Trust	company:07929429
+2666	Chipstead Valley Academy Trust	company:08891864
+2681	Christ the King Catholic Collegiate	company:08933913
+2685	Chulmleigh Academy Trust	company:07697698
+2695	Cidari Education Limited	company:08822760
+2697	Cippenham Schools' Trust, The	company:07988376
+2703	City Education Trust	company:08528776
+2705	City of London Academies Trust	company:04504128
+2709	City of Wolverhampton Academy Trust	company:06969900
+2719	Cleves Cross Learning Trust	company:08718104
+2722	East Anglia Schools Trust	company:08432486
+2727	Cloughwood Academy Trust	company:08604799
+2729	Coast Academies	company:07668923
+2731	Coastal Academies Trust	company:07552665
+2741	Collaborative Academies Trust, The	company:08168307
+2743	College Academies Trust, The	company:07272906
+2744	Collegiate Academy Trust, The	company:06336693
+2748	Colston's Girls' School Trust	company:06511936
+2753	Comberton Academy Trust	company:07491945
+2755	Community Academies Trust	company:07472736
+2757	Community First Academy Trust	company:08359889
+2758	Community Inclusive Trust	company:09071623
+2762	Complementary Education Academy Limited, The	company:08190591
+2765	ConcertEd Multi Academy Trust	company:08718062
+2766	Congleton Multi-Academy Trust	company:07538467
+2767	Congleton Primary Academy Trust Limited	company:09024278
+2771	Connected Learning	company:08579939
+2776	Coombe Secondary Schools Academy Trust, The	company:07905433
+2777	Co-operative Academies Trust, The	company:07747126
+2788	Corpus Christi Catholic Academy Trust	company:07976019
+2791	Corsham School Academy Group, The	company:07550425
+2798	Cottenham Academy, The	company:07740815
+2813	Craven Educational Trust	company:09023653
+2815	Crawley Free School Trust	company:08339290
+2816	Creative Education Trust	company:07617529
+2819	Creative Learning Multi Academy Trust	company:09227333
+2824	Crofton Schools Academy Trust	company:07824714
+2837	Cuckoo Hall Academies Trust	company:07355559
+2840	CWA Academy Trust	company:07338780
+2854	David Ross Education Trust, The	company:06182612
+2858	Dayspring Trust	company:08310825
+2864	Dean Trust, The	company:08027943
+2870	Delta Education Trust, The	company:08382383
+2878	Derby College Education Trust	company:08072758
+2879	Derby Diocesan Academy Trust	company:08980079
+2880	Derby Pride Trust	company:07109892
+2886	Diamond Learning Partnership Trust, The	company:08062508
+2887	Didcot Academy of Schools	company:08104201
+2893	Diocese of Brentwood Multi Academy Trust	company:08610377
+2894	Diocese of Bristol Academies Trust	company:08156759
+2897	Diocese of Canterbury Academies Trust, The	company:09035788
+2901	Diocese of Coventry Multi-academy Trust, The	company:08422015
+2905	Diocese of Ely Multi-academy Trust, The	company:08464996
+2907	Diocese of Gloucester Academies Trust, The	company:08149299
+2918	The Diocese of Norwich Education and Academies Trust	company:08737435
+2922	Diocese of Salisbury Multi Academy Trust	company:08656655
+2925	Diocese Of Southwell And Nottingham Multi-Academy Trust	company:08738949
+2928	Diocese of Westminster Academy Trust, The	company:07944160
+2930	Discover Learning Trust	company:08249250
+2932	Discovery Schools Academies Trust Ltd	company:08104111
+2936	Diverse Academies Trust	company:07664012
+2939	Dixons Academies Charitable Trust Ltd	company:02303464
+2941	Djanogly Learning Trust	company:04544722
+2943	Dominic Barberi Multi Academy Company, The	company:08453966
+2953	Downview Trust	company:08603388
+2958	Drapers' Multi-Academy Trust	company:07035556
+2962	DS Academies Trust, The	company:08745639
+2963	Duchy Academy Trust, The	company:08842867
+2969	Durrington Multi Academy Trust	company:08895870
+2974	E-ACT	company:06526376
+2987	East Midlands Education Trust	company:07530373
+3001	Ebor Academy Trust	company:08806335
+3004	Eden Academy, The	company:08036395
+3009	Educate Together Academy Trust	company:08859774
+3010	Education And Leadership Trust	company:08913502
+3012	Education Central Multi Academy Trust	company:08255492
+3013	Education Fellowship Trust, The	company:07848783
+3015	Education for the 21st Century	company:07559170
+3016	Education Partnership Trust	company:07950891
+3018	Education Village Academy Trust, The	company:07748248
+3019	Edwin Jones Trust	company:08512105
+3025	Elliot Foundation Academies Trust, The	company:08116706
+3028	Dunham Trust, The	company:08120128
+3033	EMLC Academy Trust	company:08149829
+3039	Engage, Enrich, Excel academies	company:09279884
+3042	Enquire Learning Trust, The	company:08056907
+3044	Epiphany School, The	company:07991877
+3047	Equitas Academies Trust	company:07662289
+3053	Esher Learning Trust	company:08812257
+3055	Essa Foundation Academies Trust	company:06731593
+3062	Evolution Academy Trust	company:08158619
+3063	Evolution Schools Learning Trust	company:07596422
+3065	Excalibur Academies Trust	company:08146633
+3066	Excel Academy Partnership, The	company:07837770
+3071	Extol Academy Trust	company:08561360
+3072	Eynsham Partnership Academy	company:07939655
+3073	Fairchildes Academy Community Trust	company:08934482
+3076	Fairfax Multi Academy Trust	company:07661164
+3080	Fallibroome Trust, The	company:07346144
+3083	Faringdon Academy of Schools	company:07977368
+3090	Federation of Abbey Schools Academy Trust, The	company:07699775
+3091	Federation of Mowden Schools Academy Trust	company:08027205
+3093	Fennwood Academy Trust	company:08763832
+3104	First Federation Trust, The	company:07819870
+3107	Fleetville Trust	company:08028375
+3111	Flying High Trust	company:08076374
+3112	Focus Academy Trust (UK) Ltd	company:08071176
+3115	Folkestone School for Girls Academy Trust, The	company:07882159
+3123	Fort Pitt Grammar School Academy Trust	company:07401701
+3126	The Partnership Trust	company:07728112
+3142	Fulham College Academy Trust, The	company:08398143
+3145	Fulston Manor Academies Trust	company:07343725
+3147	Fulwood Academy, The	company:06960253
+3150	Fusion Schools Trust	company:08663011
+3152	Future Academies	company:06543442
+3154	Future Schools Trust	company:06272751
+3155	Fylde Coast Academy Trust	company:08364709
+3163	Gateway Learning Community	company:05853746
+3166	GDST Academy Trust	company:06000347
+3173	Gilberd School, The	company:07933810
+3185	Oadby, Wigston and Leicestershire Schools Academy Trust	company:08537140
+3188	Gloucestershire Learning Alliance	company:07690119
+3190	GLF Schools	company:07551959
+3200	Goldsworth Trust	company:07887259
+3201	Good Shepherd Trust, The	company:08366199
+3206	GORSE Academies Trust, The	company:07465701
+3209	Gosforth Federated Academies Limited, The	company:07431423
+3211	Grace Academy	company:04967658
+3216	Grange Trust, The	company:09150608
+3218	Grasvenor Avenue Infant School	company:08164849
+3219	Graveney Primary School	company:07847021
+3220	Graveney Trust	company:07687897
+3222	Gravesend Grammar School Academies Trust	company:07685923
+3225	Great Academies Education Trust	company:06237630
+3235	Great Missenden Trust	company:08927321
+3240	Green School Trust, The	company:08608665
+3243	Greenacre Academy Trust, The	company:07965316
+3245	Greenfield & Pulloxhill Academy	company:07719857
+3252	Greenwood Academies Trust	company:06864339
+3257	Grenestede Academy Trust	company:09081030
+3262	Griffin Schools Trust, The	company:07893665
+3265	Grove Park Academies	company:08059055
+3266	Grove Wood Academy Trust	company:09068218
+3272	Guildford Education Partnership	company:07649091
+3273	Guilsborough Multi Academy Trust	company:07535683
+3275	Guru Nanak Sikh Academy Limited	company:07416734
+3277	Haberdashers' Adams' Federation Trust	company:06548296
+3279	Haberdashers' Aske's Federation Trust	company:02535091
+3288	Halewood Academy Centre for Learning	company:07909397
+3294	Hallam Schools' Partnership Academy Trust, The	company:08665067
+3295	Haltwhistle Community Campus	company:08624157
+3299	Hampton Academies Trust	company:09129775
+3303	Hamstead Hall Academy Trust	company:08528845
+3313	Harlington and Sundon Academy Trust, The	company:08231721
+3316	Harmony Trust Limited, The	company:08840373
+3320	Harris Federation	company:06228587
+3326	Harrowby/National Academies Trust, The	company:08105941
+3329	Hartlepool Aspire Trust	company:08604037
+3333	Harvey Academy, The	company:08142275
+3339	Hastings Academies Trust	company:07185046
+3345	Hatton Academies Trust	company:07949111
+3364	Healing Multi Academy Trust	company:07345756
+3368	Heartlands Community Trust	company:08482398
+3370	HEARTS Academy Trust	company:07851097
+3371	Heartwood Church of England Academy Trust	company:08627834
+3372	Heath Family (North West), The	company:07614421
+3375	Heathfield Academy Trust	company:08027885
+3377	Heathland Whitefriars Federation	company:09066965
+3395	Hereford Integrated Behaviour Outreach Service	company:09136556
+3396	Herefordshire Marches Federation of Academies, The	company:07578861
+3398	Hermitage Trust, The	company:08872698
+3403	Hessle Academy Community Trust, The	company:07665828
+3410	Highcliffe School	company:07631213
+3431	Brigantia Learning Trust Limited	company:08506178
+3432	Hinkler Academies Trust	company:08479066
+3457	Holy Family Catholic Academy Trust	company:08155184
+3458	Holy Family Catholic Multi Academy Trust	company:08269066
+3460	Holy Family of Nazareth Catholic Academy Trust, The	company:08307881
+3464	Holy Trinity Church Of England Academy (South Shields) Trust	company:09098446
+3477	Honywood Community Science School	company:07592309
+3483	Horizons Specialist Academy Trust	company:08608287
+3485	Hornbeam Academy Trust	company:08153765
+3493	Howard Partnership Trust, The	company:07597068
+3496	Spring Partnership Trust, The	company:07656245
+3502	Hull Collaborative Academy Trust	company:08542806
+3507	Hummersknott Academy Trust	company:07664322
+3511	The Education Alliance	company:07542211
+3527	Innovate Multi Academy Trust	company:09071405
+3528	Innovation Enterprise Academy	company:08278808
+3531	Inspiration Trust	company:08179349
+3532	Inspire Academy Trust	company:07781921
+3533	Inspire Learning Federation, The	company:09202445
+3534	Inspire Multi Academy Trust	company:08287012
+3535	Interserve Academies Trust Limited	company:09042916
+3538	Ironstone Academy Trust	company:09040348
+3539	Infinity Academies Trust Ltd	company:08358124
+3540	Iffley Academy Trust Company, The	company:08334718
+3543	Isle Education Trust	company:07814150
+3547	Ivybridge Academy Trust	company:07398467
+3552	Jefferys Education Trust	company:07690473
+3566	John Paul II Multi-academy	company:08706247
+3586	Kemnal Academies Trust, The	company:07348231
+3590	Kennet School Academies Trust	company:07543874
+3594	Kent Catholic Schools' Partnership	company:08176019
+3598	Kenton Schools Academy Trust	company:07964133
+3603	KESKOWETHYANS Multi Academy Trust	company:08872161
+3614	King Alfred Trust	company:08853971
+3628	King Ina Church of England Academy	company:08120037
+3643	Academies South West	company:07451553
+3651	Kingstone Academy Trust	company:07681857
+3652	Kingsway Community Trust	company:08339302
+3661	KJS Academy Trust, The	company:07559293
+3667	Knutsford Multi Academy Trust	company:07984413
+3668	Koinonia Academies Trust	company:08563153
+3670	L.E.A.D. Multi-Academy Trust	company:08296921
+3677	Laidlaw Schools Trust, The	company:05735093
+3684	Landau Forte Charitable Trust	company:02387916
+3688	Langley Academy Trust, The	company:05358533
+3694	Langtree School Academy Trust Company, The	company:07980335
+3698	AN Daras Multi Academy Trust	company:08156955
+3700	Launde Primary School Academy Trust	company:08515149
+3703	LDBS Academies Trust	company:08182235
+3705	LDBS Frays Academy Trust	company:08335073
+3706	LEAF Academy Trust	company:05037949
+3708	Leap Academy Trust, The	company:08482129
+3710	Learning Academy Partnership (South West)	company:07713540
+3711	Learning Alliance Academy Trust, The	company:07703829
+3713	LeAF Academy	company:08011930
+3714	Learning in Harmony Multi Academy Trust	company:09148738
+3715	Learning Pathways Academy	company:07984238
+3716	Learning Schools Trust	company:07145434
+3718	Lee Chapel Academy Trust	company:07673871
+3722	Diocese Of Leicester Academies Trust	company:08138372
+3725	Leigh Academies Trust	company:02336587
+3727	Leigh Trust	company:08779660
+3735	Magna Learning Trust	company:07491215
+3743	Lilac Sky Schools Trust, The	company:08289583
+3746	Lincoln Anglican Academy Trust	company:08737412
+3749	Lincolnshire Educational Trust Limited, The	company:07647805
+3758	Lion Academy Trust	company:08171341
+3759	Lion Education Trust	company:09161091
+3760	Lionheart Academies Trust	company:08473899
+3765	Little Mead Academy Trust	company:08245853
+3771	London Academies Enterprise Trust	company:07211219
+3782	Longfield Academy Trust	company:07700556
+3788	Lordswood Academies Trust	company:07567230
+3794	Lound Academy Trust	company:08550854
+3797	Loxford School Trust Limited	company:08743560
+3805	Lumen Learning Trust	company:08670599
+3806	Lutterworth Academies Trust, The	company:08038063
+3808	LWS Academy Trust	company:08915981
+3810	Lydiate Learning Trust	company:07732559
+3817	Macintyre Academies	company:08334745
+3834	Maltby Learning Trust	company:07033915
+3839	Manchester Creative And Media Academy	company:06888873
+3847	Manor Learning Trust	company:07816548
+3855	Marches Academy Trust	company:07680422
+3858	Marine Academy Plymouth	company:07194412
+3860	Marish Academy Trust	company:08073873
+3878	Matrix Academy Trust	company:07654219
+3884	Mead Academy Trust, The	company:08024396
+3892	Meopham Community Academies	company:07416211
+3899	Mercia Learning Trust	company:08119703
+3900	Mercia Primary Academy Trust	company:08748904
+3908	Midland Academies Trust, The	company:07191874
+3910	Midsomer Norton Schools Partnership	company:07365778
+3918	Milton Keynes Education Trust	company:07663689
+3921	Minerva Learning Trust	company:09200332
+3924	Mirfield Free Grammar and Sixth Form Multi-Academy Trust, The	company:07521584
+3931	Montsaye Community Learning Partnership	company:07670511
+3933	Moor End Academies Trust	company:07599308
+3939	Mossbourne Federation, The	company:04468267
+3940	Mossley Academy Trust, The	company:09104491
+3952	Mowbray Education Trust Limited	company:07796947
+3956	NAS Academies Trust	company:07954396
+3965	NET Academies Trust	company:08221088
+3975	New College Durham Academies Trust	company:07195175
+3977	New Dawn Trust	company:07842369
+3980	New Hall Multi Academy Trust	company:08643881
+3981	New Haw Community School	company:08718489
+3987	Newbury Academy Trust	company:08142572
+3991	Newman Catholic Collegiate, The	company:08550110
+3995	Newquay Education Trust	company:08961355
+3996	Newstead Multi Academy Trust	company:08657945
+4002	Nicholas Postgate Academy Trust	company:09203984
+4004	Ninestiles Academy Trust Limited	company:07348167
+4005	Nishkam School Trust	company:07522245
+4011	Norfolk Academies	company:07946986
+4014	North Carr Collaborative Academy Trust	company:08395383
+4017	North East Sheffield Trust	company:08863947
+4018	North Essex Multi-Academy Trust	company:07687474
+4020	North Hertfordshire Studio School Trust, The	company:07791933
+4024	North Norfolk Academy Trust	company:07800153
+4029	North West Academies Trust Limited	company:08852553
+4031	Northampton Primary Academy Trust	company:08172039
+4036	Northern Education Trust	company:07189647
+4038	Northern House School Academy Trust	company:08140768
+4039	Northern Lincolnshire Catholic Academy Trust, The	company:07973953
+4041	Northern Schools Trust	company:05067702
+4048	Northwick Park Trust	company:09154404
+4058	Nottingham University Samworth Academies Trust	company:06221293
+4065	Oak Wood Schools Academy	company:08425914
+4070	Oaks Academy Trust	company:08924656
+4073	Oakwood Learning Community Trust	company:08775996
+4074	Oakwood Park Grammar School	company:07584611
+4076	Oasis Community Learning	company:05398529
+4079	Odyssey Academy Trust, The	company:09139888
+4095	Olympus Academy Trust, The	company:07844791
+4100	Orchard Hill College Academy Trust	company:08476149
+4106	Ormiston Academies Trust	company:06982127
+4111	OUR Co-operative Academies Trust	company:08670427
+4114	Our Lady of Fatima Catholic Multi Academy Trust	company:07696069
+4115	Our Lady of Lourdes Catholic Multi-Academy Company	company:09064485
+4119	Outwood Grange Academies Trust	company:06995649
+4124	Oxford Diocesan Schools Trust	company:08143249
+4127	Painsley Catholic Academy, The	company:08146661
+4131	Paradigm Trust	company:08469218
+4132	Parallel Learning Trust	company:08605705
+4134	Park Federation Academy Trust, The	company:08146330
+4145	The Core Educational Trust	company:07949154
+4149	Parkroyal Academy Trust	company:08728422
+4151	Parkside Federation Academies	company:07557831
+4157	The Passmores Co-operative Learning Community	company:07736246
+4161	Pax Christi Catholic Academy Trust	company:08192900
+4163	Pear Tree Alliance	company:08916147
+4168	Pegasus Academy Trust, The	company:07542114
+4174	Pendle Education Trust	company:08263591
+4175	Peninsula Gateway Academy Trust	company:08095169
+4185	Perry Beeches The Academy Trust	company:07749786
+4186	Perry Hall Multi-Academy Trust	company:08566185
+4192	Peterborough Diocese Education Trust	company:08509710
+4197	Phoenix Family of Schools Academy Trust, The	company:08324412
+4208	Pioneer Academies Co-operative Trust (PACT)	company:08255683
+4209	Pioneer Academy, The	company:07691324
+4210	Plantsbrook Learning Trust	company:07655702
+4214	Plymouth CAST	company:08438686
+4219	Pokesdown Community Primary School	company:08425359
+4220	PolyMAT	company:09078530
+4223	Pontefract Academies Trust	company:08445158
+4227	Pope Francis Catholic Multi Academy Company, The	company:09113542
+4230	Portsmouth and Winchester Diocesan Academies Trust	company:08161468
+4232	Portswood Primary Academy Trust	company:08158400
+4243	Primary Academies Trust, The	company:07821367
+4244	Primary Excellence - A Catholic Education Trust	company:08068528
+4245	Primary First Trust, The	company:08738750
+4250	Priory Academy Trust, The	company:08032410
+4253	Priory Federation of Academies, The	company:06462935
+4257	Propeller Academy Trust, The	company:08340120
+4264	Pursuing Educational Excellence Together	company:08064698
+4269	QED Academy Trust	company:07493622
+4273	Quantock Academy, The	company:08767576
+4280	Queen Elizabeth's Grammar School Trust Faversham	company:07558466
+4292	Quinta Trust, The	company:08787650
+4301	Ralph Sadleir School	company:08663956
+4308	Apollo Learning Trust	company:07553596
+4320	REAch2 Academy Trust	company:08452281
+4335	Redditch RSA Academies Trust	company:08166526
+4336	Redditch West School Trust	company:07967402
+4338	Redhill Academy Trust	company:07430317
+4361	Ridings’ Federation of Academies Trust, The	company:06802948
+4362	RIGHTFORSUCCESS TRUST	company:08282834
+4365	Ringwood School	company:07552519
+4368	Rise Park Academy Trust	company:09051179
+4369	Rivers C of E Multi Academy Trust, The	company:09199371
+4372	RNIB Specialist Learning Trust	company:08478985
+4380	Robinswood Academy Trust, The	company:07530418
+4382	Robus Multi Academy Trust	company:07681811
+4384	Rochester Diocesan Multi-Academy Education Trust	company:08270657
+4386	Rodillian Multi Academy Trust, The	company:07990619
+4395	Rosebery School	company:07818029
+4397	Rosedale Hewens Academy Trust, The	company:07683702
+4405	Rowan Learning Trust, The	company:08010464
+4410	Royston Schools Academy Trust, The	company:07695881
+4417	Abingdon Learning Trust	company:07931886
+4421	Russell Education Trust	company:07452885
+4422	Rutland Learning Trust, The	company:09199785
+4426	Rye Academy Trust	company:08177657
+4437	Saffron Academy Trust	company:07618351
+4438	Saint Dominic's Catholic Academy Trust	company:08106388
+4441	Saint Nicholas Owen Catholic Multi Academy Company	company:09174154
+4442	Saint Robert Lawrence Catholic Academy Trust	company:07937154
+4443	Saints' Way Church of England Multi Academy Trust, The	company:08269215
+4447	Salford Academy Trust	company:08115121
+4449	Saltash Multi Academy Regional Trust	company:07542166
+4454	Samuel Ward Academy Trust	company:07400386
+4460	Sandhill Multi Academy Trust	company:08745045
+4473	School 21	company:07648389
+4474	School Partnership Trust Academies	company:07386086
+4477	Schoolsworks Academy Trust	company:07962974
+4482	Seckford Foundation Free Schools Trust, The	company:08077362
+4487	Sevak Education Trust Ltd	company:08267703
+4493	Shaftesbury Academy Trust	company:09040388
+4495	Sharnbrook Academy Federation	company:07500018
+4499	Shaw Education Trust, The	company:09067175
+4510	Shirebrook Academy	company:06628631
+4516	North East Learning Trust	company:07492165
+4518	Shrewsbury Academies Trust	company:08407961
+4519	Shropshire Gateway Educational Trust, The	company:09115941
+4521	Sidney Stringer Multi Academy Trust	company:06672920
+4524	Silver Birch Academy, The	company:08107310
+4528	Simon Balle Academies Trust	company:08661539
+4530	Aspire Learning Trust (Whittlesey)	company:08006711
+4533	Sir John Lawes Academies Trust, The	company:07697132
+4553	Slough and East Berkshire C of E Multi Academy Trust, The	company:07723151
+4556	Smallwood Academy Trust, The	company:09118770
+4559	Solent Academies Trust	company:08374351
+4567	South Dartmoor Academy	company:07561204
+4569	South East Essex Academy Trust	company:07527304
+4579	South Northamptonshire Church of England Multi Academy Trust	company:08569207
+4580	South Northamptonshire Village Schools Multi Academy Trust	company:08567252
+4581	South Nottingham Catholic Academy Trust	company:07743523
+4584	South Shropshire Academy Trust	company:08439425
+4586	South Tyneside Academy Trust Sponsored By South Tyneside College	company:08313162
+4593	Southfield Grange Trust, The	company:07754077
+4601	Southwark Primary Academy Trust	company:07726568
+4608	Specialist Education Trust, The	company:08610537
+4609	Spencer Academies Trust, The	company:07353824
+4610	Spiral Academies Trust	company:08322127
+4616	SS Simon and Jude Church of England Academy Trust	company:08240918
+4620	St Aidan's Education Trust	company:08442124
+4629	St. Anselm's Catholic Multi Academy Trust	company:08515862
+4636	St Barnabas Church of England Multi Academy Trust	company:08669464
+4638	St Bart's Multi Academy Trust	company:08735454
+4652	St Chad's Academies Trust	company:08526973
+4656	St Christopher's C of E (Primary) Multi Academy Trust	company:08538844
+4657	St Christopher's C of E (Secondary) Multi Academy Trust	company:08486531
+4662	St Clere's Co-operative Academy Trust	company:07703865
+4668	St Cuthbert's Roman Catholic Academy Trust	company:09023802
+4680	St Francis of Assisi Academies Trust	company:08462151
+4688	St Gilbert of Sempringham Catholic Academy Trust	company:08462512
+4697	St Hybald's Academy Trust	company:08003909
+4700	St James Church of England Academy Trust Company	company:08022455
+4703	St John Bosco Catholic Academy, The	company:08608177
+4717	Catholic Academy Trust in Aldershot, The	company:07728054
+4719	St. Joseph's Catholic Education Trust	company:08559647
+4742	St Mary's Academy Trust	company:07917752
+4750	St. Mary's Catholic School Trust	company:08599141
+4771	St Neots Learning Partnership, The	company:07703784
+4776	St. Oswald's Catholic Academy Trust	company:08924383
+4777	St Oswald's Church of England Academy	company:08176968
+4787	St Peter's Catholic Voluntary Academy Trust	company:07739194
+4791	St Piran's Cross Church of England Multi Academy Trust	company:08739625
+4797	St Thomas More Partnership of Schools	company:07900532
+4806	St Barnabas Catholic Academy Trust	company:08089246
+4813	Staffordshire University Academies Trust	company:07704020
+4815	Stamp Education Trust	company:07916297
+4819	Stanford & Corringham Schools Trust, The	company:07660783
+4822	Stanway Federation, The	company:07887953
+4824	Staploe Education Trust	company:07534901
+4828	Steel City Schools Partnership	company:08356745
+4836	Step Academy Trust	company:07612865
+4837	Stephenson (MK) Trust	company:07919427
+4850	Stour Academy Trust, The	company:08179242
+4851	Stour Federation, The	company:09174628
+4853	Stourfield Infant Academy Trust	company:08201675
+4858	Stranton Academy Trust	company:08561049
+4863	Stratton Education Trust	company:07798627
+4876	Surrey Heath Education Trust	company:08621310
+4885	Swale Academies Trust	company:07344732
+4888	Swanland Education Trust	company:07679051
+4892	Synaptic Trust	company:07588104
+4893	Talent & Enterprise Trust	company:08562954
+4895	Tall Oaks Academy Trust Ltd	company:08395421
+4899	Tapton School Academy Trust	company:07697171
+4903	Tauheedul Education Trust	company:07353849
+4908	TBAP Trust	company:08425513
+4909	Ted Wragg Multi Academy Trust, The	company:08545109
+4915	Teignmouth Learning Trust	company:07519888
+4916	Telford Co-operative Multi Academy Trust	company:08447216
+4920	Templer Academy Schools Trust	company:07518252
+4923	Thame Partnership Academy Trust	company:08154932
+4929	The Aquinas Catholic Academy Trust	company:08901256
+4935	The Bentley Wood Trust	company:07693936
+4936	The Black Pear Trust Academies	company:08922754
+4951	The Crabtree Academy Trust	company:08782792
+4955	Diocese of Chelmsford Vine Schools Trust, The	company:08709542
+4956	The Diocese of Liverpool Academies Trust (Merseyside)	company:09235635
+4958	The Dover Federation for the Arts	company:08039629
+4962	The English Martyrs Educational Trust	company:08962417
+4963	The Eveleigh Link Academy Trust	company:08823327
+4965	The Evolve Trust	company:07827747
+4986	The Kirkstead Education Trust	company:08977173
+4990	Lincoln College Academy Trust	company:08238194
+4996	The Meller Educational Trust	company:06933010
+5004	The Platanos Trust	company:07492094
+5011	The Queen Katherine School Multi Academy Trust	company:07472799
+5013	The Rainbow Multi Academy Trust	company:08909269
+5049	Thinking Schools Academy Trust, The	company:07359755
+5063	Three Rivers Learning Trust Limited, The	company:07838203
+5075	TIMU Academy Trust	company:09022463
+5079	Tollbar Multi Academy Trust	company:08085503
+5084	Torch Academy Gateway Trust	company:07635510
+5085	Torfield and Saxon Mount Academy Trust	company:09172115
+5086	Torquay Boys' Grammar School	company:07394671
+5098	Transform Trust	company:08671076
+5102	Learning Academy Trust, The	company:07394649
+5108	Trinitas Academy Trust	company:07554121
+5119	Truro & Penwith Academy Trust	company:08880841
+5122	Trust in Learning (Academies)	company:08089704
+5125	Tudhoe Learning Trust	company:08270151
+5126	Tudor Court Primary Academy Trust	company:09071607
+5128	Tudor Grange Academies Trust	company:07365748
+5132	Twyford Church of England Academies Trust	company:07648968
+5141	Uffculme Academy Trust	company:07338835
+5143	United Learning Trust	company:04439859
+5148	South Bank Academies	company:08589525
+5152	University of Chester Academies Trust	company:06929486
+5153	University of Chichester (Multi) Academy Trust	company:08595545
+5162	Upminster Academies Trust	company:08214798
+5165	Upton Court Educational Trust	company:07462530
+5176	Vale Academy Trust	company:07674473
+5178	Valley Invicta Academies Trust	company:07559256
+5183	Victoria Academies Trust	company:07887796
+5186	Village Academy, The	company:07738386
+5188	Violet Way Trust	company:07606026
+5195	Wakefield City Academies Trust	company:07462885
+5196	Wakefield Diocesan Academies Trust	company:07904096
+5199	Waldegrave Trust, The	company:08130508
+5203	Wallingford Schools Academy Trust	company:07727786
+5214	Sussex Learning Trust	company:07705100
+5222	Warrington Collegiate Education Trust	company:08298534
+5226	Washwood Heath Multi Academy Trust	company:08531479
+5228	Waterton Academy Trust	company:09124782
+5232	Waverley Education Foundation Ltd, The	company:08331922
+5238	Wearmouth Learning Trust	company:08767870
+5247	Wellington Academy Trust, The	company:06457394
+5252	Wellspring Academy Trust	company:08120960
+5253	Wellsway Multi Academy Trust	company:07746787
+5263	West Grantham Academies Trust, The	company:07489113
+5265	West Herts Community Free School Trust	company:08324782
+5271	West London Free School Academy Trust, The	company:07493696
+5273	West Newcastle Academy	company:07647538
+5275	West Norfolk Academies Trust	company:07546118
+5286	Westbrook Trust, The	company:09223515
+5299	Inspirational Futures Trust	company:08329993
+5303	South Essex Academy Trust	company:07681226
+5314	White Hills Park Federation Trust, The	company:08195720
+5315	White Horse Federation, The	company:08075785
+5316	White Rose Academies Trust	company:07958615
+5318	White Woods Primary Academy Trust	company:08589470
+5320	Whitefield Academy Trust	company:08878604
+5324	Whitehill Community Academy Multi-Academy Trust	company:07559439
+5328	Whittlesea Learning Trust	company:08795983
+5329	Wickersley Partnership Trust	company:08833508
+5333	Wigmore School	company:07466409
+5345	William Temple Multi Academy Trust	company:08813173
+5347	William Willett Learning Trust	company:07520128
+5348	Williamson Trust, The	company:07569727
+5351	Willows Academy Trust	company:09093035
+5361	Windsor Academy Trust	company:07523436
+5370	Wise Academies	company:07521946
+5372	Wise Owl Trust	company:08053288
+5385	Woodard Academies Trust	company:06415729
+5396	Woodland Academy Trust, The	company:07694050
+5402	Woodnewton Academy Trust	company:08034402
+5411	Wootton Academy Trust	company:07740758
+5418	Wrotham School	company:07662701
+5421	Wycombe High School Academies Trust	company:07597324
+5426	Wythenshawe Catholic Academy Trust, The	company:08440868
+5443	Carnovian Alliance, The	company:09221695
+5444	Keys Federation, The	company:09306360
+5445	AD Astra Academy Trust	company:09308398
+5446	Stanwix School	company:09341344
+5447	Somerset Road Education Trust	company:09343767
+5452	Greenshaw Learning Trust	company:07633694
+5453	Clevedon Learning Trust	company:07872799
+5454	Trent Academies Group	company:08128513
+5455	Cheshire Academies Trust Ltd	company:08108086
+5456	Transform Trust	company:08320065
+5461	Bridge Integrated Learning Space Ltd, The	company:08343491
+5470	Lime Academy Trust, The	company:09297519
+5471	Little Acorn Trust	company:09207180
+5473	Radcliffe Academy	company:09334026
+5476	Good Shepherd Multi Academy Trust, The	company:09341374
+5477	Ridings Trust, The	company:09290889
+5478	Learner Engagement and Achievement Partnership Multi-Academy Trust	company:07361021
+5479	Peninsula Learning Trust	company:07565242
+5480	Twynham Learning	company:07565088
+5481	South Farnham Educational Trust	company:07652902
+5482	Vyners Learning Trust	company:07796938
+5483	Bourton Meadow Education Trust, The	company:07867334
+5485	Partnership Learning	company:08339345
+5486	Wardle Academy	company:08368756
+5487	The Wulfrun Academies Trust	company:08881720
+5488	Diocese of Chichester Academy Trust, The	company:09201845
+5489	Rainbow Education Multi-Academy Trust	company:09265723
+5490	Learning Partnership Trust, The	company:09380027
+5494	Athelstan Trust, The	company:07699625
+5516	South Gloucestershire and Stroud Academy Trust	company:09353480
+5519	Invictus Education Trust	company:09284368
+5520	Sefton Education Trust	company:08307770
+5521	St Luke Academies Trust	company:09436283
+5522	SCHOOLSCOMPANY Trust, The	company:08304460
+5523	King Edward's Stourbridge Academy Trust	company:09361342
+5524	Holy Spirit Catholic Multi Academy, The	company:09432692
+5526	Wimborne Academy Trust	company:09362004
+5531	Viking Academy Trust	company:09449979
+5532	Pope John XXIII Catholic Multi Academy Company	company:09441910
+5533	St Martin's Multi Academy Trust	company:09443906
+5536	The Silk Academy Trust	company:09427476
+5537	Piper Hill Learning Trust	company:09392787
+5539	Pax Christi Catholic Partnership	company:09378390
+5540	Ipswich Primary Academies Trust	company:09434926
+5541	Future Generation Trust	company:09440033
+5542	Building Futures Enterprise Academy Trust	company:09408861
+5544	Windsor Learning Partnership	company:09409109
+5593	Derby Diocesan Academies Trust 2	company:09442311
+5594	Aspire Educational Trust, The	company:08689696
+5595	Eggbuckland Community College Academy Trust	company:08603078
+5596	Kirk Sandall Academy Trust	company:08248173
+5598	Redstart Learning Partnership, The	company:07649832
+5599	Yorkshire Causeway Schools Trust	company:07663935
+5600	Waycroft Multi Academy Trust	company:07683980
+5601	Dragonfly Education Trust	company:07728482
+5602	Levels Academy Trust, The	company:09437439
+5604	Richard Huish Trust	company:09320523
+5605	Olive Academies	company:08747464
+5606	Takely Education Trust	company:09451372
+5607	Amaya Trust	company:09155473
+5609	Lumen Christi Catholic Multi Academy Company	company:09471525
+5610	Greenacre School Trust	company:08102025
+5611	TEACH Poole	company:09484306
+5612	West Stafford Multi-Academy Trust	company:09422746
+5613	Willow Tree Academy	company:09440025
+5614	Yorkshire and Humberside Co-operative Academies Trust	company:09332738
+5615	University of Brighton Academies Trust	company:09466013
+5616	Fair Field Junior School	company:09434766
+5617	Irthlingborough And Finedon Learning Trust, The	company:09470229
+5618	Prestolee Multi Academy Trust	company:09481323
+5619	Shire Multi Academy Trust, The	company:09454169
+5620	St Catherine of SIENA Multi Academy Company	company:09497062
+5621	Our Lady Of Grace Catholic Academy Trust	company:09435396
+5622	Arete Learning Trust	company:09471240
+5630	Sirius Academy	company:06545396
+5631	Wirral Academy Trust	company:07472190
+5632	Hope Learning Trust, York	company:07559537
+5633	Langley Park Academies	company:07697400
+5634	South West Essex Community Education Trust Limited	company:07693309
+5635	SHARE Multi Academy Trust	company:07729878
+5636	Seax Trust	company:07747149
+5637	Aurum Academies Trust	company:07971651
+5638	Wigston Academies Trust	company:07975551
+5639	Legra Academy Trust	company:08066610
+5640	Greenwood Tree Academy Trust	company:08066324
+5641	TEAM Multi-Academy Trust	company:08110847
+5642	Academy Trust of Melksham, The	company:08153550
+5643	St Paul's (Astley Bridge) Church of England Primary School	company:08212263
+5644	CHS Learning Trust	company:08321679
+5645	Pelham Academy Trust	company:08439184
+5646	Engage Multi Academy Trust, The	company:08699493
+5647	Salterns Academy Trust, The	company:08921490
+5666	Cranmer Education Trust	company:07687709
+5667	Northern Star Academies Trust	company:07553531
+5668	Hackney New School Limited	company:07923624
+5669	Learning Together Trust, The	company:08561302
+5670	Castle Trust	company:08850163
+5671	Arden Multi Academy Trust	company:07375267
+5689	Trinity Academy Halifax	company:06897239
+5690	John Taylor MAT	company:07421140
+5692	Albany Learning Trust	company:08123168
+5693	South Cheshire Catholic Multi-academy Trust, The	company:08518704
+5702	Saturn Education Trust	company:09578698
+5704	Mayflower Specialist School Academy Trust	company:09610951
+5705	Bridgnorth Area Schools' Trust	company:09617166
+5708	Ocean Learning Trust	company:09628750
+5709	Salopia Catholic Schools Trust	company:09646093
+5711	Oakwood Academy Schools Trust, The	company:07982516
+5712	Southmoor Academy	company:08021855

--- a/data/alpha/school-type/school-types.tsv
+++ b/data/alpha/school-type/school-types.tsv
@@ -1,0 +1,42 @@
+school-type	name	start-date	end-date
+1	Community School		
+2	Voluntary Aided School		
+3	Voluntary Controlled School		
+5	Foundation School		
+6	City Technology College		
+7	Community Special School		
+8	Non-Maintained Special School		
+9	Independent School Approved for SEN Pupils		
+10	Independent Special School		
+11	Independent School		
+12	Foundation Special School		
+14	Pupil Referral Unit		
+15	LA Nursery School		
+17	European School		
+18	Further Education		
+22	EY Setting		
+23	Playing for Success Centre		
+24	Secure Unit		
+25	Offshore School		
+26	Childrens Education Service		
+27	Miscellaneous		
+28	Academy Sponsor Led		
+29	Higher Education Institution		
+30	Welsh Establishment		
+31	Sixth Form Centre		
+32	Special Post 16 Institution		
+33	Academy Special Sponsor Led		
+34	Academy Converter		
+35	Free School		
+36	Special Free School		
+37	British School Overseas		
+38	Free School - Alternative Provision		
+39	Free School - 16-19		
+40	University Technical College		
+41	Studio School		
+42	Academy Alternative Provision Converter		
+43	Academy Alternative Provision Sponsor Led		
+44	Academy Special Converter		
+45	Academy 16-19 Converter		
+46	Academy 16-19 Sponsor Led		
+56	Institution funded by other Government Department		

--- a/lib/school_trust.ex
+++ b/lib/school_trust.ex
@@ -1,0 +1,55 @@
+
+defmodule SchoolTrust do
+
+  def cache_files do
+    {_, files} = File.ls('./cache/')
+    files
+    |> Stream.reject(& &1 |> String.contains?("edubase"))
+    |> Stream.map(& "./cache/" <> &1)
+  end
+
+  def trust_htmls do
+    cache_files
+    |> Stream.filter(& File.stat!(&1).size >= 6750)
+    |> Stream.map(& File.read!(&1))
+    |> Stream.filter(& &1 |> String.contains?("Companies House"))
+  end
+
+  def trust_row html do
+    trust = html
+      |> Floki.find("table.est_links tbody tr td")
+      |> Enum.slice(0,4)
+      |> Enum.map(&Floki.text/1)
+    urn = html
+      |> Floki.find("h1.edUrnLeft")
+      |> Enum.map(& &1 |> Floki.text |> String.replace_leading("URN ", ""))
+    trust ++ urn
+  end
+
+  def trust_rows do
+    trust_htmls |> Stream.map(& trust_row(&1) ) |> Stream.reject(& (&1 |> Enum.at(3)) == "School sponsor" )
+  end
+
+  def trust_tsv do
+    headers = ~w[school-trust name company type urn]
+    trust_rows |> Stream.uniq |> Enum.sort_by(& &1 |> List.first) |> DataMorph.puts_tsv(headers)
+  end
+
+  def trust_map_tsv do
+    :stdio
+    |> IO.stream(:line)
+    |> DataMorph.structs_from_tsv(:dfe, :school_trust)
+    |> Stream.map(& [&1.urn, &1.school_trust])
+    |> DataMorph.puts_tsv(~w[school school-trust])
+  end
+
+  def trust_data_tsv do
+    :stdio
+    |> IO.stream(:line)
+    |> DataMorph.structs_from_tsv(:dfe, :school_trust)
+    |> Stream.map(& [&1.school_trust, &1.name, "company:"<>&1.company])
+    |> Enum.uniq
+    |> DataMorph.puts_tsv(~w[school-trust name organisation])
+  end
+
+end

--- a/lib/schools_subset.ex
+++ b/lib/schools_subset.ex
@@ -1,0 +1,30 @@
+
+defmodule SchoolSubset do
+
+  def schools_in_local_authority code do
+    :stdio
+    |> IO.stream(:line)
+    |> CSV.decode(headers: true, separator: ?\t)
+    |> Stream.filter(& &1["school-authority"] == code)
+    |> Stream.map(& &1["school"])
+    |> Enum.each(&IO.puts/1)
+  end
+
+  def school_tsv keys_file do
+    regex = key_regex(keys_file)
+    :stdio
+    |> IO.stream(:line)
+    |> Stream.filter(& &1 |> match(regex))
+    |> Enum.each(&IO.write/1)
+  end
+
+  defp match line, regex do
+    String.match?(line, regex) || String.starts_with?(line, "school\t")
+  end
+
+  defp key_regex keys_file do
+    keys = File.stream!(keys_file) |> Stream.map(&String.strip/1) |> Enum.join("|")
+    {:ok, regexp} = Regex.compile "^(" <> keys <> ")\t"
+    regexp
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,29 @@
+defmodule OrdinanceSurvey.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :school_data,
+     version: "0.0.1",
+     elixir: "~> 1.3",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps]
+  end
+
+  def application do
+    [applications: [
+      :geocalc,
+      :logger,
+    ]]
+  end
+
+  defp deps do
+    [
+      {:data_morph, branch: 'stream-filter-take', git: "https://github.com/robmckinnon/data_morph.git"},
+      {:floki, "~> 0.10"},
+      {:geocalc, "~> 0.5"},
+      {:poison, "~> 2.0"},
+      {:tabula, "~> 2.0"},
+    ]
+  end
+end


### PR DESCRIPTION
Various changes to school data fields and registers for transition to alpha phase.

The `data/alpha` dir contains data for loading to alpha phase. Only schools for a single local authority are being loaded at this time.