### PR TITLE
Complete school trust and umbrella trust data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,7 @@ _build
 deps
 mix.lock
 
+Gemfile.lock
+
 *.tsv
 *.ods

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+ruby "2.3.1"
+gem 'morph', '>= 0.4.1'

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ MAPS=\
 	maps/school-phase.tsv\
 	lists/edubase-school-trust-name/trusts.tsv\
 	lists/edubase-school-trust/trusts.tsv\
+	maps/school-trust.tsv\
 	maps/school-type.tsv
 
 all:: flake8 $(DATA)
@@ -62,6 +63,10 @@ data/alpha/school-trust/school-trusts.tsv: mix.deps
 	| sed 's/school-trust,name,company/school-trust,name,organisation/' \
 	| mix run -e 'SchoolTrust.final_trust_tsv' \
 	> $@
+
+maps/school-trust.tsv: bundle.install
+	[[ -e $@ ]] || \
+	bundle exec ruby ./lib/school_trust.rb > $@
 
 lists/edubase-school-trust/trusts.tsv: lists/edubase-school-trust-name/trusts.tsv
 	@mkdir -p lists/edubase-school-trust
@@ -130,6 +135,9 @@ lists/edubase-school-trust-name/trusts.tsv: lists/edubase-multi-academy-trust/tr
 mix.deps:
 	[[ -e mix.lock ]] || mix deps.get
 	mix compile
+
+bundle.install:
+	[[ -e Gemfile.lock ]] || bundle install
 
 # extract school addresses from address-data
 data/discovery/address/addresses.tsv:	bin/addresses.py data/discovery/school-eng/schools.tsv

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ MAPS=\
 	lists/edubase-school-trust-name/trusts.tsv\
 	lists/edubase-school-trust/trusts.tsv\
 	maps/school-trust.tsv\
+	maps/school-umbrella-trust.tsv\
 	maps/school-type.tsv
 
 all:: flake8 $(DATA)
@@ -66,7 +67,11 @@ data/alpha/school-trust/school-trusts.tsv: mix.deps
 
 maps/school-trust.tsv: bundle.install
 	[[ -e $@ ]] || \
-	bundle exec ruby ./lib/school_trust.rb > $@
+	UMBRELLA=false bundle exec ruby ./lib/school_trust.rb > $@
+
+maps/school-umbrella-trust.tsv: bundle.install
+	[[ -e $@ ]] || \
+	UMBRELLA=true bundle exec ruby ./lib/school_trust.rb > $@
 
 lists/edubase-school-trust/trusts.tsv: lists/edubase-school-trust-name/trusts.tsv
 	@mkdir -p lists/edubase-school-trust

--- a/Makefile
+++ b/Makefile
@@ -34,15 +34,26 @@ all:: flake8 $(DATA)
 
 data/alpha/school-eng/schools.tsv: mix.deps data/discovery/school-eng/schools.tsv
 	@mkdir -p data/alpha/school-eng
-	[[ -e $@ ]] || csvgrep -tc school-authority -m "919" < data/discovery/school-eng/schools.tsv | csvformat -T > $@
+	[[ -e $@ ]] || \
+	csvgrep -tc school-authority -m "919" < data/discovery/school-eng/schools.tsv \
+	| csvformat -T \
+	> $@
 
 data/discovery/school-eng/schools.tsv: bin/schools.py cache/edubase.csv $(MAPS) $(SCHOOL_DATA)
 	@mkdir -p data/discovery/school-eng
-	[[ -e $@ ]] || csvgrep -c 'GOR (name)' -im 'Wales' < cache/edubase.csv | bin/schools.py | sed 's/^school\([[:blank:]]\)/school-eng\1/' > $@
+	[[ -e $@ ]] || \
+	csvgrep -c 'GOR (name)' -im 'Wales' < cache/edubase.csv \
+	| bin/schools.py \
+	| sed 's/^school\([[:blank:]]\)/school-eng\1/' \
+	> $@
 
 data/discovery/school-wls/schools.tsv:
 	@mkdir -p data/discovery/school-wls
-	[[ -e $@ ]] || csvgrep -c 'GOR (name)' -m 'Wales' < cache/edubase.csv | bin/schools.py | sed 's/^school\([[:blank:]]\)/school-wls\1/' > $@
+	[[ -e $@ ]] || \
+	csvgrep -c 'GOR (name)' -m 'Wales' < cache/edubase.csv \
+	| bin/schools.py \
+	| sed 's/^school\([[:blank:]]\)/school-wls\1/' \
+	> $@
 
 data/alpha/school-trust/school-trusts.tsv: mix.deps
 	@mkdir -p data/alpha/school-trust

--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,12 @@ lists/edubase-school-trust-name/trusts.tsv: lists/edubase-multi-academy-trust/tr
 	| sed 's/^\([^,]*,\)\(".*\)~\(.*"\),\([^,]*\)/\1\2\",\4~\1"\3,\4/g' \
 	| sed 's/^\([^,]*,\)\([^"].*\)~\(.*\),\([^,]*\)/\1\2,\4~\1\3,\4/g' \
 	| tr '~' $$'\n'   \
-	| csvsort -c name \
+	| csvcut -c urn,type,name \
+	| tr ' ' '_' \
+	| csvsort -c name,urn \
 	| csvformat -T    \
-	| uniq -f1        \
+	| uniq -f2        \
+	| tr '_' ' ' \
 	| csvsort -tc urn \
 	| csvcut -c name,type \
 	| csvgrep -c name -r "." \

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ data/alpha/school-eng/schools.tsv: mix.deps data/discovery/school-eng/schools.ts
 
 data/discovery/school-eng/schools.tsv: bin/schools.py cache/edubase.csv $(MAPS) $(SCHOOL_DATA)
 	@mkdir -p data/discovery/school-eng
-	[[ -e $@ ]] || csvgrep -c 'GOR (name)' -im 'Wales' < cache/edubase.csv | bin/schools.py | sed '1,/school/s/school/school-eng/' > $@
+	[[ -e $@ ]] || csvgrep -c 'GOR (name)' -im 'Wales' < cache/edubase.csv | bin/schools.py | sed 's/^school\([[:blank:]]\)/school-eng\1/' > $@
 
 data/discovery/school-wls/schools.tsv:
 	@mkdir -p data/discovery/school-wls
-	[[ -e $@ ]] || csvgrep -c 'GOR (name)' -m 'Wales' < cache/edubase.csv | bin/schools.py | sed '1,/school/s/school/school-wls/' > $@
+	[[ -e $@ ]] || csvgrep -c 'GOR (name)' -m 'Wales' < cache/edubase.csv | bin/schools.py | sed 's/^school\([[:blank:]]\)/school-wls\1/' > $@
 
 data/alpha/school-trust/school-trusts.tsv: cache/links mix.deps
 	@mkdir -p data/alpha/school-trust

--- a/bin/schools.py
+++ b/bin/schools.py
@@ -23,6 +23,7 @@ fields = [
     "school-tags",
     # "school-federation",
     "school-trust",
+    "school-umbrella-trust",
     "start-date",
     "end-date",
 ]
@@ -71,7 +72,9 @@ def map_name(field, name):
 
     if _name in names[field]:
         return names[field][_name]
-    log("unknown %s value [%s]" % (field, name))
+    if field != 'school-trust':
+        if field != 'school-umbrella-trust':
+            log("unknown %s value [%s]" % (field, name))
     return ''
 
 
@@ -123,6 +126,7 @@ if __name__ == '__main__':
     load_names('school-phase', 'maps/school-phase.tsv')
 
     load_names('school-trust', 'maps/school-trust.tsv', 'school')
+    load_names('school-umbrella-trust', 'maps/school-umbrella-trust.tsv', 'school')
 
     load_names('school-type', 'data/discovery/school-type/school-types.tsv')
     load_names('school-type', 'maps/school-type.tsv')
@@ -159,6 +163,7 @@ if __name__ == '__main__':
         item['school-type'] = map_name('school-type', row['TypeOfEstablishment (name)'])
 
         item['school-trust'] = map_name('school-trust', row['URN'])
+        item['school-umbrella-trust'] = map_name('school-umbrella-trust', row['URN'])
 
         item['school-admissions-policy'] = ''
         item['school-authority'] = row['LA (code)']

--- a/data/alpha/school-eng/schools.tsv
+++ b/data/alpha/school-eng/schools.tsv
@@ -1,879 +1,879 @@
-school-eng	name	address	school-authority	minimum-age	maximum-age	religious-characters	dioceses	school-type	school-phase	school-admissions-policy	school-gender	school-tags	school-trust	start-date	end-date
-102256	Purcell School	9B1AK1J	919	8	19			11			M			1962-10-11	
-117065	Weston Way Nursery School	2X6MXMZY	919	3	5			15	NUR		M				
-117066	Arlesdene Nursery School and Pre-School	4D4TEB	919	2	5			15	NUR		M				
-117067	Greenfield Nursery School	4D4SBT	919	2	4			15	NUR		M				
-117068	Batford Nursery School	2X6MTFQ8	919	2	5			15	NUR		M				
-117069	Birchwood Nursery School	2X6MTB00	919	2	5			15	NUR		M				
-117070	Heath Lane Nursery School	9AQJZND	919	3	5			15	NUR		M				
-117071	York Road Nursery School	2X6MXJA5	919	3	5			15	NUR		M				
-117072	Rye Park Nursery School	4D5GWB	919	2	5			15	NUR		M				
-117073	Nevells Road Nursery School		919	3	5			15	NUR		M				2001-12-31
-117074	Muriel Green Nursery School		919	3	5			15	NUR		M				2001-01-01
-117075	London Colney Nursery School	2X6MTBMW	919	3	5			15	NUR		M				2015-03-31
-117076	Kingswood Nursery School	2X6MYGEW	919	2	5			15	NUR		M				
-117077	Oxhey Early Years Centre	2X6MYCMV	919	3	5			15	NUR		M				
-117078	Tenterfield Nursery School	2X6MTG52	919	3	5			15	NUR		M				
-117079	Ludwick Nursery School	2X6MTH11	919	2	5			15	NUR		M				
-117080	Peartree Way Nursery School	9C3QP0K	919	2	5			15	NUR		M				
-117081	Wall Hall Nursery School		919	3	5			15	NUR		M				2003-12-31
-117082	Lea Valley Education Support Centre		919	5	16			14			M			1995-09-01	2009-08-31
-117083	Abbots Langley School	5T8FR7NZ	919	3	11			1	PRI		M				
-117084	Ashwell Primary School	9C3H2ZH	919	3	11			1	PRI		M				
-117085	Northgate Primary School	2X6MTK10	919	3	11			1	PRI		M				2012-07-31
-117086	Bovingdon Junior School	2X6MV9XY	919	7	11			1	PRI		M				1998-09-01
-117087	Jenyns First School and Nursery	9B09NDE	919	3	9			1	PRI		M				
-117088	Bushey Heath Primary School	9B1AJWD	919	3	11			1	PRI		M				
-117089	Highwood Primary School	9B1AK0C	919	3	11			1	PRI		M				
-117090	Merry Hill Infant School and Nursery	9B1AJY1	919	3	7			1	PRI		M				
-117091	Holdbrook Primary School	4D50QJ	919	3	11			1	PRI		M				
-117092	Four Swannes Primary School	4D50QH	919	3	11			1	PRI		M				
-117093	Chorleywood Primary School	5T8FR9MQ	919	3	11			1	PRI		M				
-117094	Beechfield School	9A2MXPG	919	3	11			1	PRI		M				
-117095	New Briars Primary and Nursery School		919	3	11			1	PRI		M				2007-08-31
-117096	Shepherd Primary	5T8FR93G	919	3	11			1	PRI		M				
-117097	Hobletts Manor Junior School	9A2N6M9	919	7	11			1	PRI		M				
-117098	The Russell School	5T8FR999	919	3	11			1	PRI		M				
-117099	Cowley Hill School	9B1AJ1X	919	3	11			1	PRI		M				
-117100	Flamstead Village School	2X6MTE37	919	3	11			1	PRI		M				
-117101	Gaddesden Row JMI School	9A2N6TH	919	4	11			1	PRI		M				
-117102	Sauncey Wood Primary School	5T8GM330	919	4	11			1	PRI		M				
-117103	Manland Primary School	2X6MTFDJ	919	4	11			1	PRI		M				
-117104	Gascoyne Cecil Junior School	9AE9CV7	919	7	11			1	PRI		M				1999-09-01
-117105	Green Lanes Primary School	2X6MTBHN	919	5	11			1	PRI		M				
-117106	George Street Primary School	5T8JQF7A	919	3	11			1	PRI		M				
-117107	Boxmoor Primary School	5T8JQEZ2	919	4	11			1	PRI		M				
-117108	Two Waters Primary School	2X6MV9Y3	919	3	11			1	PRI		M				
-117109	Tudor Primary School	2X6MVAE8	919	3	11			1	PRI		M				
-117110	South Hill Primary School	9AQJZND	919	5	11			1	PRI		M				
-117111	Abel Smith School	9B09VV9	919	2	11			1	PRI		M				
-117112	Hexton Junior Mixed and Infant School	9C3H2AA	919	4	11			1	PRI		M				
-117113	Highbury Infant School and Nursery	2X6MXHN8	919	3	7			1	PRI		M				
-117114	Strathmore Infant and Nursery School	5T8GM5Z2	919	3	7			1	PRI		M				
-117115	Highover Junior Mixed and Infant School	2X6MXGR1	919	3	11			1	PRI		M				
-117116	Wilshere-Dacre Junior School	9C3H8GG	919	7	11			1	PRI		M				2014-02-28
-117117	Hunsdon Junior Mixed and Infant School		919	4	11			1	PRI		M				
-117118	Kimpton Primary School	2X6MXHA3	919	3	11			1	PRI		M				
-117119	Breachwood Green Junior Mixed and Infant School	9C3H4CS	919	4	11			1	PRI		M				
-117120	Knebworth Primary and Nursery School	9C3H3W0	919	3	11			1	PRI		M				
-117121	Wilbury Junior School	2X6MXM4C	919	7	11			1	PRI		M				
-117122	Grange Junior School	2X6MXMAX	919	7	11			1	PRI		M				
-117123	Hillshott Infant School and Nursery	2X6MXKC1	919	3	7			1	PRI		M				
-117124	Westbury Primary and Nursery School	9APZHC2	919	3	11			1	PRI		M				2009-08-31
-117125	Hertford Heath Primary and Nursery School	9B09MHA	919	3	11			1	PRI		M				
-117126	Little Hadham Primary School	9B09XQM	919	4	11			1	PRI		M				
-117127	Markyate Village School and Nursery	5T8JQERT	919	4	11			1	PRI		M				
-117128	Pirton School	5T8GM5Z6	919	4	11			1	PRI		M				
-117129	Reed First School	2X6MXNM0	919	3	9			1	PRI		M				
-117130	Yorke Mead Primary School	5T8FRBSD	919	3	11			1	PRI		M				
-117131	Harvey Road Primary School	5T8FR9S8	919	3	11			1	PRI		M				
-117132	Little Green Junior School	5T8FR9SA	919	7	11			1	PRI		M				
-117133	Malvern Way Infant and Nursery School	5T8FR9SP	919	3	7			1	PRI		M				
-117134	Tannery Drift School	2X6MXNAM	919	3	9			1	PRI		M				
-117135	Bernards Heath Infant and Nursery School	2X6MTANG	919	3	7			1	PRI		M				
-117136	Camp Primary and Nursery School	5T8JAKCQ	919	3	11			1	PRI		M				
-117137	Fleetville Junior School	5T8JAG03	919	7	11			1	PRI		M			1997-02-26	2012-05-31
-117138	Fleetville Infant and Nursery School	2X6MTAHR	919	3	7			1	PRI		M			1996-06-05	2012-05-31
-117139	Garden Fields Junior Mixed and Infant School	5T8JAKZZ	919	5	11			1	PRI		M				
-117140	St Peter's School	2X6MT9N0	919	3	11			1	PRI		M				
-117141	Aboyne Lodge Junior Mixed and Infant School	2X6MTDHF	919	3	11			1	PRI		M				
-117142	Mandeville Primary School	9A1RF1A	919	3	11			1	PRI		M				2012-12-31
-117143	Bernards Heath Junior School	5T8JAQW9	919	7	11			1	PRI		M				
-117144	St Paul's Walden Primary School	2X6MXHA2	919	4	11			1	PRI		M				
-117145	Colney Heath Junior Mixed Infant and Nursery School	2X6MTEC1	919	4	11			1	PRI		M				
-117146	London Colney Primary & Nursery School	2X6MTBMW	919	3	11			1	PRI		M				
-117147	Sandon Junior Mixed and Infant School	2X6MXNX1	919	4	11			1	PRI		M				
-117148	Sandridge School	2X6MTEVR	919	4	11			1	PRI		M				
-117149	Fawbert and Barnard Infants' School	9B09WDC	919	3	7			1	PRI		M				
-117150	Shenley Primary School	9B1AHCZ	919	3	11			1	PRI		M				
-117151	Letchmore Infants' and Nursery School	9C3QN7X	919	3	7			1	PRI		M				
-117152	Fairlands Primary School and Nursery	9C3QN1A	919	3	11			1	PRI		M				
-117153	Therfield First School	2X6MXNSQ	919	5	9			1	PRI		M				
-117154	Walkern Primary School	2X6MXFT3	919	4	11			1	PRI		M				
-117155	The Orchard Primary School	2X6MYG70	919	3	11			1	PRI		M				
-117156	Central Primary School	5T8FR0MP	919	3	11			1	PRI		M				
-117157	Bushey and Oxhey Infant School	5T8FR2HA	919	5	7			1	PRI		M				
-117158	Chater Junior School	2X6MYDFF	919	7	11			1	PRI		M				
-117159	Chater Infant School		919	3	7			1	PRI		M				
-117160	Field Junior School	2X6MYE01	919	7	11			1	PRI		M				
-117161	Watford Field School (Infant & Nursery)	5T8FR161	919	3	7			1	PRI		M				
-117162	Parkgate Junior School	2X6MYFQH	919	7	11			1	PRI		M				
-117163	Parkgate Infants' and Nursery School	2X6MYFQM	919	3	7			1	PRI		M				
-117164	Garston Infants' School		919	5	7			1	PRI		M				2005-08-31
-117165	Knutsford School	2X6MYFQJ	919	3	11			1	PRI		M				
-117166	St Meryl School	2X6MYCWQ	919	3	11			1	PRI		M				
-117167	Cassiobury Junior School	5T8FR15R	919	7	11			1	PRI		M				
-117168	Kingsway Junior School	2X6MYGF8	919	7	11			1	PRI		M				
-117169	Warren Dell Primary School	5T8FR6C3	919	2	11			1	PRI		M				
-117170	Oxhey Wood Primary School	5T8FRCN0	919	3	11			1	PRI		M				
-117171	Watton-at-Stone Primary and Nursery School	9B1RF4K	919	2	11			1	PRI		M				
-117172	Peartree Primary School	2X6MTH0Y	919	5	11			1	PRI		M				
-117173	Blackthorn Junior School	9AE9CV8	919	7	11			1	PRI		M				2001-12-31
-117174	Templewood Primary School	5T8JHBRH	919	3	11			1	PRI		M				
-117175	Holwell Primary School	2X6MTH11	919	5	11			1	PRI		M				
-117176	Widford School	9B09WXS	919	4	11			1	PRI		M				
-117177	Wymondley Junior Mixed and Infant School	2X6MXGZ4	919	4	11			1	PRI		M				
-117178	Tanners Wood Junior Mixed and Infant School	2X6MYKRX	919	3	11			1	PRI		M				
-117179	Havers Infant School		919	3	7			1	PRI		M				2005-12-31
-117180	Hurst Drive Primary School	4D4SBT	919	4	11			1	PRI		M				
-117181	Woodlands Primary School	9B1AJ1Y	919	3	11			1	PRI		M				
-117182	Summerswood Primary School	9B1AHM6	919	3	11			1	PRI		M				
-117183	Kenilworth Primary School	9B1AHNW	919	3	11			1	PRI		M				
-117184	Meryfield Primary School	9B1AJ14	919	3	11			1	PRI		M				
-117185	Salisbury Infants' School	9AE9CV7	919	5	7			1	PRI		M				1999-09-01
-117186	Icknield Infant and Nursery School	2X6MXM4M	919	3	7			1	PRI		M				
-117187	Bowmansgreen Primary School	5T8JAMAR	919	4	11			1	PRI		M				
-117188	Margaret Wix Primary School	5T8JAM3C	919	3	11			1	PRI		M				
-117189	Broom Barns Community Primary School	9ADG70X	919	4	11			1	PRI		M				
-117190	Lea Farm Junior School		919	7	11			1	PRI		M				2005-08-31
-117191	Alban Wood Junior School		919	7	11			1	PRI		M				2005-08-31
-117192	Little Furze Junior Mixed and Infant School		919	3	11			1	PRI		M				2004-12-16
-117193	Greenfields Primary School	2X6MYCZB	919	3	11			1	PRI		M				
-117194	Woodhall Primary School	5T8FR714	919	3	11			1	PRI		M				
-117195	Saffron Green Primary School	9B1AHQY	919	3	11			1	PRI		M				
-117196	Hazelgrove Primary School		919	4	11			1	PRI		M				2004-08-31
-117197	Hobletts Manor Infants' School	9A2N6M9	919	3	7			1	PRI		M				
-117198	Chaulden Junior School	2X6MTSD8	919	7	11			1	PRI		M				2013-04-30
-117199	Roebuck Junior School	9C3QNHH	919	7	11			1	PRI		M				2001-04-18
-117200	Bedwell Primary School	9C3QP13	919	4	11			1	PRI		M				
-117201	Flamstead End Junior School	4D4PHZ	919	7	11			1	PRI		M				2003-08-31
-117202	Chaulden Infants' and Nursery	2X6MTSD8	919	3	7			1	PRI		M				
-117203	Haslewood Junior School	4D5VED	919	7	11			1	PRI		M				2002-12-31
-117204	Roebuck Infant School	9C3QNHH	919	3	7			1	PRI		M				2001-04-18
-117205	Peartree Spring Junior School	5T8FDF2Q	919	7	11			1	PRI		M				2014-08-31
-117206	Peartree Spring Primary School	5T8FDF2Q	919	4	11			1	PRI		M				
-117207	Longmeadow Junior School	5T8FDGYV	919	7	11			1	PRI		M				2005-08-31
-117208	Longmeadow Infant and Nursery School	5T8FDGYV	919	3	7			1	PRI		M				2005-08-31
-117209	Bandley Hill Junior School	9ADG70Y	919	7	11			1	PRI		M				1998-03-20
-117210	Bandley Hill Infants' School	9ADG70Y	919	5	7			1	PRI		M				1998-03-20
-117211	Roundwood Primary School	5T8JAR3E	919	3	11			1	PRI		M				
-117212	Wheatfields Junior Mixed School	9AQQQ70	919	7	11			1	PRI		M				
-117213	Thumbswood Infant School	9AE9CV8	919	5	7			1	PRI		M				2001-12-31
-117214	Chambersbury Primary School	2X6MVA2W	919	3	11			1	PRI		M				
-117215	Broadfield Junior School	5T8JQEN7	919	7	11			1	PRI		M				2007-12-31
-117216	Broadfield Infants' School	2X6MV4MW	919	3	7			1	PRI		M				2007-12-31
-117217	Windermere Primary School	2X6MTAYM	919	5	11			1	PRI		M				
-117218	Anstey First School	9B1RAP4	919	2	9			1	PRI		M				
-117219	Monksmead School	9AE03VX	919	2	11			1	PRI		M				
-117220	Howe Dell Primary School	9AE9DVC	919	3	11			1	PRI		M				
-117221	Almond Hill Junior School	5T8FDH6F	919	7	11			1	PRI		M				
-117222	Oakwood Primary School	2X6MTEAJ	919	4	11			1	PRI		M				
-117223	Northfields Infants and Nursery School	2X6MXMBX	919	3	7			1	PRI		M				
-117224	Purwell Primary School	5T8GM5YV	919	3	11			1	PRI		M				
-117225	Killigrew Junior School	5T8JAQST	919	7	11			1	PRI		M				2008-08-31
-117226	Camps Hill Community Primary School	9C3QPE3	919	2	11			1	PRI		M				
-117227	Harwood Hill Junior Mixed Infant and Nursery School		919	3	11			1	PRI		M				
-117228	Fair Field Junior School	9B1AHFC	919	7	11			5	PRI		M				2015-03-31
-117229	Creswick Primary and Nursery School		919	4	11			1	PRI		M				
-117230	Thorley Hill Primary School	2X6MTKB4	919	3	11			1	PRI		M				
-117231	Micklem Primary School	2X6MTSD9	919	3	11			1	PRI		M				
-117232	Mayfield Infants' School and Nursery	4D609B	919	3	7			1	PRI		M				2010-08-31
-117233	Brookland Junior School	4D559A	919	7	11			1	PRI		M				
-117234	The Reddings Primary School	2X6MVA2V	919	3	11			1	PRI		M				
-117235	How Wood Primary and Nursery School	5T8JAQT4	919	3	11			1	PRI		M				
-117236	Redbourn Infants' and Nursery School	2X6MTDTD	919	3	7			1	PRI		M				
-117237	Lodge Farm Junior Mixed School	9C3QPF8	919	7	11			1	PRI		M				2000-04-30
-117238	Lodge Farm Infants' School		919	3	7			1	PRI		M				2000-04-30
-117239	Rossgate Primary School	2X6MTSE6	919	3	11			1	PRI		M				2008-08-31
-117240	Skyswood Primary & Nursery School	2X6MTEVX	919	3	11			1	PRI		M				
-117241	Martindale Primary and Nursery School	2X6MTSDA	919	3	11			1	PRI		M				2008-08-31
-117242	Bushey Manor Junior School	9B1AK1Q	919	7	11			1	PRI		M				
-117243	Goffs Oak Primary & Nursery School	4D4RPT	919	3	11			1	PRI		M				
-117244	Summercroft Junior School	9B09V9Y	919	7	11			1	PRI		M				2005-12-31
-117245	Eastbury Farm Primary School	5T8FRA25	919	3	11			1	PRI		M				
-117246	Burydale Junior School	9C3QNZ0	919	7	11			1	PRI		M				2005-08-31
-117247	Shephall Green Infant and Nursery School	9C3QNZ4	919	3	7			1	PRI		M				2005-08-31
-117248	Bedmond Village Primary and Nursery School	5T8FR7WQ	919	3	11			1	PRI		M				
-117249	Gade Valley Junior Mixed Infant and Nursery School	2X6MZ9HS	919	3	11			1	PRI		M				
-117250	Cunningham Hill Junior School	9AQQSA0	919	7	11			1	PRI		M				
-117251	Pin Green Primary School and Nursery		919	4	11			1	PRI		M				2005-08-31
-117252	Homerswood Primary and Nursery School	5T8JHBMF	919	3	11			1	PRI		M				
-117253	Whitehill Junior School	2X6MXHN9	919	7	11			1	PRI		M				
-117254	Westfield Primary School and Nursery	5T8JQF0C	919	3	11			1	PRI		M				
-117255	Downfield Primary School	4D50X6	919	2	11			1	PRI		M				
-117256	Pixies Hill Primary School	2X6MTSD7	919	4	11			1	PRI		M				
-117257	Rowans Primary School	2X6MTGAS	919	3	11			1	PRI		M				
-117258	The Grove Junior School	2X6MTEXS	919	7	11			1	PRI		M				
-117259	Pixmore Junior School	9APZNCK	919	7	11			1	PRI		M				
-117260	Swing Gate Infant School and Nursery	2X6MVB3M	919	3	7			1	PRI		M				
-117261	Oaklands Primary School	2X6MTFVS	919	5	11			1	PRI		M				
-117262	Flamstead End Infant and Nursery School	4D4PHZ	919	3	7			1	PRI		M				2003-08-31
-117263	Hollybush Primary School	9B09VVZ	919	3	11			1	PRI		M				
-117264	Oughtonhead Junior School	5T8GM5Z3	919	7	11			1	PRI		M				2001-09-01
-117265	Oughtonhead Infants' School	5T8GM5Z3	919	3	7			1	PRI		M				2001-09-01
-117266	Maple Cross Junior Mixed Infant and Nursery School	5T8FR8QR	919	4	11			1	PRI		M				
-117267	Killigrew Infant and Nursery School	5T8JAQST	919	3	7			1	PRI		M				2008-08-31
-117268	Wheatfields Infants' and Nursery School	9AQQQ70	919	3	7			1	PRI		M				
-117269	Moss Bury Primary School and Nursery	9C3QP1W	919	3	11			1	PRI		M				
-117270	Westfield Community Primary School	4D5ZBM	919	5	11			1	PRI		M				
-117271	Priors Wood Primary School	2X6MXAJ9	919	3	11			1	PRI		M				
-117272	Brookland Infant and Nursery School	4D559A	919	3	7			1	PRI		M				
-117273	Summercroft Infant and Nursery School	9B09V9Y	919	3	7			1	PRI		M				2005-12-31
-117274	Goldfield Infants' and Nursery School	5T8JQEW6	919	3	7			1	PRI		M				
-117275	Tower Primary School	9B09WW3	919	2	11			1	PRI		M				
-117276	Greenway Primary and Nursery School		919	3	11			1	PRI		M				
-117277	Thorn Grove Primary School	2X6MTM1G	919	3	11			1	PRI		M				
-117278	Icknield Walk First School	2X6MXNF3	919	3	9			1	PRI		M				
-117279	Cunningham Hill Infant School	9AQQSA0	919	5	7			1	PRI		M				
-117280	Reedings Junior School	9B09WC0	919	7	11			1	PRI		M				
-117281	The Grove Infant and Nursery School	2X6MTF03	919	3	7			1	PRI		M				
-117282	The Hammond Primary School	5T8JQEQG	919	5	11			1	PRI		M				2011-07-31
-117283	Kings Langley Primary School	5T8JQEXY	919	3	11			1	PRI		M				
-117284	Forres Primary School	4D5JF9	919	5	11			1	PRI		M				
-117285	Martins Wood Primary School	2X6MX9VD	919	2	11			1	PRI		M				
-117286	Dundale Primary School and Nursery		919	3	11			1	PRI		M				
-117287	Crabtree Junior School	2X6MTFQN	919	7	11			1	PRI		M				2014-03-31
-117288	Redbourn Junior School	2X6MTDTD	919	7	11			1	PRI		M				
-117289	Arnett Hills Junior Mixed and Infant School	5T8FR8CN	919	4	11			1	PRI		M				
-117290	Holywell Primary School	5T8FR0E4	919	3	11			1	PRI		M				
-117291	The Firs Junior School		919	7	11			1	PRI		M				2005-12-31
-117292	Trotts Hill Primary and Nursery School	9C3QNTR	919	4	11			1	PRI		M				
-117293	Cassiobury Infant and Nursery School	9CPSB9K	919	3	7			1	PRI		M				
-117294	Panshanger Primary School	2X6MTGAT	919	3	11			1	PRI		M				
-117295	Bovingdon Infants' School		919	5	7			1	PRI		M				1998-09-01
-117296	Bournehall Primary School		919	4	11			1	PRI		M				
-117297	Mill Mead Primary School	9B09W4W	919	3	11			1	PRI		M				
-117298	Maple Primary School	5T8JAQW1	919	4	11			1	PRI		M				
-117299	Round Diamond Primary School	9ADX0GP	919	3	11			1	PRI		M				
-117300	Hartsbourne Primary School	9B1AK05	919	4	11			1	PRI		M				
-117301	Beech Hyde Primary School and Nursery	5T8JAR6M	919	3	11			1	PRI		M				
-117302	Andrews Lane Primary School	4D5ZRZ	919	3	11			1	PRI		M				
-117303	Newberries Primary School	9B1AHFF	919	4	11			1	PRI		M				
-117304	Rickmansworth Park Junior Mixed and Infant School	5T8FR92K	919	5	11			1	PRI		M				
-117305	Mandeville Primary School	9B09WF3	919	3	11			1	PRI		M				
-117306	Giles Junior School	5T8FDH1E	919	7	11			1	PRI		M				
-117307	The Cranbourne Primary School	4D5MF5	919	4	11			1	PRI		M				2016-08-31
-117308	Bromet Primary School	2X6MYCN6	919	5	11			1	PRI		M				
-117309	Millfield First and Nursery School	2X6MXNXS	919	3	9			1	PRI		M				
-117310	Hillmead Primary School	9B09Q1V	919	3	11			1	PRI		M				
-117311	Nascot Wood Junior School	5T8FR16E	919	7	11			1	PRI		M				
-117312	Crabtree Infants' School	2X6MTFQN	919	5	7			1	PRI		M				2014-03-31
-117313	The Ryde School	2X6MTHTH	919	3	11			1	PRI		M				
-117314	William Ransom Primary School	5T8GM5Z0	919	4	11			1	PRI		M				
-117315	Prae Wood Primary School	2X6MTD7F	919	3	11			1	PRI		M				
-117316	The Giles Infant and Nursery School	5T8FDH1E	919	3	7			1	PRI		M				
-117317	Kingsway Infants' School	5T8FR163	919	5	7			1	PRI		M				
-117318	Alban Wood Infant and Nursery School	2X6MYGZD	919	3	7			1	PRI		M				2005-08-31
-117319	Kingshill Infant School	5T8HG06K	919	3	7			1	PRI		M				
-117320	Laurance Haines School	5T8FR3MT	919	3	11			1	PRI		M				
-117321	Woodside Primary School	4D4KHF	919	4	11			1	PRI		M				
-117322	Woolenwick Junior School	5T8FDH83	919	7	11			1	PRI		M				
-117323	Woolenwick Infant and Nursery School	5T8FDH83	919	3	7			1	PRI		M				
-117324	Leavesden JMI School	2X6MYGZE	919	3	11			1	PRI		M				
-117325	Springmead Primary School	5T8JHB1W	919	3	11			1	PRI		M				
-117326	Longlands Primary School and Nursery	4D56ZK	919	3	11			1	PRI		M				
-117327	The Lea Primary School and Nursery	5T8JAMXC	919	3	11			1	PRI		M				
-117328	Wheatcroft Primary School	2X6MXBM8	919	3	11			1	PRI		M				
-117329	Mary Exton Primary School	5T8GM5YW	919	5	11			1	PRI		M				
-117330	Lordship Farm Primary School	9C3H4EB	919	3	11			1	PRI		M				
-117331	Studlands Rise First School	2X6MXNSX	919	3	9			1	PRI		M				
-117332	Roman Way First School	2X6MXNAP	919	3	9			1	PRI		M				
-117333	Lime Walk Primary School	2X6MVAGM	919	3	11			1	PRI		M				
-117334	Fairfields Primary School and Nursery	4D4Q88	919	3	11			1	PRI		M				
-117335	Aycliffe Drive Primary School	2X6MV52E	919	3	11			1	PRI		M				
-117336	Holtsmere End Junior School	2X6MV5B2	919	7	11			1	PRI		M				
-117337	Samuel Lucas Junior Mixed and Infant School	9ADWWZ9	919	4	11			1	PRI		M				
-117338	Roselands Primary School	4D5CE2	919	5	11			1	PRI		M				2016-08-31
-117339	Cherry Tree Primary School	5T8FR0ZN	919	3	11			1	PRI		M				
-117340	Coates Way JMI and Nursery School	9A2MY90	919	3	11			1	PRI		M				
-117341	Grove Road Primary School	2X6MV8D9	919	3	11			1	PRI		M				
-117342	High Beeches Primary School	5T8JAR5S	919	5	11			1	PRI		M				
-117343	Barncroft Primary School	5T8JQH12	919	3	11			1	PRI		M				2008-08-31
-117344	Jupiter Drive Junior Mixed and Infant School	2X6MV4WB	919	5	11			1	PRI		M				2008-08-31
-117345	Stonehill School	2X6MXMC2	919	3	11			1	PRI		M				
-117346	Richard Whittington Primary School	2X6MTKGY	919	3	11			1	PRI		M				
-117347	Mount Pleasant Lane Junior Mixed and Infant School and Nursery	5T8JAMHS	919	3	11			1	PRI		M				
-117348	Watchlytes Junior Mixed Infant and Nursery School	2X6MTGVX	919	3	11			1	PRI		M				
-117349	Brockswood Primary School	9A2N4RC	919	3	11			1	PRI		M				
-117350	Lannock Primary School	9C3H64A	919	3	11			1	PRI		M				2009-08-31
-117351	Ryelands Primary School	4D5GPC	919	5	11			1	PRI		M				2007-08-31
-117352	Ashtree Primary School and Nursery	9C3QPDM	919	3	11			1	PRI		M				
-117353	Sheredes Primary School	4D5BFS	919	3	11			1	PRI		M				
-117354	Radburn Primary School	2X6MXKK5	919	3	11			1	PRI		M				2012-08-31
-117355	Applecroft School	2X6MTHMA	919	3	11			1	PRI		M				2012-02-29
-117356	Ley Park Primary School	4D59VX	919	3	11			1	PRI		M				2008-08-31
-117357	Five Oaks Primary and Nursery School	2X6MTBF0	919	3	11			1	PRI		M				2004-08-31
-117358	Wood End School	2X6MTFBZ	919	4	11			1	PRI		M				
-117359	Eastbrook Primary School	2X6MV5B0	919	5	11			1	PRI		M				2008-08-31
-117360	Meriden Primary School		919	3	11			1	PRI		M				2005-08-31
-117361	Bengeo Primary School		919	3	11			1	PRI		M				
-117362	Stream Woods Junior Mixed Infant and Nursery School	2X6MTBEZ	919	3	11			1	PRI		M				2007-08-31
-117363	Morgans Primary School & Nursery	9B09KZQ	919	3	11			1	PRI		M				
-117364	The Leys Primary and Nursery School	2X6MX9R5	919	3	11			1	PRI		M				
-117365	Belswains Primary School	5T8JQGDJ	919	3	11			1	PRI		M				
-117366	Bonneygrove Primary School	4D4MDG	919	3	11			1	PRI		M				
-117367	Burleigh Primary School	4D4WFP	919	4	11			1	PRI		M				
-117368	Hobbs Hill Wood Primary School	2X6MVA3W	919	3	11			1	PRI		M				
-117369	Cranborne Primary School	9AE03PB	919	3	11			1	PRI		M				
-117370	Ladbrooke Junior Mixed and Infant School	9B1AKBC	919	3	11			1	PRI		M				
-117371	Oakmere Primary School	9B1AJKB	919	3	11			1	PRI		M				
-117372	Sunny Bank Junior School		919	7	11			1	PRI		M				1999-08-31
-117373	Sunny Bank Infants' School		919	3	7			1	PRI		M				1999-08-31
-117374	Nascot Wood Infant and Nursery School	5T8FR0J2	919	3	7			1	PRI		M				
-117375	The Pines Junior Mixed and Infant School		919	4	11			1	PRI		M				2003-08-31
-117376	Hartsfield Junior Mixed and Infant School	9C3H4K7	919	4	11			1	PRI		M				
-117377	Holtsmere End Infant and Nursery School	2X6MV5B2	919	3	7			1	PRI		M				
-117378	Commonswood Primary & Nursery School	2X6MTH6E	919	4	11			1	PRI		M				
-117379	Millbrook School	4D4TB6	919	4	11			1	PRI		M				
-117380	Manor Fields Primary School	2X6MTKPQ	919	3	11			1	PRI		M				
-117381	Bellgate Primary School	5T8JQF4Y	919	4	11			1	PRI		M				2008-08-31
-117382	Aldbury Church of England Primary School	2X6MV8DA	919	4	11	C22	CE32	3	PRI		M				
-117383	St John's Church of England Infant and Nursery School	9B1AHEP	919	3	7	C22	CE32	3	PRI		M				
-117384	St Mary's Infants' School	9APZMWE	919	5	7	C22	CE32	3	PRI		M				
-117385	St Mary's Junior Mixed School	9APZMWE	919	7	11	C22	CE32	3	PRI		M				
-117386	Barley Church of England Voluntary Controlled First School	2X6MXNGE	919	5	9	C22	CE32	3	PRI		M				
-117387	Bayford Church of England Voluntary Controlled Primary School	2X6MXBTA	919	3	11	C22	CE32	3	PRI		M				
-117388	Tonwell St Mary's Church of England Primary School	2X6MXAD5	919	3	11	C22	CE32	3	PRI		M				
-117389	Benington Church of England Primary School	9B09TXM	919	4	11	C22	CE32	3	PRI		M				
-117390	Layston Church of England First School	9B09N7S	919	5	9	C22	CE32	3	PRI		M				
-117391	Ashfield Junior School	9B1AJY4	919	7	11			3	PRI		M				
-117392	Codicote Church of England Primary School	2X6MXHA4	919	3	11	C22	CE32	3	PRI		M				
-117393	Essendon CofE (VC) Primary School	2X6MTHWN	919	3	11	C22	CE32	3	PRI		M				
-117394	Furneux Pelham Church of England School	9B1RA9H	919	4	11	C22	CE32	3	PRI		M				
-117395	Graveley Primary School	2X6MXGZ5	919	4	11	C22	CE32	3	PRI		M				
-117396	Ponsbourne St Mary's Church of England Primary School	2X6MXBT5	919	4	11	C22	CE32	3	PRI		M				
-117397	Hertford St Andrew CofE Primary School	9B09VSP	919	3	11	C22	CE32	3	PRI		M				
-117398	High Wych Church of England Primary School	9B1RA9Z	919	3	11	C22	CE32	3	PRI		M				
-117399	St Paul's Voluntary Controlled Church of England Infants' School	4D5VED	919	5	7	C22	CE32	3	PRI		M				2002-12-31
-117400	Wormley Primary School	4D59VX	919	3	11	C22	CE32	3	PRI		M				
-117401	Ickleford Primary School	9C3H9EJ	919	4	11	C22	CE32	3	PRI		M				
-117402	Little Munden Church of England Voluntary Controlled Primary School	9B1N3BC	919	3	11	C22	CE32	3	PRI		M				
-117403	Preston Primary School	9C3H4EC	919	4	11	C22	CE32	3	PRI		M				
-117404	Sarratt Church of England Primary School	9A1SV6E	919	4	11	C22	CE32	3	PRI		M				
-117405	Spellbrook Primary School	9B09PAV	919	3	11	C22	CE32	3	PRI		M				
-117406	Roger De Clare First CofE School	9B09WFN	919	3	9	C22	CE32	3	PRI		M				
-117407	St Andrew's Church of England Voluntary Controlled Primary School	9B09WH6	919	3	11	C22	CE32	3	PRI		M				
-117408	Thundridge Church of England Primary School	2X6MXADA	919	3	11	C22	CE32	3	PRI		M				
-117409	St Mary's Voluntary Controlled Church of England Junior School	5T8HG06K	919	7	11	C22	CE32	3	PRI		M				
-117410	St Catherine's Church of England Primary School	9B09WT8	919	3	11	C22	CE32	3	PRI		M				
-117411	Musley Infant School	2X6MXADK	919	5	7	C22	CE32	3	PRI		M				2003-08-31
-117412	Wareside Church of England Primary School	9B09XT0	919	4	11	C22	CE32	3	PRI		M				
-117413	Weston Primary School	9C3H8X2	919	3	11	C22	CE32	3	PRI		M				
-117414	Potten End CofE Primary School	5T8JQEX2	919	3	11	C22	CE32	3	PRI		M				
-117415	Dewhurst St Mary CofE Primary School	4D5QVQ	919	5	11	C22	CE32	3	PRI		M				
-117416	Leverstock Green Church of England Primary School	9AQK0QK	919	3	11	C22	CE32	3	PRI		M				
-117417	St Paul's Church of England Primary School, Langleybury	9A1STCM	919	3	11	C22	CE32	2	PRI		M				
-117418	Nash Mills Church of England Primary School	5T8JQ82D	919	3	11	C22	CE32	2	PRI		M				
-117419	Albury Church of England Voluntary Aided Primary School	2X6MXA42	919	2	11	C22	CE32	2	PRI		M				
-117420	Ardeley St Lawrence Church of England Voluntary Aided Primary School		919	3	11	C22	CE32	2	PRI		M				
-117421	Aston St Mary's Church of England Aided Primary School	9B09TW7	919	4	11	C22	CE32	2	PRI		M				
-117422	Barkway VA Church of England First School	2X6MXNK3	919	5	9	C22	CE32	2	PRI		M				
-117423	Victoria Church of England Infant and Nursery School	5T8JQ7K1	919	3	7	C22	CE32	2	PRI		M				
-117424	St Mary's CofE Primary School, Northchurch	5T8JQGB2	919	3	11	C22	CE32	2	PRI		M				
-117425	St Joseph's Catholic Primary School	9B09V4B	919	3	11	C67	RC01	2	PRI		M				
-117426	St Michael's Church of England Primary School	2X6MTKB7	919	3	11	C22	CE32	2	PRI		M				
-117427	St Clement's Church of England Voluntary Aided Junior School	4D609B	919	7	11	C22	CE32	2	PRI		M				2010-08-31
-117428	Holy Trinity Church of England Primary School	4D5QTZ	919	4	11	C22	CE32	2	PRI		M				
-117429	St Joseph's Catholic Primary School	4D51HB	919	3	11	C67	RC01	2	PRI		M				
-117430	All Saints Church of England Voluntary Aided Primary School, Datchworth	9B09VQ6	919	5	11	C22	CE32	2	PRI		M				
-117431	St Nicholas Elstree Church of England VA Primary School	9B1AHZ8	919	3	11	C22	CE32	2	PRI		M				
-117432	St John the Baptist Voluntary Aided Church of England Primary School	9B09VQM	919	4	11	C22	CE32	2	PRI		M				
-117433	Great Gaddesden Church of England Primary School	9A2N3ZG	919	4	11	C22	CE32	2	PRI		M				
-117434	St Nicholas CofE VA Primary School	5T8JAR4F	919	4	11	C22	CE32	2	PRI		M				
-117435	St John's Voluntary Aided Church of England Primary School, Lemsford	5T8JHC7Q	919	4	11	C22	CE32	2	PRI		M				
-117436	St Joseph's Catholic Primary School		919	3	11	C67	RC01	2	PRI		M				
-117437	Broxbourne CofE Primary School	4D5AD2	919	3	11	C22	CE32	2	PRI		M				
-117438	St Augustine Roman Catholic Primary School	4D5FRY	919	3	11	C67	RC01	2	PRI		M				
-117439	Hormead Church of England (VA) First School	9B1N45D	919	3	9	C22	CE32	2	PRI		M				
-117440	St Ippolyts Church of England Aided Primary School	2X6MXGZ6	919	5	11	C22	CE32	2	PRI		M				
-117441	St Paul's Church of England Voluntary Aided Primary School, Chipperfield	2X6MYKF6	919	3	11	C22	CE32	2	PRI		M				
-117442	Norton St Nicholas CofE (VA) Primary School	2X6MXJXW	919	3	11	C22	CE32	2	PRI		M				
-117443	Little Gaddesden Church of England Voluntary Aided Primary School	2X6MVAPK	919	4	11	C22	CE32	2	PRI		M				
-117444	St Andrew's CofE Primary School and Nursery	9B09WAV	919	3	11	C22	CE32	2	PRI		M				
-117445	Offley Endowed Primary School	9C3HAY7	919	4	11	C22	CE32	2	PRI		M				
-117446	Cockernhoe Endowed CofE Primary School	9C3H7Z4	919	3	11	C22	CE32	2	PRI		M				
-117447	St Mary's Church of England Primary School, Rickmansworth	5T8FR94D	919	3	11	C22	CE32	2	PRI		M				
-117448	St Peter's Church of England Voluntary Aided Primary School	2X6MYHQ6	919	4	11	C22	CE32	2	PRI		M				
-117449	The Abbey Church of England Voluntary Aided Primary School, St Albans	5T8JAEJ1	919	4	11	C22	CE32	2	PRI		M				
-117450	St Alban and St Stephen Roman Catholic Infant and Nursery School	5T8JAQVQ	919	3	7	C67	RC01	2	PRI		M				
-117451	St Michael's Church of England Voluntary Aided Primary School, St Albans	5T8JAKVE	919	5	11	C22	CE32	2	PRI		M				
-117452	Park Street Church of England Voluntary Aided Primary School	5T8JAHE1	919	3	11	C22	CE32	2	PRI		M				
-117453	Puller Memorial, Church of England, Voluntary Aided Primary School	9B1RB29	919	3	11	C22	CE32	2	PRI		M				
-117454	St Thomas of Canterbury Roman Catholic Primary School	9B09WFA	919	3	11	C67	RC01	2	PRI		M				
-117455	Stapleford Primary School	9B09WHE	919	2	11	C22	CE32	2	PRI		M				
-117456	St Nicholas CofE (VA) Primary School and Nursery	9C3QNK2	919	3	11	C22	CE32	2	PRI		M				
-117457	Tewin Cowper Church of England Voluntary Aided Primary School	2X6MTFVR	919	4	11	C22	CE32	2	PRI		M				
-117458	Bishop Wood Church of England Junior School, Tring	2X6MV8D8	919	7	11	C22	CE32	2	PRI		M				
-117459	Long Marston VA Church of England Primary School	5T8JQGSM	919	5	11	C22	CE32	2	PRI		M				
-117460	St John's CofE Primary School	5T8JHAGW	919	3	11	C22	CE32	2	PRI		M				
-117461	St Michael's Woolmer Green CofE VA Primary School	5T8JHCKE	919	4	11	C22	CE32	2	PRI		M				
-117462	St Helen's Church of England Primary School	2X6MTEJG	919	4	11	C22	CE32	2	PRI		M				
-117463	St Bartholomew's Church of England Voluntary Aided Primary School, Wigginton	5T8JQEXV	919	4	11	C22	CE32	2	PRI		M				
-117464	Our Lady Roman Catholic Primary School	5T8JHBYW	919	4	11	C67	RC01	2	PRI		M				
-117465	St Joseph Catholic Primary School	5T8FR5R8	919	3	11	C67	RC01	2	PRI		M				
-117466	St Teresa Roman Catholic Primary School	9B1AHH8	919	3	11	C67	RC01	2	PRI		M				
-117467	St Andrew's Church of England Voluntary Aided Primary School, Hitchin	5T8GM5Z1	919	4	11	C22	CE32	2	PRI		M				
-117468	St Cuthbert Mayne Catholic Junior School	5T8JQ7VV	919	7	11	C67	RC01	2	PRI		M				
-117469	St Philip Howard Catholic Primary School	2X6MTBE4	919	4	11	C67	RC01	2	PRI		M				
-117470	St Adrian Roman Catholic Primary School	5T8JAQT5	919	3	11	C67	RC01	2	PRI		M				
-117471	Saint Albert the Great Catholic Primary School	5T8JQE5F	919	3	11	C67	RC01	2	PRI		M				
-117472	All Saints Church of England Primary School and Nursery, Bishop's Stortford	2X6MTM1E	919	3	11	C22	CE32	2	PRI		M				
-117473	Christ Church CofE (VA) Primary School and Nursery, Ware	2X6MXAE3	919	3	11	C22	CE32	2	PRI		M				
-117474	St Margaret Clitherow Roman Catholic Primary School	9C3QNHJ	919	3	11	C67	RC01	2	PRI		M				
-117475	St John Catholic Primary School	5T8FR8CM	919	4	11	C67	RC01	2	PRI		M				
-117476	Our Lady Roman Catholic Primary School	9C3H984	919	5	11	C67	RC01	2	PRI		M				2012-06-30
-117477	St Thomas More Roman Catholic Primary School	2X6MXKNC	919	3	11	C67	RC01	2	PRI		M				2012-06-30
-117478	St Dominic Catholic Primary School	5T8JAR3X	919	3	11	C67	RC01	2	PRI		M				
-117479	St Thomas More Roman Catholic Voluntary Aided Primary School	2X6MVBEF	919	3	11	C67	RC01	2	PRI		M				
-117480	St John Fisher Roman Catholic Primary School	5T8JAK3D	919	4	11	C67	RC01	2	PRI		M				
-117481	The Holy Family Catholic Primary School	5T8HFFSD	919	3	11	C67	RC01	2	PRI		M				
-117482	Countess Anne Voluntary Aided Church of England Primary School, Hatfield	5T8JHCB9	919	5	11	C22	CE32	2	PRI		M				2013-09-30
-117483	St Cross Catholic Primary School	4D5EF8	919	5	11	C67	RC01	2	PRI		M				
-117484	St Rose's Catholic Infants School	2X6MTS96	919	3	7	C67	RC01	2	PRI		M				
-117485	Divine Saviour Roman Catholic Primary School	5T8FRBGB	919	3	11	C67	RC01	2	PRI		M				
-117486	Holy Rood Catholic Junior School		919	7	11	C67	RC01	2	PRI		M				2006-08-31
-117487	St John Roman Catholic Primary School	9C3H55Z	919	3	11	C67	RC01	2	PRI		M				2012-06-30
-117488	Sacred Heart Catholic Primary School and Nursery	9B1AJXK	919	3	11	C67	RC01	2	PRI		M				
-117489	Saint Bernadette Catholic Primary School	5T8GM26F	919	4	11	C67	RC01	2	PRI		M				
-117490	Welwyn St Mary's Church of England Voluntary Aided Primary School	2X6MTG51	919	4	11	C22	CE32	2	PRI		M				
-117491	Saint Alban and St Stephen Catholic Junior School	5T8JAH43	919	7	11	C67	RC01	2	PRI		M				
-117492	St Paul's Catholic Primary School	4D4Q8A	919	3	11	C67	RC01	2	PRI		M				
-117493	Sacred Heart Catholic Primary School	9B09WMT	919	4	11	C67	RC01	2	PRI		M				
-117494	Holy Rood RC Infants' School	9A95YCZ	919	3	7	C67	RC01	2	PRI		M				2006-08-31
-117495	St Anthony's Catholic Primary School	5T8FR0DR	919	3	11	C67	RC01	2	PRI		M				
-117496	Pope Paul Catholic Primary School	9B1AJKK	919	4	11	C67	RC01	2	PRI		M				
-117497	St Mary's Church of England Primary School	2X6MTHYM	919	4	11	C22	CE32	2	PRI		M				
-117498	Saint Vincent de Paul Catholic Primary School	9C3QP13	919	4	11	C67	RC01	2	PRI		M				
-117499	The Priory School	9C3H7F5	919	11	18			5	SEC		M				
-117500	The Hemel Hempstead School	5T8JQ7X5	919	11	18			1	SEC		M				
-117501	Richard Hale School	9B09VXK	919	11	18			5	SEC		B				2013-06-30
-117502	Hitchin Boys' School	2X6MXHSD	919	11	18			1	SEC		B				2012-12-31
-117503	Hitchin Girls' School	2X6MXHBD	919	11	18			1	SEC		G				2011-08-16
-117504	Fearnhill School	9C3H9D6	919	11	18			5	SEC		M				
-117505	Verulam School	5T8FVP7Q	919	11	18			1	SEC		B				2011-07-31
-117506	Presdales School	2X6MXAZE	919	11	18			1	SEC		G				2012-03-31
-117507	Stanborough School	2X6MTHCA	919	11	18			1	SEC		M				2012-01-31
-117508	Langleybury School		919	11	18			1	SEC		M				1996-09-01
-117509	The Knights Templar School	2X6MXN06	919	11	18			1	SEC		M				2011-03-31
-117510	The Hillside School		919	13	18			1	SEC		M				2000-08-31
-117511	Sir John Lawes School	2X6MTFDH	919	11	18			5	SEC		M				2011-07-31
-117512	Adeyfield School	2X6MV4HS	919	11	18			1	SEC		M				
-117513	Norton School		919	11	18			1	SEC		M				2002-08-31
-117514	Beaumont School	2X6MTE5Z	919	11	18			1	SEC		M				2012-06-30
-117515	Barclay School	2X6N0357	919	11	18			1	SEC		M				
-117516	Hawksmoor School	9AE03ZP	919	13	18			1	SEC		M				2000-08-31
-117517	The Heathcote School	2X6MXG43	919	11	18			1	SEC		M				2012-08-31
-117518	Barnwell School	2X6MXG42	919	11	18			1	SEC		M				
-117519	Simon Balle School	2X6MXBT7	919	11	18			5	SEC		M				2013-10-31
-117520	Roundwood Park School	2X6MTFB6	919	11	18			5	SEC		M				2011-07-31
-117521	Lyndhurst Middle School		919	9	13			1	MDS		M				2001-08-31
-117522	Francis Combe School and Community College	9AQ026H	919	11	18			1	SEC		M				2009-08-31
-117523	Longdean School	2X6MV9YH	919	11	18			1	SEC		M				2011-07-31
-117524	St Albans Girls' School	2X6MTDMM	919	11	18			1	SEC		G				2011-08-31
-117525	Sir Frederic Osborn School	2X6MTGFN	919	11	18			1	SEC		M				
-117526	Kings Langley School	5T8JQHE1	919	11	18			1	SEC		M				2012-11-30
-117527	Bishop's Hatfield Girls' School	2X6MTBBS	919	11	18			1	SEC		G				2011-12-31
-117528	The Cavendish School	2X6MTSE5	919	11	18			1	SEC		M				
-117529	The Broxbourne School	4D59W3	919	11	18			5	SEC		M				2010-12-31
-117530	The Nobel School	9C3QPF9	919	11	18			1	SEC		M				
-117531	Turnford School	4D547M	919	11	18			1	SEC		M				2015-08-31
-117532	Westfield Community Technology College	2X6MYE5R	919	11	18			1	SEC		M				2013-08-31
-117533	Collenswood School	9C3QPAP	919	11	18			1	SEC		M				2006-08-31
-117534	Marriotts School		919	11	18			1	SEC		M				
-117535	The Sele School	2X6MXCRP	919	11	18			1	SEC		M				2012-07-31
-117536	Monk's Walk School	5T8JH9XV	919	11	18			5	SEC		M				2012-08-31
-117537	The Highfield School	2X6MXKNB	919	11	18			1	SEC		M				
-117538	Sheredes School	4D5BSY	919	11	18			1	SEC		M				2016-08-31
-117539	Meridian School	2X6MXNC2	919	13	18			1	SEC		M				2011-10-31
-117540	Freman College	2X6MXP1R	919	13	18			5	SEC		M				2011-07-31
-117541	Bridgewater Primary School	5T8JQEGB	919	4	11			1	PRI		M				
-117542	The Greneway School	2X6MXNC1	919	9	13			1	MDS		M				2011-10-31
-117543	Ralph Sadleir Middle School	9B09WFN	919	9	13			1	MDS		M				2013-09-30
-117544	Furzehill Middle School		919	9	13			1	MDS		M				2001-08-31
-117545	Roysia Middle School	2X6MXNAP	919	9	13			1	MDS		M				2011-10-31
-117546	Sir John Newsom School		919	11	18			1	SEC		M				1998-08-31
-117547	Onslow St Audrey's School	2X6MTBBK	919	11	18			1	SEC		M				2011-12-31
-117548	Sandringham School	5T8JAHHX	919	11	18			1	SEC		M				2011-03-31
-117549	Birchwood High School	9B09QS4	919	11	18			5	SEC		M				2011-10-31
-117550	The Thomas Alleyne School	9C3QN4X	919	11	18			1	SEC		M				2013-08-31
-117551	The Chauncy School	2X6MXAD9	919	11	18			5	SEC		M				2011-07-31
-117552	The Astley Cooper School	2X6MV56T	919	11	18			1	SEC		M				
-117553	Tring School	2X6MV863	919	11	18	C22	CE32	3	SEC		M				2012-06-30
-117554	Edwinstree Church of England Middle School	2X6MXNXN	919	9	13	C22	CE32	3	MDS		M				
-117555	Townsend CofE School	5T8JAHPF	919	11	18	C22	CE32	2	SEC		M				
-117556	St George's School	2X6N02Y7	919	11	18	C1		2	SEC		M				2012-06-30
-117557	John F Kennedy Catholic School	2X6MTSAV	919	11	18	C67	RC01	2	SEC		M				
-117558	Loreto College	2X6MTA14	919	11	18	C67	RC01	2	SEC		G				2012-04-30
-117559	The Thomas Coram Church of England School	5T8JQHHF	919	7	11	C22	CE32	2	PRI		M				
-117560	St Mary Roman Catholic Primary School	2X6MXNF8	919	3	11	C67	RC01	2	PRI		M				2012-06-30
-117561	Christ Church Church of England School		919	3	11	C22	CE32	2	PRI		M				2013-03-31
-117562	Parkside Community Primary School	9B1AHGK	919	3	11			5	PRI		M				
-117563	Hertingfordbury Cowper Primary School	9B09W9Z	919	4	11	C22	CE32	2	PRI		M				
-117564	St Giles' CofE Primary School	9B1AJ33	919	4	11	C22	CE32	2	PRI		M				
-117565	Cuffley School	2X6MTNZM	919	3	11			5	PRI		M				
-117566	The Wroxham School	9B1AJKR	919	4	11			5	PRI		M				2012-05-31
-117567	Little Heath Primary School	5T8JHCF1	919	3	11			5	PRI		M				
-117568	Little Reddings Primary School	9B1AJVM	919	3	11			5	PRI		M				2012-01-31
-117569	Northaw Church of England Primary School	5T8JH99K	919	3	11	C22	CE32	2	PRI		M				
-117570	Brookmans Park Primary School	2X6MTJ65	919	4	11			5	PRI		M				
-117571	St Catherine of Siena Catholic Primary School	5T8FR6JX	919	4	11	C67	RC01	2	PRI		M				2012-06-30
-117572	Rickmansworth School	9A1SV4G	919	11	18			5	SEC		M				2011-03-31
-117573	Watford Grammar School for Boys		919	11	18	C22		2	SEC		B				2010-08-31
-117574	Francis Bacon School	9AQQS5E	919	11	18			5	SEC		M				2012-08-31
-117575	Watford Grammar School for Girls	5T8FR333	919	11	18	C22		2	SEC		G				2010-08-31
-117576	Parmiter's School	2X6MYGZH	919	11	18			2	SEC		M				2011-06-30
-117577	The Bishop's Stortford High School	2X6MTK6F	919	11	18			5	SEC		B				
-117578	Ashlyns School	5T8GAB7X	919	11	18			5	SEC		M				
-117579	Dame Alice Owen's School	9B1AJKN	919	11	18			2	SEC		M				2011-03-31
-117580	Bushey Meads School	9B1AK1T	919	11	18			5	SEC		M				2012-01-31
-117581	Bushey Hall School	9B1AJXE	919	11	18			5	SEC		M				2009-08-31
-117582	Queens' School	9AE04NH	919	11	18			5	SEC		M				2011-06-30
-117583	Mount Grace School	9AE051S	919	11	18			5	SEC		M				2011-07-31
-117584	Nicholas Breakspear Catholic School	2X6MTE5Y	919	11	18	C67	RC01	2	SEC		M				2012-02-29
-117585	The John Henry Newman Catholic School	9C3QMQ7	919	11	18	C67	RC01	2	SEC		M				2012-02-29
-117586	Marlborough School	2X6MT9S6	919	11	18			5	SEC		M				2012-03-31
-117587	Goffs School	4D4ME9	919	11	18			5	SEC		M				2011-09-30
-117588	The Leventhorpe School	2X6MTJCP	919	11	18			5	SEC		M				2011-07-31
-117589	Saint Michael's Catholic High School		919	11	18	C67	RC01	2	SEC		M				2012-02-29
-117590	Saint Joan of Arc Catholic School		919	11	18	C67	RC01	2	SEC		M				2012-02-29
-117591	Chancellor's School	2X6MTHZS	919	11	18			5	SEC		M				
-117592	The Hertfordshire & Essex High School and Science College	2X6MZTDB	919	11	18			5	SEC		G				2014-03-31
-117593	St Clement Danes School	2X6MYJWD	919	11	18			2	SEC		M				2011-06-30
-117594	St Mary's Catholic School	2X6MTJQC	919	11	18	C67	RC01	2	SEC		M				
-117595	St Mary's Church of England High School (VA)	4D5Z7N	919	11	18	C22	CE32	2	SEC		M				2012-06-30
-117596	Cheshunt School	4D4TEG	919	11	18			5	SEC		M				
-117597	The John Warner School	4D5J74	919	11	18			5	SEC		M				2011-03-31
-117598	Hockerill Anglo-European College	9B09QK4	919	11	18			5	SEC		M				2011-01-31
-117599	Holmshill School	9B1AJ17	919	9	13			5	MDS		M				2001-08-31
-117600	Abbot's Hill School	2X6MS52Y	919	3	16			11			G			1941-01-01	
-117601	Edge Grove School		919	3	13			11			M			1938-01-01	
-117602	The Aldenham Foundation	9B1AK1W	919	3	19	C22		11			M			1910-01-01	
-117603	Berkhamsted School for Girls	2X6MVB5T	919	3	19			11			G				1996-12-06
-117604	Berkhamsted School		919	3	19	C4;C1		11			M			1902-01-01	
-117605	Bishop's Stortford College	2X6MZT6T	919	4	18			11			M			1907-01-01	
-117606	St Margaret's School	9B1AJXQ	919	4	18			11			G			1918-01-01	
-117607	Haileybury and Imperial Service College	9B0A2RT	919	11	18	C22		11			M			1920-01-01	
-117608	Aldwickbury School	2X6MTEZM	919	4	13			11			B			1950-01-01	
-117609	Queenswood School	2X6MTHW3	919	11	18	C49		11			G			1919-01-01	
-117610	Westbrook Hay Prep School		919	3	14			11			M			1920-01-01	
-117611	Lockers Park School	9A2N72Q	919	5	14	C22		11			B			1919-01-01	
-117612	St Christopher School		919	3	19			11			M			1929-01-01	
-117613	St Francis College		919	3	18	C1		11			G			1947-01-01	
-117614	Princess Helena College	9C3HAE9	919	11	18	C22		11			G			1919-01-01	
-117615	Radlett Preparatory School	9AD5AX0	919	4	11			11			M			1950-01-01	
-117616	Merchant Taylors' School		919	11	18			11			B			1927-01-01	
-117617	St Albans High School for Girls	2X6MTA18	919	4	18	C4		11			G			1908-01-01	
-117618	Tring Park School for the Performing Arts		919	8	18			11			M			1949-01-01	
-117619	Northfield School		919	2	19			11			G				1997-08-19
-117620	Beechwood Park School	5T8JQ7WB	919	3	13			11			M			1930-01-01	
-117621	Heath Mount School	9B09XVA	919	3	13			11			M			1921-01-01	
-117622	Sherrardswood School	5T8JHE7M	919	3	19			11			M			1950-01-01	
-117623	Egerton-Rothesay School	2X6MVBCY	919	6	19	C1		11			M			1956-01-01	
-117624	St Hilda's School		919	2	11			11			M			1957-10-18	
-117625	Westwood School		919	5	6			11			M			1957-10-21	2009-07-09
-117626	Harpenden Preparatory School	2X6MTF8X	919	5	10			11			M			1958-03-05	2005-07-15
-117627	St Hilda's School	2X6MTF1V	919	3	11			11			G			1957-10-15	
-117628	Duncombe School	9B09W8M	919	2	11			11			M			1957-11-13	
-117629	St Joseph's in the Park	9B1N3RZ	919	3	11			11			M			1957-10-15	
-117630	Kingshott School	9C3H9WD	919	3	13			11			M			1951-10-30	
-117631	Rudolf Steiner School	9AQJZR8	919	3	18			11			M			1957-10-18	
-117632	The Barn School	9B09WAV	919	2	8			11			M				1998-08-18
-117633	St Edmund's College	9B09SPZ	919	3	19	C67		11			M			1952-01-01	
-117634	Hart House School		919	2	7			11			M				1999-03-22
-117635	Charlotte House Preparatory School		919	3	11			11			G			1957-01-01	
-117636	York House School		919	3	13			11			M			1956-01-01	
-117637	Homewood Independent School	5T8JAQSS	919	5	6			11			M			1957-10-22	2006-07-07
-117638	St Columba's College	2X6MTCZY	919	4	18	C67		11			B			1957-12-06	
-117639	Francis House Preparatory School	2X6MZ9W3	919	3	11			11			M			1957-10-17	2014-12-12
-117640	Stanborough Secondary School		919	11	18	C73		11			M			1957-12-03	
-117641	Royal Masonic School for Girls		919	4	18			11			G			1935-01-01	
-117642	St Francis College		919	3	12			11			M			1947-01-01	2012-04-30
-117643	Lochinver House School	9B1AJKE	919	4	13			11			B			1952-01-01	
-117644	Stormont School	9B1AJMG	919	4	11			11			G			1944-01-01	
-117645	St Columba's Preparatory School	2X6MTCZY	919	5	10			11			B			1966-10-28	2005-02-02
-117646	Radlett Lodge School	2X6MYN7R	919	4	19			10			M			1974-09-30	
-117647	St Albans School	5T8JAGTK	919	11	19	C1;C1c		11			B			1980-09-30	
-117648	Haberdashers' Aske's Boys' School	9B1AHHC	919	5	18			11			B			1980-09-30	
-117649	Haberdashers' Aske's School for Girls	9B1AGR6	919	4	18			11			G			1980-09-30	
-117650	The King's School	9A1REM8	919	4	16	C1		11			M			1982-09-14	
-117651	Merchant Taylors' Prep School	5T8FRDD9	919	3	13	C1		11			B			1922-01-01	
-117652	Radlett Nursery and Infant School		919	5	6			11			M			1983-06-21	2005-09-01
-117653	Berkhamsted Pre-Prep School	5T8JQ7FV	919	3	7			11			M			1985-04-29	
-117654	Bhaktivedanta Manor School		919	4	11	D1		11			M			1985-05-16	
-117656	Haresfoot Senior School		919	11	17			11			M				2000-10-17
-117657	Immanuel College	9AD52PD	919	4	19	F1		11			M			1990-10-31	
-117658	Manor Lodge School	9B1AKKG	919	3	11			11			M			1992-02-04	
-117659	Warrax House School		919	11	16			10			M			1992-02-03	2006-03-31
-117660	High Elms Manor School	5T8FRBHC	919	1	11			11			M			1992-05-07	
-117661	South Lodge School		919	12	17			11			G				1999-12-22
-117662	Longwood School	9B1AJXV	919	3	11			11			M			1994-07-26	
-117663	Epping House School		919	7	12			7			M				1997-07-25
-117664	Pinewood School	2X6MZT45	919	11	16			12			M				2014-08-31
-117665	St Elizabeth's School		919	5	19			8			M				
-117666	Knightsfield School	5T8JHA3Z	919	10	18			7			M				2012-07-31
-117667	Garston Manor School	5T8FR09X	919	11	16			7			M				
-117668	Boxmoor House School	9A2N551	919	11	16			7			B				2006-03-31
-117669	The Valley School	5T8FDH0D	919	11	16			7			M				
-117670	Colnbrook School	2X6MYD37	919	4	11			7			M				
-117671	St Luke's School	2X6MTDT8	919	9	16			12			M				
-117672	The Collett School	2X6MTS3N	919	4	16			7			M				
-117673	Hailey Hall School	4D5CKW	919	11	16			12			B				2015-08-31
-117674	Batchwood School	2X6MTDG1	919	11	16			7			M				
-117675	The Hyde School		919	4	12			7			M				1995-09-01
-117676	Middleton School	2X6MXBAD	919	4	11			7			M				
-117677	Great Brookmead School		919	5	11			7			M				1995-08-31
-117678	Hilltop School	2X6N035B	919	5	11			7			B				1996-08-31
-117679	Lonsdale School		919	3	18			7			M				
-117680	Lakeside School	2X6MTHMB	919	2	19			7			M				
-117681	Breakspeare School	2X6MYKRW	919	2	19			7			M				
-117682	Woodfield School	2X6MV9YK	919	3	19			7			M				
-117683	Watling View School	2X6MT9W3	919	2	19			7			M				
-117684	Amwell View School	9B1N31S	919	2	19			7			M				
-117685	Heathlands School	2X6MTDHE	919	3	16			7			M				
-117686	Falconer School	9B1AJXG	919	11	16			7			B				
-117687	High Wick School	2X6N035B	919	6	11			7			M				1996-08-31
-117688	The Edward Jenner Hospital School	9AQQR2W	919	12	16			7			M				1999-10-18
-117689	Woolgrove School	2X6MXKK6	919	4	12			7			M				2012-03-31
-117690	Greenside School	9C3QNZ4	919	2	19			7			M				
-117691	Meadow Wood School	9AE04RC	919	3	11			7			M				
-127416	Holy Rood Catholic Primary School	9A95YCZ	919	3	11	C67	RC01	2	PRI		M			2006-09-01	
-127633	The Chrysalis School for Autism	9C3H48G	919	5	16			10			M			2005-07-14	2011-03-26
-129109	Highfield Nursery School		919					15	NUR						1988-08-31
-129110	Burleigh Junior School	4D4WFP	919	7	11			1	PRI		M				1994-12-31
-129111	Belswains Junior School	5T8JQGDJ	919	7	11			1	PRI		M				1993-12-31
-129112	Morgans Walk Junior Mixed School	9B09KZQ	919	7	11			1	PRI		M				1992-12-31
-129113	Mount Pleasant Lane Junior School	5T8JAMHS	919	7	11			1	PRI		M				1989-08-31
-129114	Leavesden Green Junior Mixed School		919	7	11			1	PRI		M				1992-08-31
-129115	Hobbs Hill Wood Junior School	2X6MVA3W	919	7	11			1	PRI		M				1995-08-31
-129116	Belswains Infants' School		919	4	7			1	PRI		M				1993-12-31
-129117	Hobbs Hill Wood Infants' School	2X6MVA3W	919	3	7			1	PRI		M				1995-08-31
-129118	Bengeo Junior School	9B09W62	919	7	11			1	PRI		M				1992-08-31
-129119	Bonneygrove Junior School	4D4MDG	919	7	11			1	PRI		M				1993-12-31
-129120	Broad Oaks Junior Mixed School		919					1	PRI						1991-08-31
-129121	Bishops Wood Infant School		919					1	PRI						1991-08-31
-129122	Bellgate Junior Mixed School	5T8JQF4Y	919	7	11			1	PRI		M				1987-12-31
-129123	Meriden Junior School		919	7	11			1	PRI		M				1992-08-31
-129124	St Stephen's Infant School		919					1	PRI						1989-08-31
-129125	Millwards Junior Mixed School	2X6MTBEZ	919	7	11			1	PRI		M				1992-08-31
-129126	The Downs Infant School	2X6MTBEZ	919	5	7			1	PRI		M				1992-08-31
-129127	Bellgate Infant School	5T8JQF4Y	919	5	7			1	PRI		M				1987-12-31
-129128	Meriden Infant School		919	5	7			1	PRI		M				1992-08-31
-129129	Bonneygrove Infants' School	4D4MDG	919	4	7			1	PRI		M				1993-12-31
-129130	Wood End Junior Mixed School	2X6MTFBZ	919	7	11			1	PRI		M				1991-08-31
-129131	Chalk Dell Infant School		919	5	7			1	PRI		M				1992-12-31
-129132	Bengeo Infant School		919	5	7			1	PRI		M				1992-08-31
-129133	Grangewood Infants' School	4D4WFP	919	4	7			1	PRI		M				1994-12-31
-129134	Cranbourne Junior School	4D5MF5	919	7	11			1	PRI		M				1990-08-31
-129135	Dundale Infant School		919					1	PRI						1988-08-31
-129136	Cranbourne Infant School	4D5MF5	919	5	7			1	PRI		M				1990-08-31
-129137	Leavesden Green Infant School		919	5	7			1	PRI		M				1992-08-31
-129138	Wood End Infant School	2X6MTFBZ	919	5	7			1	PRI		M				1991-08-31
-129139	Laurance Haines Infant School		919					1	PRI						1988-08-31
-129140	Eastbrook Junior School	2X6MV5B0	919	7	11			1	PRI		M				1991-08-31
-129141	Ley Park Junior School	4D59VX	919	7	11			1	PRI		M				1991-08-31
-129142	Eastbrook Infant and Nursery School	2X6MV5B0	919	5	7			1	PRI		M				1991-08-31
-129143	Wellfield Wood Junior School	2X6MX9R5	919	7	11			1	PRI		M				1993-03-31
-129144	Grove Road Junior School	2X6MV8D9	919	7	11			1	PRI		M				1992-12-31
-129145	Wellfield Wood Infant School	2X6MX9R5	919	5	7			1	PRI		M				1993-03-31
-129146	Ley Park Infant School	4D59VX	919	5	7			1	PRI		M				1991-08-31
-129147	Cottered VC Primary School		919	5	9			3	PRI		M				1992-12-31
-129148	Westmill First School		919					3	PRI						1989-08-31
-129149	Sir John Southworth RC Junior Mixed and Infant School		919					2	PRI						1990-08-31
-129150	Pope Pius XII RC Primary School		919					2	PRI						1990-08-31
-129151	Maragaret Dane School		919					1	SEC						1990-08-31
-129152	Hadham Hall School		919					1	SEC						1990-08-31
-129153	Hitchin School		919					1	SEC						1988-08-31
-129154	Durrants School		919	11	18			1	SEC		M				1991-08-31
-129155	Sir James Altham School		919					1	SEC						1989-08-31
-129156	Hatfield School		919					1	SEC						1990-08-31
-129157	Thomas Alleynes School		919					1	SEC						1989-08-31
-129158	Bowes Lyon High School		919					1	SEC						1988-08-31
-129159	The Marshalwick School	5T8JAHHX	919	11	18			1	SEC		M				1988-08-31
-129160	The Willian School		919	11	18			1	SEC		M				1991-08-31
-129161	Francis Bacon School		919					1	SEC						1990-08-31
-129162	Halsey School		919					1	SEC						1988-08-31
-129163	The Mountbatten School		919	11	18			1	SEC		M				1991-08-31
-129164	Wheathampstead School		919	11	18			1	SEC		M				1988-08-31
-129165	Stevenage Girls' School		919					1	SEC						1989-08-31
-129166	The Augustus Smith School		919					1	SEC						1988-08-31
-129167	Bishopslea School		919					1	SEC						1988-08-31
-129168	Cardinal Bourne School		919					2	SEC						1988-08-31
-129169	Thomas Bourne CofE Middle School		919					2	MDS						1988-08-31
-129170	Roasry Priory High School		919					11							1988-07-08
-129171	Lyndale School		919	3	17			11			M				1994-01-06
-129172	Sherrardswood Junior School		919					11						1950-01-01	2006-08-31
-129173	Rosary Priory Preparatory School		919					11							1988-07-08
-129174	Pamela Gardens School		919					11							1991-01-09
-129176	Marlin Montessori School		919					11							1991-10-20
-129177	Stanborough Secondary School		919					11						1950-01-01	2006-08-31
-129178	Broxbournebury School		919					7							1990-08-31
-129179	Chorleywood College		919	11	19			7			G				1987-07-31
-129180	Elmfield School		919	10	16			7			M				1987-07-31
-129181	Hangers Wood School		919	3	12			7			M				1994-09-01
-129182	Brandles School	2X6MXMZX	919	11	13			7			B				1990-09-30
-129183	Greenside School	9C3QNZ4	919					7							1989-03-31
-129184	Harperbury Hospital School	9AQQR2W	919					7							1993-12-31
-129185	Springfield School		919	3	19			7			M				1993-12-31
-129186	Home Field School	9C3QNZ4	919	3	18			7			M				1989-03-31
-130160	Summercroft Primary School	9B09V9Y	919	3	11			1	PRI		M			2006-01-01	2011-08-31
-130338	Norfolk Lodge School Ltd	9AD5DF0	919	5	10			11			M			1996-03-13	2009-08-31
-130344	North Area Pupil Referral Unit		919	5	16			14			M			1995-09-01	
-130347	Hertford, Ware and Bishop's Stortford Area Pupil Referral Unit	9B09VV9	919	5	16			14			M			1995-09-01	2009-08-31
-130348	The Park Education Support Centre	9B1AJCK	919	5	16			14			M			1995-09-01	
-130349	South West Area Pupil Referral Unit		919	5	16			14			M			1995-09-01	
-130355	Buntingford Area Pupil Referral Unit	2X6MXNXN	919	5	18			14			M			1996-04-01	1998-01-01
-130356	The Links Education Support Centre	5T8JAGKZ	919	5	16			14			M			1995-09-01	2013-01-31
-130359	Stevenage Education Support Centre	9C3QPE3	919	11	14			14			M			1995-09-01	
-130362	Southfield School	2X6MTBE4	919	4	11			7			M			1995-09-01	
-130363	Shepherd Montessori School		919	5	5			11			M			1996-05-02	1996-09-18
-130720	West Herts College	5T8FR0G2	919	16	99			18	16P		M				
-130721	North Hertfordshire College	2X6MXKN8	919	16	99			18	16P		M				
-130722	Hertford Regional College	9B09WV0	919	16	99			18	16P		M				
-130723	Oaklands College	9A1R8X0	919	16	99			18	16P		M				
-131060	Brandles School	2X6MXMZX	919	11	16			7			B			1993-10-25	
-131100	Dacorum Education Support Centre		919	5	16			14			M			1995-09-01	
-131188	Bovingdon Primary School	2X6MV9XY	919	3	11			1	PRI		M			1998-09-01	2011-06-30
-131319	Haywood Grove School	2X6MV5B0	919	5	11			7			M			1996-02-20	
-131456	Clore Shalom School	9B1AK53	919	3	11	F1		2	PRI		M			1999-09-01	
-131503	Larwood School	2X6N035B	919	5	11			12			M				
-131505	Featherstone Wood Primary School	9ADG70Y	919	3	11			1	PRI		M			1998-09-01	
-131651	Hertsmere Jewish Primary School		919	1	5			11			M				1999-09-22
-131955	Hertsmere Jewish Primary School	9B1AHEF	919	3	11	F1		2	PRI		M			1999-09-01	
-131971	Hertswood School	9AE03ZP	919	11	18			1	SEC		M			2000-09-01	2012-08-31
-132015	St Elizabeth's College (The Congregation of the Daughters of the Cross of the Liege)		919	19	25	C67		32	16P		M			2006-06-20	
-132091	Lodge Farm Primary School	9C3QPF8	919	3	11			1	PRI		M			2000-09-01	
-132105	Birchwood Avenue Primary School	9AE9CV7	919	5	11			1	PRI		M			2000-04-13	
-132118	Sunny Bank Primary School		919	3	11			5	PRI		M			1999-09-01	2008-08-31
-133065	Grove Road Infant School	2X6MV8D9	919	5	7			1	PRI		M				2001-03-29
-133134	South Lodge School		919	11	17			11			G				1993-06-21
-133263	Roebuck Primary School and Nursery		919	3	11			1	PRI		M			2001-04-18	
-133295	Integrated Services Programme		919	1	16			11			M			2001-03-26	2001-07-26
-133323	Oughton Primary and Nursery School	5T8GM5Z3	919	3	11			1	PRI		M			2001-09-01	
-133488	Swallow Dell Primary and Nursery School	9AE9CV8	919	2	11			1	PRI		M			2002-01-01	
-133738	Redemption Academy		919	3	18	C1		11			M			2002-07-26	2015-07-16
-133773	St Catherine's Hoddesdon CofE Primary School	4D5VED	919	4	11		CE32	3	PRI		M			2003-01-01	
-133783	University of Hertfordshire	2X6MTBJ3	919					29			M				
-133917	Littlebury Resource Centre	4D5QVY	919	11	16			27			M			2000-09-01	2004-05-17
-133975	Muriel Green Nursery School	5T8JARDV	919	3	5			15	NUR		M			2001-01-01	
-134087	St Albans Independent College		919	14	19			11			M			2003-01-20	
-134197	Flamstead End Primary and Nursery School	4D4PHZ	919	3	11			1	PRI		M			2003-09-01	2013-03-31
-134488	Littlebury Resource Centre	4D5QVY	919	11	16			11			M			2003-08-29	2004-09-29
-134682	Windhill School	2X6MTKCB	919	3	11			1	PRI		M			2006-01-01	2015-02-28
-134684	Berrygrove Primary and Nursery School	9A95Y4M	919	3	11			1	PRI		M			2005-09-02	2012-08-31
-134685	Alban Wood Primary School and Nursery	2X6MYGZD	919	3	11			1	PRI		M			2005-09-02	
-134716	De Havilland Primary School	2X6MTBF0	919	3	11			1	PRI		M			2004-09-01	
-134786	Village Montessori	9A2N6TH	919	4	11	C1		11			M			2004-09-01	2007-03-30
-134933	International Stanborough School		919	11	18			11			M			2005-02-10	
-134985	Yavneh College	9AE03VX	919	11	18	F1		2	SEC		M			2006-09-01	2011-06-30
-135083	Longmeadow Primary School	5T8FDGYV	919	3	11			1	PRI		M			2005-09-01	
-135084	Shephalbury Park Primary School	9C3QNZ0	919	3	11			1	PRI		M			2005-09-01	
-135221	Maple Grove Primary School	2X6MV5B0	919	3	11			1	PRI		M			2008-09-01	
-135222	Yewtree Primary School	5T8JQF4Y	919	3	11			1	PRI		M			2008-09-01	
-135223	Oak View Primary and Nursery School	2X6MTBEZ	919	3	11			1	PRI		M			2007-09-01	
-135224	Galley Hill Primary School and Nursery	2X6MTSE6	919	3	11			1	PRI		M			2008-09-01	
-135339	Broadfield Primary School	5T8JQEN7	919	3	11			1	PRI		M			2008-01-01	
-135402	Education and Youth Services (Herts)	5T8FDDY5	919	14	18			10			M			2007-09-05	2016-02-29
-135528	Killigrew Primary and Nursery School	5T8JAQST	919	3	11			1	PRI		M			2008-09-01	
-135553	Focus School - Cheshunt Primary Campus	4D5QVY	919	7	11	C61		11			M			2008-04-22	2014-10-22
-135560	Worldshapers Academy		919	13	16	C1		10			M			2008-04-24	2014-07-24
-135596	Stanborough Primary School	5T8FR15Q	919	3	11			11			M			1957-12-03	
-135876	Francis Combe Academy	9AQ026H	919	11	18			46	SEC		M		4996	2009-09-01	
-135890	Rivers Education Support Centre	4D5GPC	919	11	16			14			M			2009-09-01	
-135938	The Bushey Academy	9B1AJXE	919	11	18			46	SEC		M		4996	2009-09-01	
-136024	Churchfield CofE VA Primary	4D609B	919	3	11	C22	CE32	2	PRI		M			2010-09-01	
-136247	Roman Fields	9A2N551	919	11	18			14			M			2010-11-01	
-136276	Watford Grammar School for Boys		919	11	18	C22		45	SEC		B			2010-09-01	
-136289	Watford Grammar School for Girls	5T8FR333	919	11	18	C22		45	SEC		G			2010-09-01	
-136396	The Broxbourne School	4D59W3	919	11	18			45	SEC		M			2011-01-01	
-136482	Hockerill Anglo-European College	9B09QK4	919	11	18			45	SEC		M			2011-02-01	
-136554	Dame Alice Owen's School	9B1AJKN	919	11	18			45	SEC		M			2011-04-01	
-136606	Rickmansworth School	9A1SV4G	919	11	18			45	SEC		M			2011-04-01	
-136607	The John Warner School	4D5J74	919	11	18			45	SEC		M			2011-04-01	
-136608	The Knights Templar School	2X6MXN06	919	11	18			45	SEC		M			2011-04-01	
-136609	Sandringham School	5T8JAHHX	919	11	18			45	SEC		M			2011-04-01	
-136857	Bovingdon Primary Academy	2X6MV9XY	919	3	11			45	PRI		M		2189	2011-07-01	
-136877	Queens' School	9AE04NH	919	11	18			45	SEC		M			2011-07-01	
-136899	Parmiter's School	2X6MYGZH	919	11	18			45	SEC		M			2011-07-01	
-136901	St Clement Danes School	2X6MYJWD	919	11	18			45	SEC		M		16254	2011-07-01	
-136922	Yavneh College	9AE03VX	919	11	18	F1		45	SEC		M			2011-07-01	
-136973	Roundwood Park School	2X6MTFB6	919	11	18			45	SEC		M			2011-08-01	
-137002	Freman College	2X6MXP1R	919	13	18			45	SEC		M			2011-08-01	
-137038	Verulam School	5T8FVP7Q	919	11	18			45	SEC		B			2011-08-01	
-137090	The Chauncy School	2X6MXAD9	919	11	18			45	SEC		M			2011-08-01	
-137110	Longdean School	2X6MV9YH	919	11	18			45	SEC		M			2011-08-01	
-137156	Leventhorpe	2X6MTJCP	919	11	18			45	SEC		M		15905	2011-08-01	
-137224	Mount Grace School	9AE051S	919	11	18			45	SEC		M			2011-08-01	
-137238	Hammond Academy	5T8JQEQG	919	3	11			45	PRI		M		2189	2011-08-01	
-137270	Sir John Lawes School	2X6MTFDH	919	11	18			45	SEC		M		4533	2011-08-01	
-137288	Hitchin Girls' School	2X6MXHBD	919	11	18			45	SEC		G			2011-08-17	
-137339	St Albans Girls' School	2X6MTDMM	919	11	18			45	SEC		G			2011-09-01	
-137351	Summercroft Primary School	9B09V9Y	919	3	11			45	PRI		M			2011-09-01	
-137532	Goffs School	4D4ME9	919	11	18			45	SEC		M			2011-10-01	
-137637	Birchwood High School	9B09QS4	919	11	18			45	SEC		M			2011-11-01	
-137656	Meridian School	2X6MXNC2	919	13	18			45	SEC		M		4410	2011-11-01	
-137657	Roysia Middle School	2X6MXNAP	919	9	13			45	MDS		M		4410	2011-11-01	
-137658	The Greneway School	2X6MXNC1	919	9	13			45	MDS		M		4410	2011-11-01	
-137757	Bishop's Hatfield Girls' School	2X6MTBBS	919	11	18			45	SEC		G			2012-01-01	
-137792	Onslow St Audrey's School	2X6MTBBK	919	11	18			45	SEC		M			2012-01-01	
-137847	Stanborough School	2X6MTHCA	919	11	18			45	SEC		M			2012-02-01	
-137861	Little Reddings Primary School	9B1AJVM	919	3	11			45	PRI		M		2510	2012-02-01	
-137872	Bushey Meads School	9B1AK1T	919	11	18			45	SEC		M		2510	2012-02-01	
-137895	The John Henry Newman Catholic School	9C3QMQ7	919	11	18	C67	RC01	45	SEC		M		2928	2012-03-01	
-137914	Saint Joan of Arc Catholic School		919	11	18	C67	RC01	45	SEC		M		2111	2012-03-01	
-137922	Saint Michael's Catholic High School		919	11	18	C67	RC01	45	SEC		M		2928	2012-03-01	
-137938	Nicholas Breakspear Catholic School	2X6MTE5Y	919	11	18	C67	RC01	45	SEC		M		2928	2012-03-01	
-137943	Applecroft School	2X6MTHMA	919	3	11			45	PRI		M			2012-03-01	
-137985	Presdales School	2X6MXAZE	919	11	18			45	SEC		G			2012-04-01	
-137997	Woolgrove School, Special Needs Academy	2X6MXKK6	919	4	12			44			M			2012-04-01	
-138042	The Marlborough Science Academy	2X6MT9S6	919	11	18			45	SEC		M			2012-04-01	
-138106	Loreto College	2X6MTA14	919	11	18	C67	RC01	45	SEC		G			2012-05-01	
-138201	Hatfield Community Free School	9CQJSQ7	919	4	11			39	PRI		M			2012-09-01	
-138205	Fleetville Junior School	5T8JAG03	919	7	11			45	PRI		M		3107	2012-06-01	
-138206	Fleetville Infant and Nursery School	2X6MTAHR	919	3	7			45	PRI		M		3107	2012-06-01	
-138215	The Wroxham School	9B1AJKR	919	4	11			45	PRI		M			2012-06-01	
-138225	The Da Vinci Studio School of Science and Engineering	2X6MX8Y4	919	14	19			41	SEC		M		4020	2012-09-03	
-138231	Alban City School	5T8GN26J	919	5	11			39	PRI		M			2012-09-01	
-138286	Beaumont School	2X6MTE5Z	919	11	18			45	SEC		M			2012-07-01	
-138288	St Catherine of Siena Catholic Primary School	5T8FR6JX	919	4	11	C67	RC01	45	PRI		M		2928	2012-07-01	
-138292	St Mary Roman Catholic Primary School	2X6MXNF8	919	3	11	C67	RC01	45	PRI		M		2928	2012-07-01	
-138316	St John Roman Catholic Primary School	9C3H55Z	919	3	11	C67	RC01	45	PRI		M		2928	2012-07-01	
-138322	Our Lady Catholic Primary School	9C3H984	919	5	11	C67	RC01	45	PRI		M		2928	2012-07-01	
-138352	Tring School	2X6MV863	919	11	18	C22	CE32	45	SEC		M			2012-07-01	
-138354	St Thomas More Roman Catholic Primary School	2X6MXKNC	919	3	11	C67	RC01	45	PRI		M		2928	2012-07-01	
-138356	St George's School	2X6N02Y7	919	11	18	C1		45	SEC		M			2012-07-01	
-138360	St Mary's Church of England High School (VA)	4D5Z7N	919	11	18	C22	CE32	45	SEC		M			2012-07-01	
-138389	Garden City Academy	2X6MXKK5	919	3	11			46	PRI		M		4320	2012-09-01	
-138484	The Sele School	2X6MXCRP	919	11	18			45	SEC		M			2012-08-01	
-138485	Knightsfield School	5T8JHA3Z	919	10	18			44			M			2012-08-01	
-138507	The Grove Academy	9A95Y4M	919	3	11			46	PRI		M		2189	2012-09-01	
-138539	Northgate Primary School	2X6MTK10	919	3	11			45	PRI		M			2012-08-01	
-138561	Harpenden Free School		919	4	11			39	PRI		M		4533	2012-09-01	
-138582	Samuel Ryder Academy	9AQQS5E	919	4	19			46	ALL		M		4533	2012-09-01	
-138632	Monk's Walk School	5T8JH9XV	919	11	18			45	SEC		M			2012-09-01	
-138747	Hertswood Academy	9AE03ZP	919	11	18			45	SEC		M			2012-09-01	
-139036	Kings Langley School	5T8JQHE1	919	11	18			45	SEC		M			2012-12-01	
-139154	Hitchin Boys' School	2X6MXHSD	919	11	18			45	SEC		B			2013-01-01	
-139159	Mandeville Primary School	9A1RF1A	919	3	11			45	PRI		M		4610	2013-01-01	
-139197	Links Academy	5T8JAGKZ	919	5	16			42			M			2013-02-01	
-139416	The Elstree UTC		919	14	19			40	SEC		M			2013-09-01	
-139507	Christ Church Chorleywood CofE School		919	3	11	C22	CE32	45	PRI		M			2013-04-01	
-139545	Flamstead End School	4D4PHZ	919	2	11			45	PRI		M			2013-04-01	
-139550	Chaulden Junior School	2X6MTSD8	919	7	11			46	PRI		M		4610	2013-05-01	
-139662	The Reach Free School		919	11	18			39	SEC		M			2013-09-02	
-139835	Rhodes Farm School		919	8	18			11			M			2013-06-27	
-139873	Richard Hale School	9B09VXK	919	11	18			45	SEC		B			2013-07-01	
-139902	The Da Vinci Studio School of Creative Enterprise		919	14	19			41	SEC		M		4020	2013-09-02	
-140037	The Thomas Alleyne School	9C3QN4X	919	11	18			46	SEC		M		4020	2013-09-01	
-140049	Westfield Academy	2X6MYE5R	919	11	18			45	SEC		M			2013-09-01	
-140238	Countess Anne Church of England School	5T8JHCB9	919	5	11	C22	CE32	45	PRI		M			2013-10-01	
-140249	Ralph Sadleir School	9B09WFN	919	9	13			45	MDS		M		4301	2013-10-01	
-140294	Simon Balle All-Through School	2X6MXBT7	919	4	18			45	ALL		M		4528	2013-11-01	
-140611	Wilshere-Dacre Junior Academy	9C3H8GG	919	7	11			46	PRI		M		4320	2014-03-01	
-140707	Crabtree Infants' School	2X6MTFQN	919	5	7			45	PRI		M		4951	2014-04-01	
-140708	Crabtree Junior School	2X6MTFQN	919	7	11			45	PRI		M		4951	2014-04-01	
-140786	The Hertfordshire & Essex High School and Science College	2X6MZTDB	919	11	18			45	SEC		G			2014-04-01	
-140954	Lanchester Community Free School		919	4	11			39	PRI		M		5265	2014-09-01	
-140955	Jupiter Community Free School	2X6MV4WB	919	4	11			39	PRI		M		5265	2014-09-01	
-140956	Ascot Road Community Free School		919	4	11			39	PRI		M		5265	2014-09-01	
-141004	The Watford UTC		919	14	19			40	SEC		M			2014-09-01	
-141251	Pinewood School	2X6MZT45	919	11	16			44			M			2014-09-01	
-141851	Windhill21	2X6MTKCB	919	3	11			45	PRI		M			2015-03-01	
-141898	Fair Field Junior School	9B1AHFC	919	7	11			45	PRI		M		5616	2015-04-01	
-142051	Haileybury Turnford	4D547M	919	11	18			46	SEC		M			2015-09-01	
-142221	Watford St John's Church of England Primary School		919	4	11	C22;C1		39	PRI		M			2016-09-07	
-142257	Hailey Hall School	4D5CKW	919	11	16			44			B			2015-09-01	
-142413	Garden City Montessori School		919	2	12			11			M			2015-09-22	
-142862	Yavneh Primary School		919	4	11	F7		39	PRI		M			2016-09-01	
-143131	Sheredes School		919	11	18			46	SEC		M			2016-09-01	
-143409	Roselands Primary School		919	5	11			45	PRI		M			2016-09-01	
-143410	The Cranbourne Primary School		919	4	11			45	PRI		M			2016-09-01	
+school-eng	name	address	school-authority	minimum-age	maximum-age	religious-characters	dioceses	school-type	school-phase	school-admissions-policy	school-gender	school-tags	school-trust	school-umbrella-trust	start-date	end-date
+102256	Purcell School	9B1AK1J	919	8	19			11			M				1962-10-11	
+117065	Weston Way Nursery School	2X6MXMZY	919	3	5			15	NUR		M					
+117066	Arlesdene Nursery School and Pre-School	4D4TEB	919	2	5			15	NUR		M					
+117067	Greenfield Nursery School	4D4SBT	919	2	4			15	NUR		M					
+117068	Batford Nursery School	2X6MTFQ8	919	2	5			15	NUR		M					
+117069	Birchwood Nursery School	2X6MTB00	919	2	5			15	NUR		M					
+117070	Heath Lane Nursery School	9AQJZND	919	3	5			15	NUR		M					
+117071	York Road Nursery School	2X6MXJA5	919	3	5			15	NUR		M					
+117072	Rye Park Nursery School	4D5GWB	919	2	5			15	NUR		M					
+117073	Nevells Road Nursery School		919	3	5			15	NUR		M					2001-12-31
+117074	Muriel Green Nursery School		919	3	5			15	NUR		M					2001-01-01
+117075	London Colney Nursery School	2X6MTBMW	919	3	5			15	NUR		M					2015-03-31
+117076	Kingswood Nursery School	2X6MYGEW	919	2	5			15	NUR		M					
+117077	Oxhey Early Years Centre	2X6MYCMV	919	3	5			15	NUR		M					
+117078	Tenterfield Nursery School	2X6MTG52	919	3	5			15	NUR		M					
+117079	Ludwick Nursery School	2X6MTH11	919	2	5			15	NUR		M					
+117080	Peartree Way Nursery School	9C3QP0K	919	2	5			15	NUR		M					
+117081	Wall Hall Nursery School		919	3	5			15	NUR		M					2003-12-31
+117082	Lea Valley Education Support Centre		919	5	16			14			M				1995-09-01	2009-08-31
+117083	Abbots Langley School	5T8FR7NZ	919	3	11			1	PRI		M					
+117084	Ashwell Primary School	9C3H2ZH	919	3	11			1	PRI		M					
+117085	Northgate Primary School	2X6MTK10	919	3	11			1	PRI		M					2012-07-31
+117086	Bovingdon Junior School	2X6MV9XY	919	7	11			1	PRI		M					1998-09-01
+117087	Jenyns First School and Nursery	9B09NDE	919	3	9			1	PRI		M					
+117088	Bushey Heath Primary School	9B1AJWD	919	3	11			1	PRI		M					
+117089	Highwood Primary School	9B1AK0C	919	3	11			1	PRI		M					
+117090	Merry Hill Infant School and Nursery	9B1AJY1	919	3	7			1	PRI		M					
+117091	Holdbrook Primary School	4D50QJ	919	3	11			1	PRI		M					
+117092	Four Swannes Primary School	4D50QH	919	3	11			1	PRI		M					
+117093	Chorleywood Primary School	5T8FR9MQ	919	3	11			1	PRI		M					
+117094	Beechfield School	9A2MXPG	919	3	11			1	PRI		M					
+117095	New Briars Primary and Nursery School		919	3	11			1	PRI		M					2007-08-31
+117096	Shepherd Primary	5T8FR93G	919	3	11			1	PRI		M					
+117097	Hobletts Manor Junior School	9A2N6M9	919	7	11			1	PRI		M					
+117098	The Russell School	5T8FR999	919	3	11			1	PRI		M					
+117099	Cowley Hill School	9B1AJ1X	919	3	11			1	PRI		M					
+117100	Flamstead Village School	2X6MTE37	919	3	11			1	PRI		M					
+117101	Gaddesden Row JMI School	9A2N6TH	919	4	11			1	PRI		M					
+117102	Sauncey Wood Primary School	5T8GM330	919	4	11			1	PRI		M					
+117103	Manland Primary School	2X6MTFDJ	919	4	11			1	PRI		M					
+117104	Gascoyne Cecil Junior School	9AE9CV7	919	7	11			1	PRI		M					1999-09-01
+117105	Green Lanes Primary School	2X6MTBHN	919	5	11			1	PRI		M					
+117106	George Street Primary School	5T8JQF7A	919	3	11			1	PRI		M					
+117107	Boxmoor Primary School	5T8JQEZ2	919	4	11			1	PRI		M					
+117108	Two Waters Primary School	2X6MV9Y3	919	3	11			1	PRI		M					
+117109	Tudor Primary School	2X6MVAE8	919	3	11			1	PRI		M					
+117110	South Hill Primary School	9AQJZND	919	5	11			1	PRI		M					
+117111	Abel Smith School	9B09VV9	919	2	11			1	PRI		M					
+117112	Hexton Junior Mixed and Infant School	9C3H2AA	919	4	11			1	PRI		M					
+117113	Highbury Infant School and Nursery	2X6MXHN8	919	3	7			1	PRI		M					
+117114	Strathmore Infant and Nursery School	5T8GM5Z2	919	3	7			1	PRI		M					
+117115	Highover Junior Mixed and Infant School	2X6MXGR1	919	3	11			1	PRI		M					
+117116	Wilshere-Dacre Junior School	9C3H8GG	919	7	11			1	PRI		M					2014-02-28
+117117	Hunsdon Junior Mixed and Infant School		919	4	11			1	PRI		M					
+117118	Kimpton Primary School	2X6MXHA3	919	3	11			1	PRI		M					
+117119	Breachwood Green Junior Mixed and Infant School	9C3H4CS	919	4	11			1	PRI		M					
+117120	Knebworth Primary and Nursery School	9C3H3W0	919	3	11			1	PRI		M					
+117121	Wilbury Junior School	2X6MXM4C	919	7	11			1	PRI		M					
+117122	Grange Junior School	2X6MXMAX	919	7	11			1	PRI		M					
+117123	Hillshott Infant School and Nursery	2X6MXKC1	919	3	7			1	PRI		M					
+117124	Westbury Primary and Nursery School	9APZHC2	919	3	11			1	PRI		M					2009-08-31
+117125	Hertford Heath Primary and Nursery School	9B09MHA	919	3	11			1	PRI		M					
+117126	Little Hadham Primary School	9B09XQM	919	4	11			1	PRI		M					
+117127	Markyate Village School and Nursery	5T8JQERT	919	4	11			1	PRI		M					
+117128	Pirton School	5T8GM5Z6	919	4	11			1	PRI		M					
+117129	Reed First School	2X6MXNM0	919	3	9			1	PRI		M					
+117130	Yorke Mead Primary School	5T8FRBSD	919	3	11			1	PRI		M					
+117131	Harvey Road Primary School	5T8FR9S8	919	3	11			1	PRI		M					
+117132	Little Green Junior School	5T8FR9SA	919	7	11			1	PRI		M					
+117133	Malvern Way Infant and Nursery School	5T8FR9SP	919	3	7			1	PRI		M					
+117134	Tannery Drift School	2X6MXNAM	919	3	9			1	PRI		M					
+117135	Bernards Heath Infant and Nursery School	2X6MTANG	919	3	7			1	PRI		M					
+117136	Camp Primary and Nursery School	5T8JAKCQ	919	3	11			1	PRI		M					
+117137	Fleetville Junior School	5T8JAG03	919	7	11			1	PRI		M				1997-02-26	2012-05-31
+117138	Fleetville Infant and Nursery School	2X6MTAHR	919	3	7			1	PRI		M				1996-06-05	2012-05-31
+117139	Garden Fields Junior Mixed and Infant School	5T8JAKZZ	919	5	11			1	PRI		M					
+117140	St Peter's School	2X6MT9N0	919	3	11			1	PRI		M					
+117141	Aboyne Lodge Junior Mixed and Infant School	2X6MTDHF	919	3	11			1	PRI		M					
+117142	Mandeville Primary School	9A1RF1A	919	3	11			1	PRI		M					2012-12-31
+117143	Bernards Heath Junior School	5T8JAQW9	919	7	11			1	PRI		M					
+117144	St Paul's Walden Primary School	2X6MXHA2	919	4	11			1	PRI		M					
+117145	Colney Heath Junior Mixed Infant and Nursery School	2X6MTEC1	919	4	11			1	PRI		M					
+117146	London Colney Primary & Nursery School	2X6MTBMW	919	3	11			1	PRI		M					
+117147	Sandon Junior Mixed and Infant School	2X6MXNX1	919	4	11			1	PRI		M					
+117148	Sandridge School	2X6MTEVR	919	4	11			1	PRI		M					
+117149	Fawbert and Barnard Infants' School	9B09WDC	919	3	7			1	PRI		M					
+117150	Shenley Primary School	9B1AHCZ	919	3	11			1	PRI		M					
+117151	Letchmore Infants' and Nursery School	9C3QN7X	919	3	7			1	PRI		M					
+117152	Fairlands Primary School and Nursery	9C3QN1A	919	3	11			1	PRI		M					
+117153	Therfield First School	2X6MXNSQ	919	5	9			1	PRI		M					
+117154	Walkern Primary School	2X6MXFT3	919	4	11			1	PRI		M					
+117155	The Orchard Primary School	2X6MYG70	919	3	11			1	PRI		M					
+117156	Central Primary School	5T8FR0MP	919	3	11			1	PRI		M					
+117157	Bushey and Oxhey Infant School	5T8FR2HA	919	5	7			1	PRI		M					
+117158	Chater Junior School	2X6MYDFF	919	7	11			1	PRI		M					
+117159	Chater Infant School		919	3	7			1	PRI		M					
+117160	Field Junior School	2X6MYE01	919	7	11			1	PRI		M					
+117161	Watford Field School (Infant & Nursery)	5T8FR161	919	3	7			1	PRI		M					
+117162	Parkgate Junior School	2X6MYFQH	919	7	11			1	PRI		M					
+117163	Parkgate Infants' and Nursery School	2X6MYFQM	919	3	7			1	PRI		M					
+117164	Garston Infants' School		919	5	7			1	PRI		M					2005-08-31
+117165	Knutsford School	2X6MYFQJ	919	3	11			1	PRI		M					
+117166	St Meryl School	2X6MYCWQ	919	3	11			1	PRI		M					
+117167	Cassiobury Junior School	5T8FR15R	919	7	11			1	PRI		M					
+117168	Kingsway Junior School	2X6MYGF8	919	7	11			1	PRI		M					
+117169	Warren Dell Primary School	5T8FR6C3	919	2	11			1	PRI		M					
+117170	Oxhey Wood Primary School	5T8FRCN0	919	3	11			1	PRI		M					
+117171	Watton-at-Stone Primary and Nursery School	9B1RF4K	919	2	11			1	PRI		M					
+117172	Peartree Primary School	2X6MTH0Y	919	5	11			1	PRI		M					
+117173	Blackthorn Junior School	9AE9CV8	919	7	11			1	PRI		M					2001-12-31
+117174	Templewood Primary School	5T8JHBRH	919	3	11			1	PRI		M					
+117175	Holwell Primary School	2X6MTH11	919	5	11			1	PRI		M					
+117176	Widford School	9B09WXS	919	4	11			1	PRI		M					
+117177	Wymondley Junior Mixed and Infant School	2X6MXGZ4	919	4	11			1	PRI		M					
+117178	Tanners Wood Junior Mixed and Infant School	2X6MYKRX	919	3	11			1	PRI		M					
+117179	Havers Infant School		919	3	7			1	PRI		M					2005-12-31
+117180	Hurst Drive Primary School	4D4SBT	919	4	11			1	PRI		M					
+117181	Woodlands Primary School	9B1AJ1Y	919	3	11			1	PRI		M					
+117182	Summerswood Primary School	9B1AHM6	919	3	11			1	PRI		M					
+117183	Kenilworth Primary School	9B1AHNW	919	3	11			1	PRI		M					
+117184	Meryfield Primary School	9B1AJ14	919	3	11			1	PRI		M					
+117185	Salisbury Infants' School	9AE9CV7	919	5	7			1	PRI		M					1999-09-01
+117186	Icknield Infant and Nursery School	2X6MXM4M	919	3	7			1	PRI		M					
+117187	Bowmansgreen Primary School	5T8JAMAR	919	4	11			1	PRI		M					
+117188	Margaret Wix Primary School	5T8JAM3C	919	3	11			1	PRI		M					
+117189	Broom Barns Community Primary School	9ADG70X	919	4	11			1	PRI		M					
+117190	Lea Farm Junior School		919	7	11			1	PRI		M					2005-08-31
+117191	Alban Wood Junior School		919	7	11			1	PRI		M					2005-08-31
+117192	Little Furze Junior Mixed and Infant School		919	3	11			1	PRI		M					2004-12-16
+117193	Greenfields Primary School	2X6MYCZB	919	3	11			1	PRI		M					
+117194	Woodhall Primary School	5T8FR714	919	3	11			1	PRI		M					
+117195	Saffron Green Primary School	9B1AHQY	919	3	11			1	PRI		M					
+117196	Hazelgrove Primary School		919	4	11			1	PRI		M					2004-08-31
+117197	Hobletts Manor Infants' School	9A2N6M9	919	3	7			1	PRI		M					
+117198	Chaulden Junior School	2X6MTSD8	919	7	11			1	PRI		M					2013-04-30
+117199	Roebuck Junior School	9C3QNHH	919	7	11			1	PRI		M					2001-04-18
+117200	Bedwell Primary School	9C3QP13	919	4	11			1	PRI		M					
+117201	Flamstead End Junior School	4D4PHZ	919	7	11			1	PRI		M					2003-08-31
+117202	Chaulden Infants' and Nursery	2X6MTSD8	919	3	7			1	PRI		M					
+117203	Haslewood Junior School	4D5VED	919	7	11			1	PRI		M					2002-12-31
+117204	Roebuck Infant School	9C3QNHH	919	3	7			1	PRI		M					2001-04-18
+117205	Peartree Spring Junior School	5T8FDF2Q	919	7	11			1	PRI		M					2014-08-31
+117206	Peartree Spring Primary School	5T8FDF2Q	919	4	11			1	PRI		M					
+117207	Longmeadow Junior School	5T8FDGYV	919	7	11			1	PRI		M					2005-08-31
+117208	Longmeadow Infant and Nursery School	5T8FDGYV	919	3	7			1	PRI		M					2005-08-31
+117209	Bandley Hill Junior School	9ADG70Y	919	7	11			1	PRI		M					1998-03-20
+117210	Bandley Hill Infants' School	9ADG70Y	919	5	7			1	PRI		M					1998-03-20
+117211	Roundwood Primary School	5T8JAR3E	919	3	11			1	PRI		M					
+117212	Wheatfields Junior Mixed School	9AQQQ70	919	7	11			1	PRI		M					
+117213	Thumbswood Infant School	9AE9CV8	919	5	7			1	PRI		M					2001-12-31
+117214	Chambersbury Primary School	2X6MVA2W	919	3	11			1	PRI		M					
+117215	Broadfield Junior School	5T8JQEN7	919	7	11			1	PRI		M					2007-12-31
+117216	Broadfield Infants' School	2X6MV4MW	919	3	7			1	PRI		M					2007-12-31
+117217	Windermere Primary School	2X6MTAYM	919	5	11			1	PRI		M					
+117218	Anstey First School	9B1RAP4	919	2	9			1	PRI		M					
+117219	Monksmead School	9AE03VX	919	2	11			1	PRI		M					
+117220	Howe Dell Primary School	9AE9DVC	919	3	11			1	PRI		M					
+117221	Almond Hill Junior School	5T8FDH6F	919	7	11			1	PRI		M					
+117222	Oakwood Primary School	2X6MTEAJ	919	4	11			1	PRI		M					
+117223	Northfields Infants and Nursery School	2X6MXMBX	919	3	7			1	PRI		M					
+117224	Purwell Primary School	5T8GM5YV	919	3	11			1	PRI		M					
+117225	Killigrew Junior School	5T8JAQST	919	7	11			1	PRI		M					2008-08-31
+117226	Camps Hill Community Primary School	9C3QPE3	919	2	11			1	PRI		M					
+117227	Harwood Hill Junior Mixed Infant and Nursery School		919	3	11			1	PRI		M					
+117228	Fair Field Junior School	9B1AHFC	919	7	11			5	PRI		M					2015-03-31
+117229	Creswick Primary and Nursery School		919	4	11			1	PRI		M					
+117230	Thorley Hill Primary School	2X6MTKB4	919	3	11			1	PRI		M					
+117231	Micklem Primary School	2X6MTSD9	919	3	11			1	PRI		M					
+117232	Mayfield Infants' School and Nursery	4D609B	919	3	7			1	PRI		M					2010-08-31
+117233	Brookland Junior School	4D559A	919	7	11			1	PRI		M					
+117234	The Reddings Primary School	2X6MVA2V	919	3	11			1	PRI		M					
+117235	How Wood Primary and Nursery School	5T8JAQT4	919	3	11			1	PRI		M					
+117236	Redbourn Infants' and Nursery School	2X6MTDTD	919	3	7			1	PRI		M					
+117237	Lodge Farm Junior Mixed School	9C3QPF8	919	7	11			1	PRI		M					2000-04-30
+117238	Lodge Farm Infants' School		919	3	7			1	PRI		M					2000-04-30
+117239	Rossgate Primary School	2X6MTSE6	919	3	11			1	PRI		M					2008-08-31
+117240	Skyswood Primary & Nursery School	2X6MTEVX	919	3	11			1	PRI		M					
+117241	Martindale Primary and Nursery School	2X6MTSDA	919	3	11			1	PRI		M					2008-08-31
+117242	Bushey Manor Junior School	9B1AK1Q	919	7	11			1	PRI		M					
+117243	Goffs Oak Primary & Nursery School	4D4RPT	919	3	11			1	PRI		M					
+117244	Summercroft Junior School	9B09V9Y	919	7	11			1	PRI		M					2005-12-31
+117245	Eastbury Farm Primary School	5T8FRA25	919	3	11			1	PRI		M					
+117246	Burydale Junior School	9C3QNZ0	919	7	11			1	PRI		M					2005-08-31
+117247	Shephall Green Infant and Nursery School	9C3QNZ4	919	3	7			1	PRI		M					2005-08-31
+117248	Bedmond Village Primary and Nursery School	5T8FR7WQ	919	3	11			1	PRI		M					
+117249	Gade Valley Junior Mixed Infant and Nursery School	2X6MZ9HS	919	3	11			1	PRI		M					
+117250	Cunningham Hill Junior School	9AQQSA0	919	7	11			1	PRI		M					
+117251	Pin Green Primary School and Nursery		919	4	11			1	PRI		M					2005-08-31
+117252	Homerswood Primary and Nursery School	5T8JHBMF	919	3	11			1	PRI		M					
+117253	Whitehill Junior School	2X6MXHN9	919	7	11			1	PRI		M					
+117254	Westfield Primary School and Nursery	5T8JQF0C	919	3	11			1	PRI		M					
+117255	Downfield Primary School	4D50X6	919	2	11			1	PRI		M					
+117256	Pixies Hill Primary School	2X6MTSD7	919	4	11			1	PRI		M					
+117257	Rowans Primary School	2X6MTGAS	919	3	11			1	PRI		M					
+117258	The Grove Junior School	2X6MTEXS	919	7	11			1	PRI		M					
+117259	Pixmore Junior School	9APZNCK	919	7	11			1	PRI		M					
+117260	Swing Gate Infant School and Nursery	2X6MVB3M	919	3	7			1	PRI		M					
+117261	Oaklands Primary School	2X6MTFVS	919	5	11			1	PRI		M					
+117262	Flamstead End Infant and Nursery School	4D4PHZ	919	3	7			1	PRI		M					2003-08-31
+117263	Hollybush Primary School	9B09VVZ	919	3	11			1	PRI		M					
+117264	Oughtonhead Junior School	5T8GM5Z3	919	7	11			1	PRI		M					2001-09-01
+117265	Oughtonhead Infants' School	5T8GM5Z3	919	3	7			1	PRI		M					2001-09-01
+117266	Maple Cross Junior Mixed Infant and Nursery School	5T8FR8QR	919	4	11			1	PRI		M					
+117267	Killigrew Infant and Nursery School	5T8JAQST	919	3	7			1	PRI		M					2008-08-31
+117268	Wheatfields Infants' and Nursery School	9AQQQ70	919	3	7			1	PRI		M					
+117269	Moss Bury Primary School and Nursery	9C3QP1W	919	3	11			1	PRI		M					
+117270	Westfield Community Primary School	4D5ZBM	919	5	11			1	PRI		M					
+117271	Priors Wood Primary School	2X6MXAJ9	919	3	11			1	PRI		M					
+117272	Brookland Infant and Nursery School	4D559A	919	3	7			1	PRI		M					
+117273	Summercroft Infant and Nursery School	9B09V9Y	919	3	7			1	PRI		M					2005-12-31
+117274	Goldfield Infants' and Nursery School	5T8JQEW6	919	3	7			1	PRI		M					
+117275	Tower Primary School	9B09WW3	919	2	11			1	PRI		M					
+117276	Greenway Primary and Nursery School		919	3	11			1	PRI		M					
+117277	Thorn Grove Primary School	2X6MTM1G	919	3	11			1	PRI		M					
+117278	Icknield Walk First School	2X6MXNF3	919	3	9			1	PRI		M					
+117279	Cunningham Hill Infant School	9AQQSA0	919	5	7			1	PRI		M					
+117280	Reedings Junior School	9B09WC0	919	7	11			1	PRI		M					
+117281	The Grove Infant and Nursery School	2X6MTF03	919	3	7			1	PRI		M					
+117282	The Hammond Primary School	5T8JQEQG	919	5	11			1	PRI		M					2011-07-31
+117283	Kings Langley Primary School	5T8JQEXY	919	3	11			1	PRI		M					
+117284	Forres Primary School	4D5JF9	919	5	11			1	PRI		M					
+117285	Martins Wood Primary School	2X6MX9VD	919	2	11			1	PRI		M					
+117286	Dundale Primary School and Nursery		919	3	11			1	PRI		M					
+117287	Crabtree Junior School	2X6MTFQN	919	7	11			1	PRI		M					2014-03-31
+117288	Redbourn Junior School	2X6MTDTD	919	7	11			1	PRI		M					
+117289	Arnett Hills Junior Mixed and Infant School	5T8FR8CN	919	4	11			1	PRI		M					
+117290	Holywell Primary School	5T8FR0E4	919	3	11			1	PRI		M					
+117291	The Firs Junior School		919	7	11			1	PRI		M					2005-12-31
+117292	Trotts Hill Primary and Nursery School	9C3QNTR	919	4	11			1	PRI		M					
+117293	Cassiobury Infant and Nursery School	9CPSB9K	919	3	7			1	PRI		M					
+117294	Panshanger Primary School	2X6MTGAT	919	3	11			1	PRI		M					
+117295	Bovingdon Infants' School		919	5	7			1	PRI		M					1998-09-01
+117296	Bournehall Primary School		919	4	11			1	PRI		M					
+117297	Mill Mead Primary School	9B09W4W	919	3	11			1	PRI		M					
+117298	Maple Primary School	5T8JAQW1	919	4	11			1	PRI		M					
+117299	Round Diamond Primary School	9ADX0GP	919	3	11			1	PRI		M					
+117300	Hartsbourne Primary School	9B1AK05	919	4	11			1	PRI		M					
+117301	Beech Hyde Primary School and Nursery	5T8JAR6M	919	3	11			1	PRI		M					
+117302	Andrews Lane Primary School	4D5ZRZ	919	3	11			1	PRI		M					
+117303	Newberries Primary School	9B1AHFF	919	4	11			1	PRI		M					
+117304	Rickmansworth Park Junior Mixed and Infant School	5T8FR92K	919	5	11			1	PRI		M					
+117305	Mandeville Primary School	9B09WF3	919	3	11			1	PRI		M					
+117306	Giles Junior School	5T8FDH1E	919	7	11			1	PRI		M					
+117307	The Cranbourne Primary School	4D5MF5	919	4	11			1	PRI		M					2016-08-31
+117308	Bromet Primary School	2X6MYCN6	919	5	11			1	PRI		M					
+117309	Millfield First and Nursery School	2X6MXNXS	919	3	9			1	PRI		M					
+117310	Hillmead Primary School	9B09Q1V	919	3	11			1	PRI		M					
+117311	Nascot Wood Junior School	5T8FR16E	919	7	11			1	PRI		M					
+117312	Crabtree Infants' School	2X6MTFQN	919	5	7			1	PRI		M					2014-03-31
+117313	The Ryde School	2X6MTHTH	919	3	11			1	PRI		M					
+117314	William Ransom Primary School	5T8GM5Z0	919	4	11			1	PRI		M					
+117315	Prae Wood Primary School	2X6MTD7F	919	3	11			1	PRI		M					
+117316	The Giles Infant and Nursery School	5T8FDH1E	919	3	7			1	PRI		M					
+117317	Kingsway Infants' School	5T8FR163	919	5	7			1	PRI		M					
+117318	Alban Wood Infant and Nursery School	2X6MYGZD	919	3	7			1	PRI		M					2005-08-31
+117319	Kingshill Infant School	5T8HG06K	919	3	7			1	PRI		M					
+117320	Laurance Haines School	5T8FR3MT	919	3	11			1	PRI		M					
+117321	Woodside Primary School	4D4KHF	919	4	11			1	PRI		M					
+117322	Woolenwick Junior School	5T8FDH83	919	7	11			1	PRI		M					
+117323	Woolenwick Infant and Nursery School	5T8FDH83	919	3	7			1	PRI		M					
+117324	Leavesden JMI School	2X6MYGZE	919	3	11			1	PRI		M					
+117325	Springmead Primary School	5T8JHB1W	919	3	11			1	PRI		M					
+117326	Longlands Primary School and Nursery	4D56ZK	919	3	11			1	PRI		M					
+117327	The Lea Primary School and Nursery	5T8JAMXC	919	3	11			1	PRI		M					
+117328	Wheatcroft Primary School	2X6MXBM8	919	3	11			1	PRI		M					
+117329	Mary Exton Primary School	5T8GM5YW	919	5	11			1	PRI		M					
+117330	Lordship Farm Primary School	9C3H4EB	919	3	11			1	PRI		M					
+117331	Studlands Rise First School	2X6MXNSX	919	3	9			1	PRI		M					
+117332	Roman Way First School	2X6MXNAP	919	3	9			1	PRI		M					
+117333	Lime Walk Primary School	2X6MVAGM	919	3	11			1	PRI		M					
+117334	Fairfields Primary School and Nursery	4D4Q88	919	3	11			1	PRI		M					
+117335	Aycliffe Drive Primary School	2X6MV52E	919	3	11			1	PRI		M					
+117336	Holtsmere End Junior School	2X6MV5B2	919	7	11			1	PRI		M					
+117337	Samuel Lucas Junior Mixed and Infant School	9ADWWZ9	919	4	11			1	PRI		M					
+117338	Roselands Primary School	4D5CE2	919	5	11			1	PRI		M					2016-08-31
+117339	Cherry Tree Primary School	5T8FR0ZN	919	3	11			1	PRI		M					
+117340	Coates Way JMI and Nursery School	9A2MY90	919	3	11			1	PRI		M					
+117341	Grove Road Primary School	2X6MV8D9	919	3	11			1	PRI		M					
+117342	High Beeches Primary School	5T8JAR5S	919	5	11			1	PRI		M					
+117343	Barncroft Primary School	5T8JQH12	919	3	11			1	PRI		M					2008-08-31
+117344	Jupiter Drive Junior Mixed and Infant School	2X6MV4WB	919	5	11			1	PRI		M					2008-08-31
+117345	Stonehill School	2X6MXMC2	919	3	11			1	PRI		M					
+117346	Richard Whittington Primary School	2X6MTKGY	919	3	11			1	PRI		M					
+117347	Mount Pleasant Lane Junior Mixed and Infant School and Nursery	5T8JAMHS	919	3	11			1	PRI		M					
+117348	Watchlytes Junior Mixed Infant and Nursery School	2X6MTGVX	919	3	11			1	PRI		M					
+117349	Brockswood Primary School	9A2N4RC	919	3	11			1	PRI		M					
+117350	Lannock Primary School	9C3H64A	919	3	11			1	PRI		M					2009-08-31
+117351	Ryelands Primary School	4D5GPC	919	5	11			1	PRI		M					2007-08-31
+117352	Ashtree Primary School and Nursery	9C3QPDM	919	3	11			1	PRI		M					
+117353	Sheredes Primary School	4D5BFS	919	3	11			1	PRI		M					
+117354	Radburn Primary School	2X6MXKK5	919	3	11			1	PRI		M					2012-08-31
+117355	Applecroft School	2X6MTHMA	919	3	11			1	PRI		M					2012-02-29
+117356	Ley Park Primary School	4D59VX	919	3	11			1	PRI		M					2008-08-31
+117357	Five Oaks Primary and Nursery School	2X6MTBF0	919	3	11			1	PRI		M					2004-08-31
+117358	Wood End School	2X6MTFBZ	919	4	11			1	PRI		M					
+117359	Eastbrook Primary School	2X6MV5B0	919	5	11			1	PRI		M					2008-08-31
+117360	Meriden Primary School		919	3	11			1	PRI		M					2005-08-31
+117361	Bengeo Primary School		919	3	11			1	PRI		M					
+117362	Stream Woods Junior Mixed Infant and Nursery School	2X6MTBEZ	919	3	11			1	PRI		M					2007-08-31
+117363	Morgans Primary School & Nursery	9B09KZQ	919	3	11			1	PRI		M					
+117364	The Leys Primary and Nursery School	2X6MX9R5	919	3	11			1	PRI		M					
+117365	Belswains Primary School	5T8JQGDJ	919	3	11			1	PRI		M					
+117366	Bonneygrove Primary School	4D4MDG	919	3	11			1	PRI		M					
+117367	Burleigh Primary School	4D4WFP	919	4	11			1	PRI		M					
+117368	Hobbs Hill Wood Primary School	2X6MVA3W	919	3	11			1	PRI		M					
+117369	Cranborne Primary School	9AE03PB	919	3	11			1	PRI		M					
+117370	Ladbrooke Junior Mixed and Infant School	9B1AKBC	919	3	11			1	PRI		M					
+117371	Oakmere Primary School	9B1AJKB	919	3	11			1	PRI		M					
+117372	Sunny Bank Junior School		919	7	11			1	PRI		M					1999-08-31
+117373	Sunny Bank Infants' School		919	3	7			1	PRI		M					1999-08-31
+117374	Nascot Wood Infant and Nursery School	5T8FR0J2	919	3	7			1	PRI		M					
+117375	The Pines Junior Mixed and Infant School		919	4	11			1	PRI		M					2003-08-31
+117376	Hartsfield Junior Mixed and Infant School	9C3H4K7	919	4	11			1	PRI		M					
+117377	Holtsmere End Infant and Nursery School	2X6MV5B2	919	3	7			1	PRI		M					
+117378	Commonswood Primary & Nursery School	2X6MTH6E	919	4	11			1	PRI		M					
+117379	Millbrook School	4D4TB6	919	4	11			1	PRI		M					
+117380	Manor Fields Primary School	2X6MTKPQ	919	3	11			1	PRI		M					
+117381	Bellgate Primary School	5T8JQF4Y	919	4	11			1	PRI		M					2008-08-31
+117382	Aldbury Church of England Primary School	2X6MV8DA	919	4	11	C22	CE32	3	PRI		M					
+117383	St John's Church of England Infant and Nursery School	9B1AHEP	919	3	7	C22	CE32	3	PRI		M					
+117384	St Mary's Infants' School	9APZMWE	919	5	7	C22	CE32	3	PRI		M					
+117385	St Mary's Junior Mixed School	9APZMWE	919	7	11	C22	CE32	3	PRI		M					
+117386	Barley Church of England Voluntary Controlled First School	2X6MXNGE	919	5	9	C22	CE32	3	PRI		M					
+117387	Bayford Church of England Voluntary Controlled Primary School	2X6MXBTA	919	3	11	C22	CE32	3	PRI		M					
+117388	Tonwell St Mary's Church of England Primary School	2X6MXAD5	919	3	11	C22	CE32	3	PRI		M					
+117389	Benington Church of England Primary School	9B09TXM	919	4	11	C22	CE32	3	PRI		M					
+117390	Layston Church of England First School	9B09N7S	919	5	9	C22	CE32	3	PRI		M					
+117391	Ashfield Junior School	9B1AJY4	919	7	11			3	PRI		M					
+117392	Codicote Church of England Primary School	2X6MXHA4	919	3	11	C22	CE32	3	PRI		M					
+117393	Essendon CofE (VC) Primary School	2X6MTHWN	919	3	11	C22	CE32	3	PRI		M					
+117394	Furneux Pelham Church of England School	9B1RA9H	919	4	11	C22	CE32	3	PRI		M					
+117395	Graveley Primary School	2X6MXGZ5	919	4	11	C22	CE32	3	PRI		M					
+117396	Ponsbourne St Mary's Church of England Primary School	2X6MXBT5	919	4	11	C22	CE32	3	PRI		M					
+117397	Hertford St Andrew CofE Primary School	9B09VSP	919	3	11	C22	CE32	3	PRI		M					
+117398	High Wych Church of England Primary School	9B1RA9Z	919	3	11	C22	CE32	3	PRI		M					
+117399	St Paul's Voluntary Controlled Church of England Infants' School	4D5VED	919	5	7	C22	CE32	3	PRI		M					2002-12-31
+117400	Wormley Primary School	4D59VX	919	3	11	C22	CE32	3	PRI		M					
+117401	Ickleford Primary School	9C3H9EJ	919	4	11	C22	CE32	3	PRI		M					
+117402	Little Munden Church of England Voluntary Controlled Primary School	9B1N3BC	919	3	11	C22	CE32	3	PRI		M					
+117403	Preston Primary School	9C3H4EC	919	4	11	C22	CE32	3	PRI		M					
+117404	Sarratt Church of England Primary School	9A1SV6E	919	4	11	C22	CE32	3	PRI		M					
+117405	Spellbrook Primary School	9B09PAV	919	3	11	C22	CE32	3	PRI		M					
+117406	Roger De Clare First CofE School	9B09WFN	919	3	9	C22	CE32	3	PRI		M					
+117407	St Andrew's Church of England Voluntary Controlled Primary School	9B09WH6	919	3	11	C22	CE32	3	PRI		M					
+117408	Thundridge Church of England Primary School	2X6MXADA	919	3	11	C22	CE32	3	PRI		M					
+117409	St Mary's Voluntary Controlled Church of England Junior School	5T8HG06K	919	7	11	C22	CE32	3	PRI		M					
+117410	St Catherine's Church of England Primary School	9B09WT8	919	3	11	C22	CE32	3	PRI		M					
+117411	Musley Infant School	2X6MXADK	919	5	7	C22	CE32	3	PRI		M					2003-08-31
+117412	Wareside Church of England Primary School	9B09XT0	919	4	11	C22	CE32	3	PRI		M					
+117413	Weston Primary School	9C3H8X2	919	3	11	C22	CE32	3	PRI		M					
+117414	Potten End CofE Primary School	5T8JQEX2	919	3	11	C22	CE32	3	PRI		M					
+117415	Dewhurst St Mary CofE Primary School	4D5QVQ	919	5	11	C22	CE32	3	PRI		M					
+117416	Leverstock Green Church of England Primary School	9AQK0QK	919	3	11	C22	CE32	3	PRI		M					
+117417	St Paul's Church of England Primary School, Langleybury	9A1STCM	919	3	11	C22	CE32	2	PRI		M					
+117418	Nash Mills Church of England Primary School	5T8JQ82D	919	3	11	C22	CE32	2	PRI		M					
+117419	Albury Church of England Voluntary Aided Primary School	2X6MXA42	919	2	11	C22	CE32	2	PRI		M					
+117420	Ardeley St Lawrence Church of England Voluntary Aided Primary School		919	3	11	C22	CE32	2	PRI		M					
+117421	Aston St Mary's Church of England Aided Primary School	9B09TW7	919	4	11	C22	CE32	2	PRI		M					
+117422	Barkway VA Church of England First School	2X6MXNK3	919	5	9	C22	CE32	2	PRI		M					
+117423	Victoria Church of England Infant and Nursery School	5T8JQ7K1	919	3	7	C22	CE32	2	PRI		M					
+117424	St Mary's CofE Primary School, Northchurch	5T8JQGB2	919	3	11	C22	CE32	2	PRI		M					
+117425	St Joseph's Catholic Primary School	9B09V4B	919	3	11	C67	RC01	2	PRI		M					
+117426	St Michael's Church of England Primary School	2X6MTKB7	919	3	11	C22	CE32	2	PRI		M					
+117427	St Clement's Church of England Voluntary Aided Junior School	4D609B	919	7	11	C22	CE32	2	PRI		M					2010-08-31
+117428	Holy Trinity Church of England Primary School	4D5QTZ	919	4	11	C22	CE32	2	PRI		M					
+117429	St Joseph's Catholic Primary School	4D51HB	919	3	11	C67	RC01	2	PRI		M					
+117430	All Saints Church of England Voluntary Aided Primary School, Datchworth	9B09VQ6	919	5	11	C22	CE32	2	PRI		M					
+117431	St Nicholas Elstree Church of England VA Primary School	9B1AHZ8	919	3	11	C22	CE32	2	PRI		M					
+117432	St John the Baptist Voluntary Aided Church of England Primary School	9B09VQM	919	4	11	C22	CE32	2	PRI		M					
+117433	Great Gaddesden Church of England Primary School	9A2N3ZG	919	4	11	C22	CE32	2	PRI		M					
+117434	St Nicholas CofE VA Primary School	5T8JAR4F	919	4	11	C22	CE32	2	PRI		M					
+117435	St John's Voluntary Aided Church of England Primary School, Lemsford	5T8JHC7Q	919	4	11	C22	CE32	2	PRI		M					
+117436	St Joseph's Catholic Primary School		919	3	11	C67	RC01	2	PRI		M					
+117437	Broxbourne CofE Primary School	4D5AD2	919	3	11	C22	CE32	2	PRI		M					
+117438	St Augustine Roman Catholic Primary School	4D5FRY	919	3	11	C67	RC01	2	PRI		M					
+117439	Hormead Church of England (VA) First School	9B1N45D	919	3	9	C22	CE32	2	PRI		M					
+117440	St Ippolyts Church of England Aided Primary School	2X6MXGZ6	919	5	11	C22	CE32	2	PRI		M					
+117441	St Paul's Church of England Voluntary Aided Primary School, Chipperfield	2X6MYKF6	919	3	11	C22	CE32	2	PRI		M					
+117442	Norton St Nicholas CofE (VA) Primary School	2X6MXJXW	919	3	11	C22	CE32	2	PRI		M					
+117443	Little Gaddesden Church of England Voluntary Aided Primary School	2X6MVAPK	919	4	11	C22	CE32	2	PRI		M					
+117444	St Andrew's CofE Primary School and Nursery	9B09WAV	919	3	11	C22	CE32	2	PRI		M					
+117445	Offley Endowed Primary School	9C3HAY7	919	4	11	C22	CE32	2	PRI		M					
+117446	Cockernhoe Endowed CofE Primary School	9C3H7Z4	919	3	11	C22	CE32	2	PRI		M					
+117447	St Mary's Church of England Primary School, Rickmansworth	5T8FR94D	919	3	11	C22	CE32	2	PRI		M					
+117448	St Peter's Church of England Voluntary Aided Primary School	2X6MYHQ6	919	4	11	C22	CE32	2	PRI		M					
+117449	The Abbey Church of England Voluntary Aided Primary School, St Albans	5T8JAEJ1	919	4	11	C22	CE32	2	PRI		M					
+117450	St Alban and St Stephen Roman Catholic Infant and Nursery School	5T8JAQVQ	919	3	7	C67	RC01	2	PRI		M					
+117451	St Michael's Church of England Voluntary Aided Primary School, St Albans	5T8JAKVE	919	5	11	C22	CE32	2	PRI		M					
+117452	Park Street Church of England Voluntary Aided Primary School	5T8JAHE1	919	3	11	C22	CE32	2	PRI		M					
+117453	Puller Memorial, Church of England, Voluntary Aided Primary School	9B1RB29	919	3	11	C22	CE32	2	PRI		M					
+117454	St Thomas of Canterbury Roman Catholic Primary School	9B09WFA	919	3	11	C67	RC01	2	PRI		M					
+117455	Stapleford Primary School	9B09WHE	919	2	11	C22	CE32	2	PRI		M					
+117456	St Nicholas CofE (VA) Primary School and Nursery	9C3QNK2	919	3	11	C22	CE32	2	PRI		M					
+117457	Tewin Cowper Church of England Voluntary Aided Primary School	2X6MTFVR	919	4	11	C22	CE32	2	PRI		M					
+117458	Bishop Wood Church of England Junior School, Tring	2X6MV8D8	919	7	11	C22	CE32	2	PRI		M					
+117459	Long Marston VA Church of England Primary School	5T8JQGSM	919	5	11	C22	CE32	2	PRI		M					
+117460	St John's CofE Primary School	5T8JHAGW	919	3	11	C22	CE32	2	PRI		M					
+117461	St Michael's Woolmer Green CofE VA Primary School	5T8JHCKE	919	4	11	C22	CE32	2	PRI		M					
+117462	St Helen's Church of England Primary School	2X6MTEJG	919	4	11	C22	CE32	2	PRI		M					
+117463	St Bartholomew's Church of England Voluntary Aided Primary School, Wigginton	5T8JQEXV	919	4	11	C22	CE32	2	PRI		M					
+117464	Our Lady Roman Catholic Primary School	5T8JHBYW	919	4	11	C67	RC01	2	PRI		M					
+117465	St Joseph Catholic Primary School	5T8FR5R8	919	3	11	C67	RC01	2	PRI		M					
+117466	St Teresa Roman Catholic Primary School	9B1AHH8	919	3	11	C67	RC01	2	PRI		M					
+117467	St Andrew's Church of England Voluntary Aided Primary School, Hitchin	5T8GM5Z1	919	4	11	C22	CE32	2	PRI		M					
+117468	St Cuthbert Mayne Catholic Junior School	5T8JQ7VV	919	7	11	C67	RC01	2	PRI		M					
+117469	St Philip Howard Catholic Primary School	2X6MTBE4	919	4	11	C67	RC01	2	PRI		M					
+117470	St Adrian Roman Catholic Primary School	5T8JAQT5	919	3	11	C67	RC01	2	PRI		M					
+117471	Saint Albert the Great Catholic Primary School	5T8JQE5F	919	3	11	C67	RC01	2	PRI		M					
+117472	All Saints Church of England Primary School and Nursery, Bishop's Stortford	2X6MTM1E	919	3	11	C22	CE32	2	PRI		M					
+117473	Christ Church CofE (VA) Primary School and Nursery, Ware	2X6MXAE3	919	3	11	C22	CE32	2	PRI		M					
+117474	St Margaret Clitherow Roman Catholic Primary School	9C3QNHJ	919	3	11	C67	RC01	2	PRI		M					
+117475	St John Catholic Primary School	5T8FR8CM	919	4	11	C67	RC01	2	PRI		M					
+117476	Our Lady Roman Catholic Primary School	9C3H984	919	5	11	C67	RC01	2	PRI		M					2012-06-30
+117477	St Thomas More Roman Catholic Primary School	2X6MXKNC	919	3	11	C67	RC01	2	PRI		M					2012-06-30
+117478	St Dominic Catholic Primary School	5T8JAR3X	919	3	11	C67	RC01	2	PRI		M					
+117479	St Thomas More Roman Catholic Voluntary Aided Primary School	2X6MVBEF	919	3	11	C67	RC01	2	PRI		M					
+117480	St John Fisher Roman Catholic Primary School	5T8JAK3D	919	4	11	C67	RC01	2	PRI		M					
+117481	The Holy Family Catholic Primary School	5T8HFFSD	919	3	11	C67	RC01	2	PRI		M					
+117482	Countess Anne Voluntary Aided Church of England Primary School, Hatfield	5T8JHCB9	919	5	11	C22	CE32	2	PRI		M					2013-09-30
+117483	St Cross Catholic Primary School	4D5EF8	919	5	11	C67	RC01	2	PRI		M					
+117484	St Rose's Catholic Infants School	2X6MTS96	919	3	7	C67	RC01	2	PRI		M					
+117485	Divine Saviour Roman Catholic Primary School	5T8FRBGB	919	3	11	C67	RC01	2	PRI		M					
+117486	Holy Rood Catholic Junior School		919	7	11	C67	RC01	2	PRI		M					2006-08-31
+117487	St John Roman Catholic Primary School	9C3H55Z	919	3	11	C67	RC01	2	PRI		M					2012-06-30
+117488	Sacred Heart Catholic Primary School and Nursery	9B1AJXK	919	3	11	C67	RC01	2	PRI		M					
+117489	Saint Bernadette Catholic Primary School	5T8GM26F	919	4	11	C67	RC01	2	PRI		M					
+117490	Welwyn St Mary's Church of England Voluntary Aided Primary School	2X6MTG51	919	4	11	C22	CE32	2	PRI		M					
+117491	Saint Alban and St Stephen Catholic Junior School	5T8JAH43	919	7	11	C67	RC01	2	PRI		M					
+117492	St Paul's Catholic Primary School	4D4Q8A	919	3	11	C67	RC01	2	PRI		M					
+117493	Sacred Heart Catholic Primary School	9B09WMT	919	4	11	C67	RC01	2	PRI		M					
+117494	Holy Rood RC Infants' School	9A95YCZ	919	3	7	C67	RC01	2	PRI		M					2006-08-31
+117495	St Anthony's Catholic Primary School	5T8FR0DR	919	3	11	C67	RC01	2	PRI		M					
+117496	Pope Paul Catholic Primary School	9B1AJKK	919	4	11	C67	RC01	2	PRI		M					
+117497	St Mary's Church of England Primary School	2X6MTHYM	919	4	11	C22	CE32	2	PRI		M					
+117498	Saint Vincent de Paul Catholic Primary School	9C3QP13	919	4	11	C67	RC01	2	PRI		M					
+117499	The Priory School	9C3H7F5	919	11	18			5	SEC		M					
+117500	The Hemel Hempstead School	5T8JQ7X5	919	11	18			1	SEC		M					
+117501	Richard Hale School	9B09VXK	919	11	18			5	SEC		B					2013-06-30
+117502	Hitchin Boys' School	2X6MXHSD	919	11	18			1	SEC		B					2012-12-31
+117503	Hitchin Girls' School	2X6MXHBD	919	11	18			1	SEC		G					2011-08-16
+117504	Fearnhill School	9C3H9D6	919	11	18			5	SEC		M					
+117505	Verulam School	5T8FVP7Q	919	11	18			1	SEC		B					2011-07-31
+117506	Presdales School	2X6MXAZE	919	11	18			1	SEC		G					2012-03-31
+117507	Stanborough School	2X6MTHCA	919	11	18			1	SEC		M					2012-01-31
+117508	Langleybury School		919	11	18			1	SEC		M					1996-09-01
+117509	The Knights Templar School	2X6MXN06	919	11	18			1	SEC		M					2011-03-31
+117510	The Hillside School		919	13	18			1	SEC		M					2000-08-31
+117511	Sir John Lawes School	2X6MTFDH	919	11	18			5	SEC		M					2011-07-31
+117512	Adeyfield School	2X6MV4HS	919	11	18			1	SEC		M					
+117513	Norton School		919	11	18			1	SEC		M					2002-08-31
+117514	Beaumont School	2X6MTE5Z	919	11	18			1	SEC		M					2012-06-30
+117515	Barclay School	2X6N0357	919	11	18			1	SEC		M					
+117516	Hawksmoor School	9AE03ZP	919	13	18			1	SEC		M					2000-08-31
+117517	The Heathcote School	2X6MXG43	919	11	18			1	SEC		M					2012-08-31
+117518	Barnwell School	2X6MXG42	919	11	18			1	SEC		M					
+117519	Simon Balle School	2X6MXBT7	919	11	18			5	SEC		M					2013-10-31
+117520	Roundwood Park School	2X6MTFB6	919	11	18			5	SEC		M					2011-07-31
+117521	Lyndhurst Middle School		919	9	13			1	MDS		M					2001-08-31
+117522	Francis Combe School and Community College	9AQ026H	919	11	18			1	SEC		M					2009-08-31
+117523	Longdean School	2X6MV9YH	919	11	18			1	SEC		M					2011-07-31
+117524	St Albans Girls' School	2X6MTDMM	919	11	18			1	SEC		G					2011-08-31
+117525	Sir Frederic Osborn School	2X6MTGFN	919	11	18			1	SEC		M					
+117526	Kings Langley School	5T8JQHE1	919	11	18			1	SEC		M					2012-11-30
+117527	Bishop's Hatfield Girls' School	2X6MTBBS	919	11	18			1	SEC		G					2011-12-31
+117528	The Cavendish School	2X6MTSE5	919	11	18			1	SEC		M					
+117529	The Broxbourne School	4D59W3	919	11	18			5	SEC		M					2010-12-31
+117530	The Nobel School	9C3QPF9	919	11	18			1	SEC		M					
+117531	Turnford School	4D547M	919	11	18			1	SEC		M					2015-08-31
+117532	Westfield Community Technology College	2X6MYE5R	919	11	18			1	SEC		M					2013-08-31
+117533	Collenswood School	9C3QPAP	919	11	18			1	SEC		M					2006-08-31
+117534	Marriotts School		919	11	18			1	SEC		M					
+117535	The Sele School	2X6MXCRP	919	11	18			1	SEC		M					2012-07-31
+117536	Monk's Walk School	5T8JH9XV	919	11	18			5	SEC		M					2012-08-31
+117537	The Highfield School	2X6MXKNB	919	11	18			1	SEC		M					
+117538	Sheredes School	4D5BSY	919	11	18			1	SEC		M					2016-08-31
+117539	Meridian School	2X6MXNC2	919	13	18			1	SEC		M					2011-10-31
+117540	Freman College	2X6MXP1R	919	13	18			5	SEC		M					2011-07-31
+117541	Bridgewater Primary School	5T8JQEGB	919	4	11			1	PRI		M					
+117542	The Greneway School	2X6MXNC1	919	9	13			1	MDS		M					2011-10-31
+117543	Ralph Sadleir Middle School	9B09WFN	919	9	13			1	MDS		M					2013-09-30
+117544	Furzehill Middle School		919	9	13			1	MDS		M					2001-08-31
+117545	Roysia Middle School	2X6MXNAP	919	9	13			1	MDS		M					2011-10-31
+117546	Sir John Newsom School		919	11	18			1	SEC		M					1998-08-31
+117547	Onslow St Audrey's School	2X6MTBBK	919	11	18			1	SEC		M					2011-12-31
+117548	Sandringham School	5T8JAHHX	919	11	18			1	SEC		M					2011-03-31
+117549	Birchwood High School	9B09QS4	919	11	18			5	SEC		M					2011-10-31
+117550	The Thomas Alleyne School	9C3QN4X	919	11	18			1	SEC		M					2013-08-31
+117551	The Chauncy School	2X6MXAD9	919	11	18			5	SEC		M					2011-07-31
+117552	The Astley Cooper School	2X6MV56T	919	11	18			1	SEC		M					
+117553	Tring School	2X6MV863	919	11	18	C22	CE32	3	SEC		M					2012-06-30
+117554	Edwinstree Church of England Middle School	2X6MXNXN	919	9	13	C22	CE32	3	MDS		M					
+117555	Townsend CofE School	5T8JAHPF	919	11	18	C22	CE32	2	SEC		M					
+117556	St George's School	2X6N02Y7	919	11	18	C1		2	SEC		M					2012-06-30
+117557	John F Kennedy Catholic School	2X6MTSAV	919	11	18	C67	RC01	2	SEC		M					
+117558	Loreto College	2X6MTA14	919	11	18	C67	RC01	2	SEC		G					2012-04-30
+117559	The Thomas Coram Church of England School	5T8JQHHF	919	7	11	C22	CE32	2	PRI		M					
+117560	St Mary Roman Catholic Primary School	2X6MXNF8	919	3	11	C67	RC01	2	PRI		M					2012-06-30
+117561	Christ Church Church of England School		919	3	11	C22	CE32	2	PRI		M					2013-03-31
+117562	Parkside Community Primary School	9B1AHGK	919	3	11			5	PRI		M					
+117563	Hertingfordbury Cowper Primary School	9B09W9Z	919	4	11	C22	CE32	2	PRI		M					
+117564	St Giles' CofE Primary School	9B1AJ33	919	4	11	C22	CE32	2	PRI		M					
+117565	Cuffley School	2X6MTNZM	919	3	11			5	PRI		M					
+117566	The Wroxham School	9B1AJKR	919	4	11			5	PRI		M					2012-05-31
+117567	Little Heath Primary School	5T8JHCF1	919	3	11			5	PRI		M					
+117568	Little Reddings Primary School	9B1AJVM	919	3	11			5	PRI		M					2012-01-31
+117569	Northaw Church of England Primary School	5T8JH99K	919	3	11	C22	CE32	2	PRI		M					
+117570	Brookmans Park Primary School	2X6MTJ65	919	4	11			5	PRI		M					
+117571	St Catherine of Siena Catholic Primary School	5T8FR6JX	919	4	11	C67	RC01	2	PRI		M					2012-06-30
+117572	Rickmansworth School	9A1SV4G	919	11	18			5	SEC		M					2011-03-31
+117573	Watford Grammar School for Boys		919	11	18	C22		2	SEC		B					2010-08-31
+117574	Francis Bacon School	9AQQS5E	919	11	18			5	SEC		M					2012-08-31
+117575	Watford Grammar School for Girls	5T8FR333	919	11	18	C22		2	SEC		G					2010-08-31
+117576	Parmiter's School	2X6MYGZH	919	11	18			2	SEC		M					2011-06-30
+117577	The Bishop's Stortford High School	2X6MTK6F	919	11	18			5	SEC		B					
+117578	Ashlyns School	5T8GAB7X	919	11	18			5	SEC		M					
+117579	Dame Alice Owen's School	9B1AJKN	919	11	18			2	SEC		M					2011-03-31
+117580	Bushey Meads School	9B1AK1T	919	11	18			5	SEC		M					2012-01-31
+117581	Bushey Hall School	9B1AJXE	919	11	18			5	SEC		M					2009-08-31
+117582	Queens' School	9AE04NH	919	11	18			5	SEC		M					2011-06-30
+117583	Mount Grace School	9AE051S	919	11	18			5	SEC		M					2011-07-31
+117584	Nicholas Breakspear Catholic School	2X6MTE5Y	919	11	18	C67	RC01	2	SEC		M					2012-02-29
+117585	The John Henry Newman Catholic School	9C3QMQ7	919	11	18	C67	RC01	2	SEC		M					2012-02-29
+117586	Marlborough School	2X6MT9S6	919	11	18			5	SEC		M					2012-03-31
+117587	Goffs School	4D4ME9	919	11	18			5	SEC		M					2011-09-30
+117588	The Leventhorpe School	2X6MTJCP	919	11	18			5	SEC		M					2011-07-31
+117589	Saint Michael's Catholic High School		919	11	18	C67	RC01	2	SEC		M					2012-02-29
+117590	Saint Joan of Arc Catholic School		919	11	18	C67	RC01	2	SEC		M					2012-02-29
+117591	Chancellor's School	2X6MTHZS	919	11	18			5	SEC		M					
+117592	The Hertfordshire & Essex High School and Science College	2X6MZTDB	919	11	18			5	SEC		G					2014-03-31
+117593	St Clement Danes School	2X6MYJWD	919	11	18			2	SEC		M					2011-06-30
+117594	St Mary's Catholic School	2X6MTJQC	919	11	18	C67	RC01	2	SEC		M					
+117595	St Mary's Church of England High School (VA)	4D5Z7N	919	11	18	C22	CE32	2	SEC		M					2012-06-30
+117596	Cheshunt School	4D4TEG	919	11	18			5	SEC		M					
+117597	The John Warner School	4D5J74	919	11	18			5	SEC		M					2011-03-31
+117598	Hockerill Anglo-European College	9B09QK4	919	11	18			5	SEC		M					2011-01-31
+117599	Holmshill School	9B1AJ17	919	9	13			5	MDS		M					2001-08-31
+117600	Abbot's Hill School	2X6MS52Y	919	3	16			11			G				1941-01-01	
+117601	Edge Grove School		919	3	13			11			M				1938-01-01	
+117602	The Aldenham Foundation	9B1AK1W	919	3	19	C22		11			M				1910-01-01	
+117603	Berkhamsted School for Girls	2X6MVB5T	919	3	19			11			G					1996-12-06
+117604	Berkhamsted School		919	3	19	C4;C1		11			M				1902-01-01	
+117605	Bishop's Stortford College	2X6MZT6T	919	4	18			11			M				1907-01-01	
+117606	St Margaret's School	9B1AJXQ	919	4	18			11			G				1918-01-01	
+117607	Haileybury and Imperial Service College	9B0A2RT	919	11	18	C22		11			M				1920-01-01	
+117608	Aldwickbury School	2X6MTEZM	919	4	13			11			B				1950-01-01	
+117609	Queenswood School	2X6MTHW3	919	11	18	C49		11			G				1919-01-01	
+117610	Westbrook Hay Prep School		919	3	14			11			M				1920-01-01	
+117611	Lockers Park School	9A2N72Q	919	5	14	C22		11			B				1919-01-01	
+117612	St Christopher School		919	3	19			11			M				1929-01-01	
+117613	St Francis College		919	3	18	C1		11			G				1947-01-01	
+117614	Princess Helena College	9C3HAE9	919	11	18	C22		11			G				1919-01-01	
+117615	Radlett Preparatory School	9AD5AX0	919	4	11			11			M				1950-01-01	
+117616	Merchant Taylors' School		919	11	18			11			B				1927-01-01	
+117617	St Albans High School for Girls	2X6MTA18	919	4	18	C4		11			G				1908-01-01	
+117618	Tring Park School for the Performing Arts		919	8	18			11			M				1949-01-01	
+117619	Northfield School		919	2	19			11			G					1997-08-19
+117620	Beechwood Park School	5T8JQ7WB	919	3	13			11			M				1930-01-01	
+117621	Heath Mount School	9B09XVA	919	3	13			11			M				1921-01-01	
+117622	Sherrardswood School	5T8JHE7M	919	3	19			11			M				1950-01-01	
+117623	Egerton-Rothesay School	2X6MVBCY	919	6	19	C1		11			M				1956-01-01	
+117624	St Hilda's School		919	2	11			11			M				1957-10-18	
+117625	Westwood School		919	5	6			11			M				1957-10-21	2009-07-09
+117626	Harpenden Preparatory School	2X6MTF8X	919	5	10			11			M				1958-03-05	2005-07-15
+117627	St Hilda's School	2X6MTF1V	919	3	11			11			G				1957-10-15	
+117628	Duncombe School	9B09W8M	919	2	11			11			M				1957-11-13	
+117629	St Joseph's in the Park	9B1N3RZ	919	3	11			11			M				1957-10-15	
+117630	Kingshott School	9C3H9WD	919	3	13			11			M				1951-10-30	
+117631	Rudolf Steiner School	9AQJZR8	919	3	18			11			M				1957-10-18	
+117632	The Barn School	9B09WAV	919	2	8			11			M					1998-08-18
+117633	St Edmund's College	9B09SPZ	919	3	19	C67		11			M				1952-01-01	
+117634	Hart House School		919	2	7			11			M					1999-03-22
+117635	Charlotte House Preparatory School		919	3	11			11			G				1957-01-01	
+117636	York House School		919	3	13			11			M				1956-01-01	
+117637	Homewood Independent School	5T8JAQSS	919	5	6			11			M				1957-10-22	2006-07-07
+117638	St Columba's College	2X6MTCZY	919	4	18	C67		11			B				1957-12-06	
+117639	Francis House Preparatory School	2X6MZ9W3	919	3	11			11			M				1957-10-17	2014-12-12
+117640	Stanborough Secondary School		919	11	18	C73		11			M				1957-12-03	
+117641	Royal Masonic School for Girls		919	4	18			11			G				1935-01-01	
+117642	St Francis College		919	3	12			11			M				1947-01-01	2012-04-30
+117643	Lochinver House School	9B1AJKE	919	4	13			11			B				1952-01-01	
+117644	Stormont School	9B1AJMG	919	4	11			11			G				1944-01-01	
+117645	St Columba's Preparatory School	2X6MTCZY	919	5	10			11			B				1966-10-28	2005-02-02
+117646	Radlett Lodge School	2X6MYN7R	919	4	19			10			M				1974-09-30	
+117647	St Albans School	5T8JAGTK	919	11	19	C1;C1c		11			B				1980-09-30	
+117648	Haberdashers' Aske's Boys' School	9B1AHHC	919	5	18			11			B				1980-09-30	
+117649	Haberdashers' Aske's School for Girls	9B1AGR6	919	4	18			11			G				1980-09-30	
+117650	The King's School	9A1REM8	919	4	16	C1		11			M				1982-09-14	
+117651	Merchant Taylors' Prep School	5T8FRDD9	919	3	13	C1		11			B				1922-01-01	
+117652	Radlett Nursery and Infant School		919	5	6			11			M				1983-06-21	2005-09-01
+117653	Berkhamsted Pre-Prep School	5T8JQ7FV	919	3	7			11			M				1985-04-29	
+117654	Bhaktivedanta Manor School		919	4	11	D1		11			M				1985-05-16	
+117656	Haresfoot Senior School		919	11	17			11			M					2000-10-17
+117657	Immanuel College	9AD52PD	919	4	19	F1		11			M				1990-10-31	
+117658	Manor Lodge School	9B1AKKG	919	3	11			11			M				1992-02-04	
+117659	Warrax House School		919	11	16			10			M				1992-02-03	2006-03-31
+117660	High Elms Manor School	5T8FRBHC	919	1	11			11			M				1992-05-07	
+117661	South Lodge School		919	12	17			11			G					1999-12-22
+117662	Longwood School	9B1AJXV	919	3	11			11			M				1994-07-26	
+117663	Epping House School		919	7	12			7			M					1997-07-25
+117664	Pinewood School	2X6MZT45	919	11	16			12			M					2014-08-31
+117665	St Elizabeth's School		919	5	19			8			M					
+117666	Knightsfield School	5T8JHA3Z	919	10	18			7			M					2012-07-31
+117667	Garston Manor School	5T8FR09X	919	11	16			7			M					
+117668	Boxmoor House School	9A2N551	919	11	16			7			B					2006-03-31
+117669	The Valley School	5T8FDH0D	919	11	16			7			M					
+117670	Colnbrook School	2X6MYD37	919	4	11			7			M					
+117671	St Luke's School	2X6MTDT8	919	9	16			12			M					
+117672	The Collett School	2X6MTS3N	919	4	16			7			M					
+117673	Hailey Hall School	4D5CKW	919	11	16			12			B					2015-08-31
+117674	Batchwood School	2X6MTDG1	919	11	16			7			M					
+117675	The Hyde School		919	4	12			7			M					1995-09-01
+117676	Middleton School	2X6MXBAD	919	4	11			7			M					
+117677	Great Brookmead School		919	5	11			7			M					1995-08-31
+117678	Hilltop School	2X6N035B	919	5	11			7			B					1996-08-31
+117679	Lonsdale School		919	3	18			7			M					
+117680	Lakeside School	2X6MTHMB	919	2	19			7			M					
+117681	Breakspeare School	2X6MYKRW	919	2	19			7			M					
+117682	Woodfield School	2X6MV9YK	919	3	19			7			M					
+117683	Watling View School	2X6MT9W3	919	2	19			7			M					
+117684	Amwell View School	9B1N31S	919	2	19			7			M					
+117685	Heathlands School	2X6MTDHE	919	3	16			7			M					
+117686	Falconer School	9B1AJXG	919	11	16			7			B					
+117687	High Wick School	2X6N035B	919	6	11			7			M					1996-08-31
+117688	The Edward Jenner Hospital School	9AQQR2W	919	12	16			7			M					1999-10-18
+117689	Woolgrove School	2X6MXKK6	919	4	12			7			M					2012-03-31
+117690	Greenside School	9C3QNZ4	919	2	19			7			M					
+117691	Meadow Wood School	9AE04RC	919	3	11			7			M					
+127416	Holy Rood Catholic Primary School	9A95YCZ	919	3	11	C67	RC01	2	PRI		M				2006-09-01	
+127633	The Chrysalis School for Autism	9C3H48G	919	5	16			10			M				2005-07-14	2011-03-26
+129109	Highfield Nursery School		919					15	NUR							1988-08-31
+129110	Burleigh Junior School	4D4WFP	919	7	11			1	PRI		M					1994-12-31
+129111	Belswains Junior School	5T8JQGDJ	919	7	11			1	PRI		M					1993-12-31
+129112	Morgans Walk Junior Mixed School	9B09KZQ	919	7	11			1	PRI		M					1992-12-31
+129113	Mount Pleasant Lane Junior School	5T8JAMHS	919	7	11			1	PRI		M					1989-08-31
+129114	Leavesden Green Junior Mixed School		919	7	11			1	PRI		M					1992-08-31
+129115	Hobbs Hill Wood Junior School	2X6MVA3W	919	7	11			1	PRI		M					1995-08-31
+129116	Belswains Infants' School		919	4	7			1	PRI		M					1993-12-31
+129117	Hobbs Hill Wood Infants' School	2X6MVA3W	919	3	7			1	PRI		M					1995-08-31
+129118	Bengeo Junior School	9B09W62	919	7	11			1	PRI		M					1992-08-31
+129119	Bonneygrove Junior School	4D4MDG	919	7	11			1	PRI		M					1993-12-31
+129120	Broad Oaks Junior Mixed School		919					1	PRI							1991-08-31
+129121	Bishops Wood Infant School		919					1	PRI							1991-08-31
+129122	Bellgate Junior Mixed School	5T8JQF4Y	919	7	11			1	PRI		M					1987-12-31
+129123	Meriden Junior School		919	7	11			1	PRI		M					1992-08-31
+129124	St Stephen's Infant School		919					1	PRI							1989-08-31
+129125	Millwards Junior Mixed School	2X6MTBEZ	919	7	11			1	PRI		M					1992-08-31
+129126	The Downs Infant School	2X6MTBEZ	919	5	7			1	PRI		M					1992-08-31
+129127	Bellgate Infant School	5T8JQF4Y	919	5	7			1	PRI		M					1987-12-31
+129128	Meriden Infant School		919	5	7			1	PRI		M					1992-08-31
+129129	Bonneygrove Infants' School	4D4MDG	919	4	7			1	PRI		M					1993-12-31
+129130	Wood End Junior Mixed School	2X6MTFBZ	919	7	11			1	PRI		M					1991-08-31
+129131	Chalk Dell Infant School		919	5	7			1	PRI		M					1992-12-31
+129132	Bengeo Infant School		919	5	7			1	PRI		M					1992-08-31
+129133	Grangewood Infants' School	4D4WFP	919	4	7			1	PRI		M					1994-12-31
+129134	Cranbourne Junior School	4D5MF5	919	7	11			1	PRI		M					1990-08-31
+129135	Dundale Infant School		919					1	PRI							1988-08-31
+129136	Cranbourne Infant School	4D5MF5	919	5	7			1	PRI		M					1990-08-31
+129137	Leavesden Green Infant School		919	5	7			1	PRI		M					1992-08-31
+129138	Wood End Infant School	2X6MTFBZ	919	5	7			1	PRI		M					1991-08-31
+129139	Laurance Haines Infant School		919					1	PRI							1988-08-31
+129140	Eastbrook Junior School	2X6MV5B0	919	7	11			1	PRI		M					1991-08-31
+129141	Ley Park Junior School	4D59VX	919	7	11			1	PRI		M					1991-08-31
+129142	Eastbrook Infant and Nursery School	2X6MV5B0	919	5	7			1	PRI		M					1991-08-31
+129143	Wellfield Wood Junior School	2X6MX9R5	919	7	11			1	PRI		M					1993-03-31
+129144	Grove Road Junior School	2X6MV8D9	919	7	11			1	PRI		M					1992-12-31
+129145	Wellfield Wood Infant School	2X6MX9R5	919	5	7			1	PRI		M					1993-03-31
+129146	Ley Park Infant School	4D59VX	919	5	7			1	PRI		M					1991-08-31
+129147	Cottered VC Primary School		919	5	9			3	PRI		M					1992-12-31
+129148	Westmill First School		919					3	PRI							1989-08-31
+129149	Sir John Southworth RC Junior Mixed and Infant School		919					2	PRI							1990-08-31
+129150	Pope Pius XII RC Primary School		919					2	PRI							1990-08-31
+129151	Maragaret Dane School		919					1	SEC							1990-08-31
+129152	Hadham Hall School		919					1	SEC							1990-08-31
+129153	Hitchin School		919					1	SEC							1988-08-31
+129154	Durrants School		919	11	18			1	SEC		M					1991-08-31
+129155	Sir James Altham School		919					1	SEC							1989-08-31
+129156	Hatfield School		919					1	SEC							1990-08-31
+129157	Thomas Alleynes School		919					1	SEC							1989-08-31
+129158	Bowes Lyon High School		919					1	SEC							1988-08-31
+129159	The Marshalwick School	5T8JAHHX	919	11	18			1	SEC		M					1988-08-31
+129160	The Willian School		919	11	18			1	SEC		M					1991-08-31
+129161	Francis Bacon School		919					1	SEC							1990-08-31
+129162	Halsey School		919					1	SEC							1988-08-31
+129163	The Mountbatten School		919	11	18			1	SEC		M					1991-08-31
+129164	Wheathampstead School		919	11	18			1	SEC		M					1988-08-31
+129165	Stevenage Girls' School		919					1	SEC							1989-08-31
+129166	The Augustus Smith School		919					1	SEC							1988-08-31
+129167	Bishopslea School		919					1	SEC							1988-08-31
+129168	Cardinal Bourne School		919					2	SEC							1988-08-31
+129169	Thomas Bourne CofE Middle School		919					2	MDS							1988-08-31
+129170	Roasry Priory High School		919					11								1988-07-08
+129171	Lyndale School		919	3	17			11			M					1994-01-06
+129172	Sherrardswood Junior School		919					11							1950-01-01	2006-08-31
+129173	Rosary Priory Preparatory School		919					11								1988-07-08
+129174	Pamela Gardens School		919					11								1991-01-09
+129176	Marlin Montessori School		919					11								1991-10-20
+129177	Stanborough Secondary School		919					11							1950-01-01	2006-08-31
+129178	Broxbournebury School		919					7								1990-08-31
+129179	Chorleywood College		919	11	19			7			G					1987-07-31
+129180	Elmfield School		919	10	16			7			M					1987-07-31
+129181	Hangers Wood School		919	3	12			7			M					1994-09-01
+129182	Brandles School	2X6MXMZX	919	11	13			7			B					1990-09-30
+129183	Greenside School	9C3QNZ4	919					7								1989-03-31
+129184	Harperbury Hospital School	9AQQR2W	919					7								1993-12-31
+129185	Springfield School		919	3	19			7			M					1993-12-31
+129186	Home Field School	9C3QNZ4	919	3	18			7			M					1989-03-31
+130160	Summercroft Primary School	9B09V9Y	919	3	11			1	PRI		M				2006-01-01	2011-08-31
+130338	Norfolk Lodge School Ltd	9AD5DF0	919	5	10			11			M				1996-03-13	2009-08-31
+130344	North Area Pupil Referral Unit		919	5	16			14			M				1995-09-01	
+130347	Hertford, Ware and Bishop's Stortford Area Pupil Referral Unit	9B09VV9	919	5	16			14			M				1995-09-01	2009-08-31
+130348	The Park Education Support Centre	9B1AJCK	919	5	16			14			M				1995-09-01	
+130349	South West Area Pupil Referral Unit		919	5	16			14			M				1995-09-01	
+130355	Buntingford Area Pupil Referral Unit	2X6MXNXN	919	5	18			14			M				1996-04-01	1998-01-01
+130356	The Links Education Support Centre	5T8JAGKZ	919	5	16			14			M				1995-09-01	2013-01-31
+130359	Stevenage Education Support Centre	9C3QPE3	919	11	14			14			M				1995-09-01	
+130362	Southfield School	2X6MTBE4	919	4	11			7			M				1995-09-01	
+130363	Shepherd Montessori School		919	5	5			11			M				1996-05-02	1996-09-18
+130720	West Herts College	5T8FR0G2	919	16	99			18	16P		M					
+130721	North Hertfordshire College	2X6MXKN8	919	16	99			18	16P		M					
+130722	Hertford Regional College	9B09WV0	919	16	99			18	16P		M					
+130723	Oaklands College	9A1R8X0	919	16	99			18	16P		M					
+131060	Brandles School	2X6MXMZX	919	11	16			7			B				1993-10-25	
+131100	Dacorum Education Support Centre		919	5	16			14			M				1995-09-01	
+131188	Bovingdon Primary School	2X6MV9XY	919	3	11			1	PRI		M				1998-09-01	2011-06-30
+131319	Haywood Grove School	2X6MV5B0	919	5	11			7			M				1996-02-20	
+131456	Clore Shalom School	9B1AK53	919	3	11	F1		2	PRI		M				1999-09-01	
+131503	Larwood School	2X6N035B	919	5	11			12			M					
+131505	Featherstone Wood Primary School	9ADG70Y	919	3	11			1	PRI		M				1998-09-01	
+131651	Hertsmere Jewish Primary School		919	1	5			11			M					1999-09-22
+131955	Hertsmere Jewish Primary School	9B1AHEF	919	3	11	F1		2	PRI		M				1999-09-01	
+131971	Hertswood School	9AE03ZP	919	11	18			1	SEC		M				2000-09-01	2012-08-31
+132015	St Elizabeth's College (The Congregation of the Daughters of the Cross of the Liege)		919	19	25	C67		32	16P		M				2006-06-20	
+132091	Lodge Farm Primary School	9C3QPF8	919	3	11			1	PRI		M				2000-09-01	
+132105	Birchwood Avenue Primary School	9AE9CV7	919	5	11			1	PRI		M				2000-04-13	
+132118	Sunny Bank Primary School		919	3	11			5	PRI		M				1999-09-01	2008-08-31
+133065	Grove Road Infant School	2X6MV8D9	919	5	7			1	PRI		M					2001-03-29
+133134	South Lodge School		919	11	17			11			G					1993-06-21
+133263	Roebuck Primary School and Nursery		919	3	11			1	PRI		M				2001-04-18	
+133295	Integrated Services Programme		919	1	16			11			M				2001-03-26	2001-07-26
+133323	Oughton Primary and Nursery School	5T8GM5Z3	919	3	11			1	PRI		M				2001-09-01	
+133488	Swallow Dell Primary and Nursery School	9AE9CV8	919	2	11			1	PRI		M				2002-01-01	
+133738	Redemption Academy		919	3	18	C1		11			M				2002-07-26	2015-07-16
+133773	St Catherine's Hoddesdon CofE Primary School	4D5VED	919	4	11		CE32	3	PRI		M				2003-01-01	
+133783	University of Hertfordshire	2X6MTBJ3	919					29			M					
+133917	Littlebury Resource Centre	4D5QVY	919	11	16			27			M				2000-09-01	2004-05-17
+133975	Muriel Green Nursery School	5T8JARDV	919	3	5			15	NUR		M				2001-01-01	
+134087	St Albans Independent College		919	14	19			11			M				2003-01-20	
+134197	Flamstead End Primary and Nursery School	4D4PHZ	919	3	11			1	PRI		M				2003-09-01	2013-03-31
+134488	Littlebury Resource Centre	4D5QVY	919	11	16			11			M				2003-08-29	2004-09-29
+134682	Windhill School	2X6MTKCB	919	3	11			1	PRI		M				2006-01-01	2015-02-28
+134684	Berrygrove Primary and Nursery School	9A95Y4M	919	3	11			1	PRI		M				2005-09-02	2012-08-31
+134685	Alban Wood Primary School and Nursery	2X6MYGZD	919	3	11			1	PRI		M				2005-09-02	
+134716	De Havilland Primary School	2X6MTBF0	919	3	11			1	PRI		M				2004-09-01	
+134786	Village Montessori	9A2N6TH	919	4	11	C1		11			M				2004-09-01	2007-03-30
+134933	International Stanborough School		919	11	18			11			M				2005-02-10	
+134985	Yavneh College	9AE03VX	919	11	18	F1		2	SEC		M				2006-09-01	2011-06-30
+135083	Longmeadow Primary School	5T8FDGYV	919	3	11			1	PRI		M				2005-09-01	
+135084	Shephalbury Park Primary School	9C3QNZ0	919	3	11			1	PRI		M				2005-09-01	
+135221	Maple Grove Primary School	2X6MV5B0	919	3	11			1	PRI		M				2008-09-01	
+135222	Yewtree Primary School	5T8JQF4Y	919	3	11			1	PRI		M				2008-09-01	
+135223	Oak View Primary and Nursery School	2X6MTBEZ	919	3	11			1	PRI		M				2007-09-01	
+135224	Galley Hill Primary School and Nursery	2X6MTSE6	919	3	11			1	PRI		M				2008-09-01	
+135339	Broadfield Primary School	5T8JQEN7	919	3	11			1	PRI		M				2008-01-01	
+135402	Education and Youth Services (Herts)	5T8FDDY5	919	14	18			10			M				2007-09-05	2016-02-29
+135528	Killigrew Primary and Nursery School	5T8JAQST	919	3	11			1	PRI		M				2008-09-01	
+135553	Focus School - Cheshunt Primary Campus	4D5QVY	919	7	11	C61		11			M				2008-04-22	2014-10-22
+135560	Worldshapers Academy		919	13	16	C1		10			M				2008-04-24	2014-07-24
+135596	Stanborough Primary School	5T8FR15Q	919	3	11			11			M				1957-12-03	
+135876	Francis Combe Academy	9AQ026H	919	11	18			46	SEC		M		355		2009-09-01	
+135890	Rivers Education Support Centre	4D5GPC	919	11	16			14			M				2009-09-01	
+135938	The Bushey Academy	9B1AJXE	919	11	18			46	SEC		M		355		2009-09-01	
+136024	Churchfield CofE VA Primary	4D609B	919	3	11	C22	CE32	2	PRI		M				2010-09-01	
+136247	Roman Fields	9A2N551	919	11	18			14			M				2010-11-01	
+136276	Watford Grammar School for Boys		919	11	18	C22		45	SEC		B		440		2010-09-01	
+136289	Watford Grammar School for Girls	5T8FR333	919	11	18	C22		45	SEC		G		450		2010-09-01	
+136396	The Broxbourne School	4D59W3	919	11	18			45	SEC		M		539		2011-01-01	
+136482	Hockerill Anglo-European College	9B09QK4	919	11	18			45	SEC		M		587		2011-02-01	
+136554	Dame Alice Owen's School	9B1AJKN	919	11	18			45	SEC		M		644		2011-04-01	
+136606	Rickmansworth School	9A1SV4G	919	11	18			45	SEC		M		684		2011-04-01	
+136607	The John Warner School	4D5J74	919	11	18			45	SEC		M		685		2011-04-01	
+136608	The Knights Templar School	2X6MXN06	919	11	18			45	SEC		M		686		2011-04-01	
+136609	Sandringham School	5T8JAHHX	919	11	18			45	SEC		M		687		2011-04-01	
+136857	Bovingdon Primary Academy	2X6MV9XY	919	3	11			45	PRI		M		852		2011-07-01	
+136877	Queens' School	9AE04NH	919	11	18			45	SEC		M		868		2011-07-01	
+136899	Parmiter's School	2X6MYGZH	919	11	18			45	SEC		M		890		2011-07-01	
+136901	St Clement Danes School	2X6MYJWD	919	11	18			45	SEC		M		892		2011-07-01	
+136922	Yavneh College	9AE03VX	919	11	18	F1		45	SEC		M		911		2011-07-01	
+136973	Roundwood Park School	2X6MTFB6	919	11	18			45	SEC		M		939		2011-08-01	
+137002	Freman College	2X6MXP1R	919	13	18			45	SEC		M		965		2011-08-01	
+137038	Verulam School	5T8FVP7Q	919	11	18			45	SEC		B		992		2011-08-01	
+137090	The Chauncy School	2X6MXAD9	919	11	18			45	SEC		M		1030		2011-08-01	
+137110	Longdean School	2X6MV9YH	919	11	18			45	SEC		M		1043		2011-08-01	
+137156	Leventhorpe	2X6MTJCP	919	11	18			45	SEC		M		1072		2011-08-01	
+137224	Mount Grace School	9AE051S	919	11	18			45	SEC		M		1126		2011-08-01	
+137238	Hammond Academy	5T8JQEQG	919	3	11			45	PRI		M		852		2011-08-01	
+137270	Sir John Lawes School	2X6MTFDH	919	11	18			45	SEC		M		1168		2011-08-01	
+137288	Hitchin Girls' School	2X6MXHBD	919	11	18			45	SEC		G		1176		2011-08-17	
+137339	St Albans Girls' School	2X6MTDMM	919	11	18			45	SEC		G		1206		2011-09-01	
+137351	Summercroft Primary School	9B09V9Y	919	3	11			45	PRI		M		1218		2011-09-01	
+137532	Goffs School	4D4ME9	919	11	18			45	SEC		M		1340		2011-10-01	
+137637	Birchwood High School	9B09QS4	919	11	18			45	SEC		M		1400		2011-11-01	
+137656	Meridian School	2X6MXNC2	919	13	18			45	SEC		M		1411		2011-11-01	
+137657	Roysia Middle School	2X6MXNAP	919	9	13			45	MDS		M		1411		2011-11-01	
+137658	The Greneway School	2X6MXNC1	919	9	13			45	MDS		M		1411		2011-11-01	
+137757	Bishop's Hatfield Girls' School	2X6MTBBS	919	11	18			45	SEC		G		1464		2012-01-01	
+137792	Onslow St Audrey's School	2X6MTBBK	919	11	18			45	SEC		M		1488		2012-01-01	
+137847	Stanborough School	2X6MTHCA	919	11	18			45	SEC		M		1520		2012-02-01	
+137861	Little Reddings Primary School	9B1AJVM	919	3	11			45	PRI		M		1533		2012-02-01	
+137872	Bushey Meads School	9B1AK1T	919	11	18			45	SEC		M		1533		2012-02-01	
+137895	The John Henry Newman Catholic School	9C3QMQ7	919	11	18	C67	RC01	45	SEC		M		1546		2012-03-01	
+137914	Saint Joan of Arc Catholic School		919	11	18	C67	RC01	45	SEC		M		1563		2012-03-01	
+137922	Saint Michael's Catholic High School		919	11	18	C67	RC01	45	SEC		M		1546		2012-03-01	
+137938	Nicholas Breakspear Catholic School	2X6MTE5Y	919	11	18	C67	RC01	45	SEC		M		1546		2012-03-01	
+137943	Applecroft School	2X6MTHMA	919	3	11			45	PRI		M		1588		2012-03-01	
+137985	Presdales School	2X6MXAZE	919	11	18			45	SEC		G		1617		2012-04-01	
+137997	Woolgrove School, Special Needs Academy	2X6MXKK6	919	4	12			44			M		1625		2012-04-01	
+138042	The Marlborough Science Academy	2X6MT9S6	919	11	18			45	SEC		M		1656		2012-04-01	
+138106	Loreto College	2X6MTA14	919	11	18	C67	RC01	45	SEC		G		1684		2012-05-01	
+138201	Hatfield Community Free School	9CQJSQ7	919	4	11			39	PRI		M		1739		2012-09-01	
+138205	Fleetville Junior School	5T8JAG03	919	7	11			45	PRI		M		1742		2012-06-01	
+138206	Fleetville Infant and Nursery School	2X6MTAHR	919	3	7			45	PRI		M		1742		2012-06-01	
+138215	The Wroxham School	9B1AJKR	919	4	11			45	PRI		M		1750		2012-06-01	
+138225	The Da Vinci Studio School of Science and Engineering	2X6MX8Y4	919	14	19			41	SEC		M		1757		2012-09-03	
+138231	Alban City School	5T8GN26J	919	5	11			39	PRI		M		1760		2012-09-01	
+138286	Beaumont School	2X6MTE5Z	919	11	18			45	SEC		M		1783		2012-07-01	
+138288	St Catherine of Siena Catholic Primary School	5T8FR6JX	919	4	11	C67	RC01	45	PRI		M		1546		2012-07-01	
+138292	St Mary Roman Catholic Primary School	2X6MXNF8	919	3	11	C67	RC01	45	PRI		M		1546		2012-07-01	
+138316	St John Roman Catholic Primary School	9C3H55Z	919	3	11	C67	RC01	45	PRI		M		1546		2012-07-01	
+138322	Our Lady Catholic Primary School	9C3H984	919	5	11	C67	RC01	45	PRI		M		1546		2012-07-01	
+138352	Tring School	2X6MV863	919	11	18	C22	CE32	45	SEC		M		1825		2012-07-01	
+138354	St Thomas More Roman Catholic Primary School	2X6MXKNC	919	3	11	C67	RC01	45	PRI		M		1546		2012-07-01	
+138356	St George's School	2X6N02Y7	919	11	18	C1		45	SEC		M		1828		2012-07-01	
+138360	St Mary's Church of England High School (VA)	4D5Z7N	919	11	18	C22	CE32	45	SEC		M		1830		2012-07-01	
+138389	Garden City Academy	2X6MXKK5	919	3	11			46	PRI		M		1284		2012-09-01	
+138484	The Sele School	2X6MXCRP	919	11	18			45	SEC		M		1876		2012-08-01	
+138485	Knightsfield School	5T8JHA3Z	919	10	18			44			M		1877		2012-08-01	
+138507	The Grove Academy	9A95Y4M	919	3	11			46	PRI		M		852		2012-09-01	
+138539	Northgate Primary School	2X6MTK10	919	3	11			45	PRI		M		1906		2012-08-01	
+138561	Harpenden Free School		919	4	11			39	PRI		M		1168		2012-09-01	
+138582	Samuel Ryder Academy	9AQQS5E	919	4	19			46	ALL		M		1168		2012-09-01	
+138632	Monk's Walk School	5T8JH9XV	919	11	18			45	SEC		M		1947		2012-09-01	
+138747	Hertswood Academy	9AE03ZP	919	11	18			45	SEC		M		2014		2012-09-01	
+139036	Kings Langley School	5T8JQHE1	919	11	18			45	SEC		M		2129		2012-12-01	
+139154	Hitchin Boys' School	2X6MXHSD	919	11	18			45	SEC		B		2176		2013-01-01	
+139159	Mandeville Primary School	9A1RF1A	919	3	11			45	PRI		M		2179		2013-01-01	
+139197	Links Academy	5T8JAGKZ	919	5	16			42			M		2206		2013-02-01	
+139416	The Elstree UTC		919	14	19			40	SEC		M		2279		2013-09-01	
+139507	Christ Church Chorleywood CofE School		919	3	11	C22	CE32	45	PRI		M		2331		2013-04-01	
+139545	Flamstead End School	4D4PHZ	919	2	11			45	PRI		M		2353		2013-04-01	
+139550	Chaulden Junior School	2X6MTSD8	919	7	11			46	PRI		M		2179		2013-05-01	
+139662	The Reach Free School		919	11	18			39	SEC		M		2392		2013-09-02	
+139835	Rhodes Farm School		919	8	18			11			M				2013-06-27	
+139873	Richard Hale School	9B09VXK	919	11	18			45	SEC		B		2480		2013-07-01	
+139902	The Da Vinci Studio School of Creative Enterprise		919	14	19			41	SEC		M		1757		2013-09-02	
+140037	The Thomas Alleyne School	9C3QN4X	919	11	18			46	SEC		M		1757		2013-09-01	
+140049	Westfield Academy	2X6MYE5R	919	11	18			45	SEC		M		2529		2013-09-01	
+140238	Countess Anne Church of England School	5T8JHCB9	919	5	11	C22	CE32	45	PRI		M		2593		2013-10-01	
+140249	Ralph Sadleir School	9B09WFN	919	9	13			45	MDS		M		2601		2013-10-01	
+140294	Simon Balle All-Through School	2X6MXBT7	919	4	18			45	ALL		M		2626		2013-11-01	
+140611	Wilshere-Dacre Junior Academy	9C3H8GG	919	7	11			46	PRI		M		1284		2014-03-01	
+140707	Crabtree Infants' School	2X6MTFQN	919	5	7			45	PRI		M		2742		2014-04-01	
+140708	Crabtree Junior School	2X6MTFQN	919	7	11			45	PRI		M		2742		2014-04-01	
+140786	The Hertfordshire & Essex High School and Science College	2X6MZTDB	919	11	18			45	SEC		G		2765		2014-04-01	
+140954	Lanchester Community Free School		919	4	11			39	PRI		M		2821		2014-09-01	
+140955	Jupiter Community Free School	2X6MV4WB	919	4	11			39	PRI		M		2821		2014-09-01	
+140956	Ascot Road Community Free School		919	4	11			39	PRI		M		2821		2014-09-01	
+141004	The Watford UTC		919	14	19			40	SEC		M		2836		2014-09-01	
+141251	Pinewood School	2X6MZT45	919	11	16			44			M		2901		2014-09-01	
+141851	Windhill21	2X6MTKCB	919	3	11			45	PRI		M		3016		2015-03-01	
+141898	Fair Field Junior School	9B1AHFC	919	7	11			45	PRI		M		3026		2015-04-01	
+142051	Haileybury Turnford	4D547M	919	11	18			46	SEC		M		3058		2015-09-01	
+142221	Watford St John's Church of England Primary School		919	4	11	C22;C1		39	PRI		M				2016-09-07	
+142257	Hailey Hall School	4D5CKW	919	11	16			44			B		3102		2015-09-01	
+142413	Garden City Montessori School		919	2	12			11			M				2015-09-22	
+142862	Yavneh Primary School		919	4	11	F7		39	PRI		M				2016-09-01	
+143131	Sheredes School		919	11	18			46	SEC		M				2016-09-01	
+143409	Roselands Primary School		919	5	11			45	PRI		M				2016-09-01	
+143410	The Cranbourne Primary School		919	4	11			45	PRI		M				2016-09-01	

--- a/data/alpha/school-trust/school-trusts.tsv
+++ b/data/alpha/school-trust/school-trusts.tsv
@@ -1,1042 +1,3204 @@
 school-trust	name	organisation
-15710	Activate Learning Education Trust	company:08707909
-15711	Romero Catholic Academy, The	company:09702162
-15712	St Edmundsbury and Ipswich Diocesan Multi-Academy Trust	company:09499496
-15713	Yorkshire Collaborative Academy Trust	company:09668526
-15715	The Small Schools Multi Academy Trust	company:09613632
-15716	Manor Hall Academy Trust	company:09461655
-15717	Learning for Life Trust	company:09690231
-15718	The Three Saints Academy Trust	company:09626002
-15719	The Warriner Multi Academy Trust	company:09696059
-15720	West Oxford Schools Trust	company:09591931
-15726	Benfleet Schools Trust	company:07561574
-15727	Red Kite Learning Trust	company:07523507
-15728	Consilium Academies	company:09495671
-15729	Batley Multi Academy Trust	company:07732537
-15730	Heart Education Trust, The	company:08286818
-15732	Futures Trust, The	company:08678162
-15747	The Westgate School	company:09583593
-15748	TEES VALLEY EDUCATION	company:09630999
-15750	Warden House Trust	company:09692191
-15751	Excell3 Independent Schools Ltd	company:07654452
-15753	St. James And Emmanuel Academy Trust Ltd	company:08652284
-15754	GEMS Learning Trust	company:08346116
-15755	Floreat Education Academies Trust	company:09007740
-15756	Knowledge School Trust	company:09027131
-15757	The CSIA Trust	company:07551989
-15758	Great Schools Trust, The	company:07641004
-15759	Big Life Schools	company:07945230
-15760	Skinners' Kent Academy, The	company:06912857
-15761	Dulwich Hamlet Educational Trust	company:07531811
-15762	Maiden Erlegh Trust	company:07548754
-15763	The Khalsa Academies Trust Limited	company:07549443
-15764	Chesham Grammar School Academy Trust	company:07697482
-15765	William Howard Trust	company:07698631
-15766	Finham Park Multi-Academy Trust	company:07700317
-15767	Bursley Multi Academy Trust	company:07972070
-15769	New Bridge Multi Academy Trust	company:08131158
-15771	The Challenger Multi Academy Trust	company:09270040
-15772	Carillion Academies Trust	company:09323071
-15773	Compass Academy Trust	company:09323096
-15774	The Moorlands Primary Federation	company:09378112
-15775	Shavington Academy	company:09587693
-15776	Sabden Multi Academy Trust, The	company:09611796
-15777	Russett Learning Trust, The	company:09617195
-15778	Elmwey Learning Trust	company:09625982
-15779	Medway Anglican Schools Trust	company:09628754
-15780	King Edward VI Education Trust	company:09635329
-15781	Cirrus Primary Academy Trust	company:09642581
-15782	Argent Trust	company:09646939
-15784	The Derwent Trust	company:09648418
-15785	St Alban Catholic Academies Trust	company:09660515
-15786	Venn Academy Trust	company:09662303
-15787	Amadeus Primary Academies Trust	company:09662313
-15788	Our Lady of Light Catholic Academy Trust	company:09676023
-15789	Birchwood Academy Trust	company:09679683
-15791	Penlee Academy Trust	company:09683218
-15792	Lincolnshire Wolds Community Trust	company:09691946
-15793	Inspired Learning Multi Academy Trust	company:09692208
-15794	St Mary's Catholic Primary Schools Trust	company:09693822
-15795	Suffolk Academies Trust	company:09702333
-15796	TCAT Multi Academy Trust	company:09709935
-15797	PA Community Trust	company:09718257
-15799	Inspire Education Trust	company:09728614
-15856	EBN Trust	company:07665550
-15858	Baylis Court Trust	company:07662414
-15863	South Newcastle Trust	company:09679560
-15864	The Kite Academy Trust	company:09785186
-15865	The Pathway Academy Trust	company:09782388
-15866	Elston Hall Multi Academy Trust	company:09780473
-15867	Riviera Primary Academy Trust	company:09751294
-15868	Bournemouth Primary MAT	company:09754024
-15870	Sparkle Multi-Academy Trust	company:09741508
-15872	Every Child Matters Academy Trust	company:09700223
-15873	drb Ignite Multi Academy Trust	company:09284055
-15877	Furness Academies Trust	company:06895426
-15878	Leo Academy Trust	company:07543202
-15879	Cornerstone Academy Trust	company:07339625
-15880	The Hamblin Education Trust	company:07484717
-15881	Cheam Academies Network	company:07588097
-15882	Nonsuch and Wallington Education Trust	company:07627961
-15883	The Robert Carre Trust	company:07671174
-15884	The De Ferrers Trust	company:07442789
-15885	The Liverpool Joint Catholic and Church of England Academies Trust	company:07007398
-15886	The Mill Academy	company:08060721
-15888	Pride Multi Academy Trust	company:08582084
-15897	Harlow Inspirational Learning Trust	company:09791050
-15899	Brite Trust	company:09795288
-15900	Rushey Mead Educational Trust	company:09079258
-15901	St Hilda’s Catholic Academy Trust	company:09811711
-15902	WCGS Academy Trust	company:07627302
-15903	The Tenax Schools Trust	company:07542155
-15904	Unity Schools Trust	company:07692130
-15905	The Rivers Multi Academy Trust	company:07697367
-15906	All Saints Multi Academy Trust, Birmingham	company:08255653
-15935	Mercian Educational Trust	company:07698974
-15936	The Collegiate Trust	company:08058921
-15937	EPA Multi Academy Trust (Excellent Partnerships Achieve)	company:07896123
-15950	Lever Academy Trust	company:09677480
-15951	Highfields School	company:09527057
-15952	The Learning for Life Partnership	company:09675372
-15953	The Heath Academy Trust	company:09809895
-15954	Discover Multi Academy Trust	company:09680241
-15958	Haybrook College Trust	company:09606079
-15964	Crewe Multi Academy Trust	company:09379253
-15966	Sovereign Trust	company:09666511
-15967	The Inspire Multi Academy Trust (South West)	company:09916360
-15968	Thedwastre Education Trust	company:09896672
-15969	Rivermead Inclusive Trust	company:09853252
-15970	Spring Common Academy Trust	company:09896071
-15971	All Saints Trust	company:09887971
-15972	Barchelai Academy Trust	company:08326570
-16003	Cascade Multi Academy Trust	company:09913676
-16004	Cockburn Multi Academy Trust	company:09946495
-16005	Cygnus Academies Trust	company:09950137
-16008	Leaders in Learning Multi Academy Trust	company:09482529
-16011	Manor Multi Academy Trust	company:09323792
-16012	Mid-Trent Multi Academy Trust	company:09878928
-16013	Northern Saints Catholic Education Trust	company:09940352
-16015	Abney Trust	company:09912859
-16016	The Blue Kite Academy Trust	company:09889819
-16026	Cathedral Schools Trust	company:06516626
-16028	The Thomas Hardye Multi Academy Trust	company:07677838
-16029	Millfield Community Academy Trust	company:07705438
-16030	RMET	company:07654628
-16031	Bottisham Multi Academy Trust	company:07564749
-16032	Priorslee Multi-Academy Trust	company:07481145
-16033	Brooke Hill Academy Trust Limited	company:07693338
-16034	St George's Church of England Academy	company:07984221
-16035	The Trinity Catholic Multi Academy Trust	company:07890590
-16036	Mid Essex Anglican Academy Trust	company:08524638
-16038	Sheffield UTC Academy Trust, The	company:07652696
-16040	Nexus Education Schools Trust	company:08753719
-16041	Trinity Academy Newcastle	company:08449062
-16042	The Howard Academy Trust	company:09175427
-16043	King's Group Academies	company:09017776
-16045	Holy Trinity Catholic Multi Academy Company	company:10013691
-16046	Leodis Academies Trust	company:07720181
-16049	Roseland Multi Academy Trust, The	company:07557817
-16050	Feversham Education Trust	company:07697587
-16051	Balmoral Learning Trust	company:08083620
-16052	Tudor Park Education Trust	company:07798639
-16054	The Wensum Trust	company:07982312
-16055	Launceston College	company:08150106
-16063	Comenius Trust	company:10049139
-16066	Bolton Impact Trust, The	company:09971348
-16068	River Tees Multi-Academy Trust	company:09861442
-16070	Portico Academy Trust	company:09952066
-16072	Mulberry Academy Trust	company:09648420
-16073	South Bank Multi Academy Trust	company:10067116
-16074	Link Academy Trust	company:10049068
-16075	Aston Tower Multi-Academy Trust	company:10034419
-16076	Kendal Primary Multi Academy Trust	company:09996478
-16077	Chiltern Way Academy Trust	company:10004115
-16078	Talentum Learning Trust, The	company:09999238
-16079	Excellence in Education Trust	company:10035934
-16080	Urbis Academy Trust	company:10035844
-16081	Southgate School Academy Trust	company:10039553
-16084	St Thomas of Canterbury Catholic Academies Trust	company:09980467
-16085	St. Thomas of Canterbury Catholic Multi Academy Trust	company:10034058
-16086	Southfield Trust, The	company:10042321
-16090	Premier Learning Trust Limited	company:10065284
-16091	Key Educational Trust, The	company:07702211
-16092	Chancery Education Trust	company:07671255
-16093	Two Counties Trust, The	company:07972029
-16094	St John the Baptist Catholic Multi Academy Trust	company:07913261
-16095	South Orpington Learning Alliance Multi-Academy Trust	company:07943613
-16096	Odyssey Educational Trust	company:08612100
-16098	Minerva Learning Trust (Dorset) Limited, The	company:08561222
-16099	Northwood Park Educational Trust	company:09341839
-16104	REAch4 Academy Trust	company:09791051
-16108	Leading Learning Trust	company:10028278
-16110	Five Rivers Multi Academy Trust	company:10070417
-16111	Raedwald Trust	company:08702099
-16114	Inspiring Schools Partnership	company:07557634
-16115	Hartismere Family of Schools	company:07341583
-16116	West Somerset Academy Trust	company:07630164
-16119	Sharples School A Multi Academy Trust	company:09677469
-16120	Alexandra Academy Trust	company:09978459
-16122	ACE Schools Multi Academy Trust	company:10038640
-16123	Royal County of Berkshire Schools Trust, The	company:10052450
-16124	Plym Academy Trust	company:10056460
-16125	Nexus Multi Academy Trust	company:10075893
-16126	The Academy for Character and Excellence	company:10098444
-16127	Inspire Education Community Trust	company:10155032
-16139	Cavendish Learning Trust	company:07935515
-16140	Westbourne Academy Trust	company:07626526
-16141	Inspiring Futures Through Learning	company:07698904
-16146	Bronte Academy Trust	company:10201636
-16147	Harbourside Learning Partnership	company:10161526
-16148	Learners' Trust	company:10224802
-16149	Streetsbrook Academy Trust	company:10225404
-16151	The South East Stafford Academy Trust	company:10178490
-16152	Inspiration Academy Trust	company:10174100
-16153	Salisbury Plain Academies	company:10163646
-16157	Orchard Academy Trust	company:08249884
-16158	Palladian Academy Trust	company:08061092
-16159	Brine Multi Academy Trust	company:07344747
-16160	Zest Academies Trust	company:08087508
-16162	Pathfinder Multi Acdemy Trust	company:07559610
-16163	Synergy Multi Academy Trust	company:08198980
-16165	Creative Learning Partnership Trust, The	company:10226712
-16166	Bolton and Farnworth Church of England Primary Multi Academy Trust	company:10261477
-16167	BASE Academy Trust	company:10227910
-16168	Tilian Partnership, The	company:10259334
-16169	VENN Academy Learning Trust	company:10249712
-16170	Warrington Primary Academy Trust	company:10181707
-16171	Consortium Multi-Academy Trust, The	company:10255142
-16172	Whinless Down Academy Trust	company:10253931
-16178	Central Schools Trust	company:08148546
-16179	Inspire Partnership Multi Academy Trust	company:07805262
-16241	Richmond West Schools Trust	company:10081995
-16243	Tove Learning Trust	company:07525820
-16245	Manchester Communication Academy	company:06754335
-16246	Teesside Learning Trust	company:07185357
-16247	South Lincolnshire Academies Trust	company:07559187
-16249	Cambridgeshire Educational Trust	company:07665396
-16250	Wembley High Technology College	company:08137772
-16251	Empower Learning Academy Trust	company:07702119
-16252	Philip Morant School and College Academy Trust, The	company:07803969
-16253	Every Child, Every Day Academy Trust	company:08185432
-16254	Danes Educational Trust	company:07671949
-16255	Canons High School	company:07694362
-16256	Bishop Ramsey Church Of England Academies Trust	company:07724916
-16257	Sigma Trust, The	company:07926573
-16258	Greys Education Centre	company:08156641
-16259	Accord Multi Academy Trust	company:07484308
-2044	Abbey Academies Trust	company:07318714
-2046	Abbey Multi Academy Trust	company:07705552
-2053	Academies Enterprise Trust	company:06625091
-2059	Academy of Lincoln Trust, The	company:07557670
-2060	Academy of Woodlands, The	company:08444770
-2062	Academy Transformation Trust	company:07846852
-2064	Ace Learning	company:08681270
-2067	Acorn Academy Cornwall	company:08418341
-2070	Acorn Education Trust	company:07654902
-2071	Acorn Multi Academy Trust	company:09253218
-2072	Acorn Trust	company:08638158
-2075	Active Learning Trust Limited, The	company:07903002
-2076	Adelaide Academy Trust, The	company:08725920
-2079	Advance Trust	company:08414933
-2081	Adventure Learning Academy Trust	company:08614382
-2082	Aim High Academy Trust	company:08842629
-2083	Airedale Academies Trust	company:07556117
-2095	Aldersley Academies Trust	company:08310900
-2096	Aldridge North West Education Trust	company:05670663
-2100	Aletheia Anglican Academies Trust	company:07801612
-2109	All Saints' Academies Trust	company:08998917
-2111	All Saints Catholic Academy Trust, The	company:07943555
-2112	All Saints Catholic Collegiate	company:08709352
-2122	Alsager Multi Academy Trust	company:08597784
-2128	Ambitions Academies Trust	company:07977940
-2133	Amherst School (Academy) Trust	company:07517121
-2135	Ann Harris Academy Trust, The	company:08741949
-2137	Apollo Schools Trust	company:08641815
-2143	Aquinas Church of England Education Trust Limited	company:07525735
-2147	Sentamu Academy Learning Trust	company:06544825
-2157	ARK Schools	company:05112090
-2161	The Gryphon Trust	company:07546874
-2166	Arthur Terry Learning Partnership, The	company:07730920
-2168	Ascent Academies Trust, The	company:08098007
-2177	Ashley Hill Multi Academy Trust	company:08163445
-2186	Aspirations Academies Trust	company:07867577
-2189	Aspire Academies Trust	company:08187216
-2192	ASPIRE Academy Trust	company:07387540
-2194	Aspire Multi - Academy Trust	company:08840094
-2195	Aston Community Education Trust	company:07577113
-2199	Atlantic Centre of Excellence Multi Academy Trust	company:08782544
-2200	Attwood Academies	company:09148479
-2206	Aurora Academies Trust	company:08107711
-2207	Autism Schools Trust	company:08335297
-2209	Avanti Schools Trust	company:07506598
-2212	Avocet Academy Trust	company:09254238
-2213	Avonbourne International Business and Enterprise Academy Trust	company:08080096
-2231	Barnes Academy Trust	company:09083904
-2232	Barnet City Academy	company:04389132
-2233	The Shared Learning Trust	company:05958361
-2237	Barnhill Partnership Trust, The	company:07719016
-2239	Barnwell Academy Trust	company:08929065
-2248	Basildon Academies, The	company:06308595
-2250	Bath and Wells Diocesan Academies Trust, The	company:08207095
-2255	Bay Education Trust	company:09299975
-2259	Beacon Community College Academy Trust	company:07959980
-2265	Beacon Multi-Academy Trust Limited	company:07835788
-2268	Beaver Road Academy Trust	company:08698831
-2270	Beckfoot Trust	company:08155088
-2275	Bedfordshire East Multi-Academy Trust	company:07546141
-2288	Bellevue Place Education Trust	company:07956784
-2299	Green spring Education Trust	company:07856680
-2305	Bicester Learning Academy	company:09053713
-2307	Biddick Academy Trust	company:08521080
-2311	Biggleswade Academy Trust	company:07928028
-2322	Birmingham City University Academies Trust	company:08497028
-2326	Bishop Anthony Educational Trust, The	company:08762217
-2328	Bishop Cleary Catholic Multi Academy Company	company:08578428
-2332	Bishop Konstant Catholic Academy Trust, The	company:08253770
-2342	Bishop Wheeler Catholic Academy Trust, The	company:08399801
-2348	Blackbird Academy Trust	company:08544741
-2350	Blackpool Multi Academy Trust	company:08597962
-2351	Blandford Education Trust	company:09050439
-2353	Blessed Christopher Wharton Catholic Academy Trust	company:09066969
-2354	Blessed Cyprian Tansi Catholic Academy Trust, The	company:08090890
-2355	Blessed Edward Bamber Catholic Multi Academy Trust, The	company:09111449
-2356	Blessed Peter Snow Catholic Academy Trust	company:09068195
-2358	Blue Bell Hill Academy Trust	company:08554393
-2363	Bluecoat Academies Trust	company:07875164
-2365	Blyth Quays Trust, The	company:08428466
-2368	Bohunt Education Trust	company:07535642
-2376	Boston Witham Academies Federation, The	company:08158309
-2377	Boswells Academy Trust, The	company:07907388
-2386	Bourne Education Trust	company:07768726
-2400	Bradfields Academy	company:08899707
-2404	Bradford Academy Trust	company:05508735
-2406	Bradford College Education Trust	company:06772181
-2408	Bradford Diocesan Academies Trust	company:08258994
-2413	Brampton Manor Trust	company:07540236
-2415	BRandH Academy Limited	company:07698718
-2424	Brentwood Academies Trust	company:07638800
-2425	Brentwood Community Academies Trust	company:09030028
-2430	Bridge Multi-academy Trust	company:07736425
-2434	Bridgwater College Trust	company:08098956
-2437	Bright Futures Educational Trust	company:07695771
-2439	Bright Tribe Trust	company:08144578
-2440	Brighter Academy Trust	company:08557883
-2442	Brighter Futures Academy Trust	company:08175471
-2455	Broadmere and New Monument Multi Academy Trust	company:08407871
-2465	Bromley Educational Trust	company:09028122
-2468	Brook Learning Trust	company:07368292
-2471	Brooke Weston Trust, The	company:02400784
-2497	Burnt Mill Academy Trust	company:07843166
-2504	Burton and South Derbyshire Education Trust	company:09142556
-2507	Bury College Education Trust	company:08769073
-2508	Bury St Edmunds Academy Trust	company:07697600
-2510	Bushey St James Trust	company:07895684
-2514	Byrchall High School Academy Trust	company:08175642
-2516	Cabot Learning Federation	company:06207590
-2522	Calthorpe Teaching Academy Trust	company:09064864
-2526	Cambridge Meridian Academies Trust	company:07552498
-2528	Cambridge Primary Education Trust	company:08304433
-2535	Canary Wharf College Ltd	company:07413883
-2539	Canterbury Academy, The	company:07345430
-2543	Cardinal Hume Academies Trust, The	company:08148675
-2548	Carmel Education Trust	company:07808732
-2563	Castle Partnership Academy Trust, The	company:08066451
-2564	Castle Partnership Trust, The	company:07657731
-2565	Castle Phoenix Trust	company:08331385
-2567	Castle School Education Trust	company:08397975
-2572	Castleford Academy Trust	company:07547039
-2573	Castleman Academy Trust	company:09101036
-2575	Catalyst Academies Trust	company:08407989
-2577	Catch22 Multi Academies Trust Limited	company:08299181
-2579	Catholic Academy Trust in East Berkshire, The	company:08561153
-2580	Catholic Academy Trust in Havant, The	company:07721932
-2581	Catholic Academy Trust in South Hampshire, The	company:07723349
-2582	Catholic Academy Trust in Southampton, The	company:07714121
-2584	Rutland And District Schools' Federation	company:07552631
-2592	Central Academy Trust	company:07685645
-2594	Central Learning Partnership Trust	company:07827368
-2597	CFBT Schools Trust	company:07468210
-2605	Change Schools Partnership	company:08182064
-2609	Chapel Street Community Schools Trust	company:07885963
-2611	Charles Darwin Academy Trust	company:07554396
-2622	Chatham & Clarendon Grammar School Federation, The	company:07455452
-2627	Laurus Trust, The	company:07907463
-2639	Cheney School Academy Trust	company:08319810
-2643	Cherry Tree Academy Trust Marham	company:09106277
-2644	River Learning Trust	company:07966500
-2646	Chester Catholic Academies Partnership, The	company:08375925
-2647	Chester Diocesan Academies Trust	company:08451787
-2650	Chesterton Academy Trust	company:08786812
-2657	Children of Success Schools Trust	company:08438964
-2658	Children's Academy Trust Ltd	company:09061804
-2659	Chilford Hundred Education Trust	company:07482650
-2661	Chiltern Learning Trust	company:07559901
-2662	Chingford Academies Trust	company:08179498
-2665	Chipping Norton School Academy Trust	company:07929429
-2666	Chipstead Valley Academy Trust	company:08891864
-2681	Christ the King Catholic Collegiate	company:08933913
-2685	Chulmleigh Academy Trust	company:07697698
-2695	Cidari Education Limited	company:08822760
-2697	Cippenham Schools' Trust, The	company:07988376
-2703	City Education Trust	company:08528776
-2705	City of London Academies Trust	company:04504128
-2709	City of Wolverhampton Academy Trust	company:06969900
-2719	Cleves Cross Learning Trust	company:08718104
-2722	East Anglia Schools Trust	company:08432486
-2727	Cloughwood Academy Trust	company:08604799
-2729	Coast Academies	company:07668923
-2731	Coastal Academies Trust	company:07552665
-2741	Collaborative Academies Trust, The	company:08168307
-2743	College Academies Trust, The	company:07272906
-2744	Collegiate Academy Trust, The	company:06336693
-2748	Colston's Girls' School Trust	company:06511936
-2753	Comberton Academy Trust	company:07491945
-2755	Community Academies Trust	company:07472736
-2757	Community First Academy Trust	company:08359889
-2758	Community Inclusive Trust	company:09071623
-2762	Complementary Education Academy Limited, The	company:08190591
-2765	ConcertEd Multi Academy Trust	company:08718062
-2766	Congleton Multi-Academy Trust	company:07538467
-2767	Congleton Primary Academy Trust Limited	company:09024278
-2771	Connected Learning	company:08579939
-2776	Coombe Secondary Schools Academy Trust, The	company:07905433
-2777	Co-operative Academies Trust, The	company:07747126
-2788	Corpus Christi Catholic Academy Trust	company:07976019
-2791	Corsham School Academy Group, The	company:07550425
-2798	Cottenham Academy, The	company:07740815
-2813	Craven Educational Trust	company:09023653
-2815	Crawley Free School Trust	company:08339290
-2816	Creative Education Trust	company:07617529
-2819	Creative Learning Multi Academy Trust	company:09227333
-2824	Crofton Schools Academy Trust	company:07824714
-2837	Cuckoo Hall Academies Trust	company:07355559
-2840	CWA Academy Trust	company:07338780
-2854	David Ross Education Trust, The	company:06182612
-2858	Dayspring Trust	company:08310825
-2864	Dean Trust, The	company:08027943
-2870	Delta Education Trust, The	company:08382383
-2878	Derby College Education Trust	company:08072758
-2879	Derby Diocesan Academy Trust	company:08980079
-2880	Derby Pride Trust	company:07109892
-2886	Diamond Learning Partnership Trust, The	company:08062508
-2887	Didcot Academy of Schools	company:08104201
-2893	Diocese of Brentwood Multi Academy Trust	company:08610377
-2894	Diocese of Bristol Academies Trust	company:08156759
-2897	Diocese of Canterbury Academies Trust, The	company:09035788
-2901	Diocese of Coventry Multi-academy Trust, The	company:08422015
-2905	Diocese of Ely Multi-academy Trust, The	company:08464996
-2907	Diocese of Gloucester Academies Trust, The	company:08149299
-2918	The Diocese of Norwich Education and Academies Trust	company:08737435
-2922	Diocese of Salisbury Multi Academy Trust	company:08656655
-2925	Diocese Of Southwell And Nottingham Multi-Academy Trust	company:08738949
-2928	Diocese of Westminster Academy Trust, The	company:07944160
-2930	Discover Learning Trust	company:08249250
-2932	Discovery Schools Academies Trust Ltd	company:08104111
-2936	Diverse Academies Trust	company:07664012
-2939	Dixons Academies Charitable Trust Ltd	company:02303464
-2941	Djanogly Learning Trust	company:04544722
-2943	Dominic Barberi Multi Academy Company, The	company:08453966
-2953	Downview Trust	company:08603388
-2958	Drapers' Multi-Academy Trust	company:07035556
-2962	DS Academies Trust, The	company:08745639
-2963	Duchy Academy Trust, The	company:08842867
-2969	Durrington Multi Academy Trust	company:08895870
-2974	E-ACT	company:06526376
-2987	East Midlands Education Trust	company:07530373
-3001	Ebor Academy Trust	company:08806335
-3004	Eden Academy, The	company:08036395
-3009	Educate Together Academy Trust	company:08859774
-3010	Education And Leadership Trust	company:08913502
-3012	Education Central Multi Academy Trust	company:08255492
-3013	Education Fellowship Trust, The	company:07848783
-3015	Education for the 21st Century	company:07559170
-3016	Education Partnership Trust	company:07950891
-3018	Education Village Academy Trust, The	company:07748248
-3019	Edwin Jones Trust	company:08512105
-3025	Elliot Foundation Academies Trust, The	company:08116706
-3028	Dunham Trust, The	company:08120128
-3033	EMLC Academy Trust	company:08149829
-3039	Engage, Enrich, Excel academies	company:09279884
-3042	Enquire Learning Trust, The	company:08056907
-3044	Epiphany School, The	company:07991877
-3047	Equitas Academies Trust	company:07662289
-3053	Esher Learning Trust	company:08812257
-3055	Essa Foundation Academies Trust	company:06731593
-3062	Evolution Academy Trust	company:08158619
-3063	Evolution Schools Learning Trust	company:07596422
-3065	Excalibur Academies Trust	company:08146633
-3066	Excel Academy Partnership, The	company:07837770
-3071	Extol Academy Trust	company:08561360
-3072	Eynsham Partnership Academy	company:07939655
-3073	Fairchildes Academy Community Trust	company:08934482
-3076	Fairfax Multi Academy Trust	company:07661164
-3080	Fallibroome Trust, The	company:07346144
-3083	Faringdon Academy of Schools	company:07977368
-3090	Federation of Abbey Schools Academy Trust, The	company:07699775
-3091	Federation of Mowden Schools Academy Trust	company:08027205
-3093	Fennwood Academy Trust	company:08763832
-3104	First Federation Trust, The	company:07819870
-3107	Fleetville Trust	company:08028375
-3111	Flying High Trust	company:08076374
-3112	Focus Academy Trust (UK) Ltd	company:08071176
-3115	Folkestone School for Girls Academy Trust, The	company:07882159
-3123	Fort Pitt Grammar School Academy Trust	company:07401701
-3126	The Partnership Trust	company:07728112
-3142	Fulham College Academy Trust, The	company:08398143
-3145	Fulston Manor Academies Trust	company:07343725
-3147	Fulwood Academy, The	company:06960253
-3150	Fusion Schools Trust	company:08663011
-3152	Future Academies	company:06543442
-3154	Future Schools Trust	company:06272751
-3155	Fylde Coast Academy Trust	company:08364709
-3163	Gateway Learning Community	company:05853746
-3166	GDST Academy Trust	company:06000347
-3173	Gilberd School, The	company:07933810
-3185	Oadby, Wigston and Leicestershire Schools Academy Trust	company:08537140
-3188	Gloucestershire Learning Alliance	company:07690119
-3190	GLF Schools	company:07551959
-3200	Goldsworth Trust	company:07887259
-3201	Good Shepherd Trust, The	company:08366199
-3206	GORSE Academies Trust, The	company:07465701
-3209	Gosforth Federated Academies Limited, The	company:07431423
-3211	Grace Academy	company:04967658
-3216	Grange Trust, The	company:09150608
-3218	Grasvenor Avenue Infant School	company:08164849
-3219	Graveney Primary School	company:07847021
-3220	Graveney Trust	company:07687897
-3222	Gravesend Grammar School Academies Trust	company:07685923
-3225	Great Academies Education Trust	company:06237630
-3235	Great Missenden Trust	company:08927321
-3240	Green School Trust, The	company:08608665
-3243	Greenacre Academy Trust, The	company:07965316
-3245	Greenfield & Pulloxhill Academy	company:07719857
-3252	Greenwood Academies Trust	company:06864339
-3257	Grenestede Academy Trust	company:09081030
-3262	Griffin Schools Trust, The	company:07893665
-3265	Grove Park Academies	company:08059055
-3266	Grove Wood Academy Trust	company:09068218
-3272	Guildford Education Partnership	company:07649091
-3273	Guilsborough Multi Academy Trust	company:07535683
-3275	Guru Nanak Sikh Academy Limited	company:07416734
-3277	Haberdashers' Adams' Federation Trust	company:06548296
-3279	Haberdashers' Aske's Federation Trust	company:02535091
-3288	Halewood Academy Centre for Learning	company:07909397
-3294	Hallam Schools' Partnership Academy Trust, The	company:08665067
-3295	Haltwhistle Community Campus	company:08624157
-3299	Hampton Academies Trust	company:09129775
-3303	Hamstead Hall Academy Trust	company:08528845
-3313	Harlington and Sundon Academy Trust, The	company:08231721
-3316	Harmony Trust Limited, The	company:08840373
-3320	Harris Federation	company:06228587
-3326	Harrowby/National Academies Trust, The	company:08105941
-3329	Hartlepool Aspire Trust	company:08604037
-3333	Harvey Academy, The	company:08142275
-3339	Hastings Academies Trust	company:07185046
-3345	Hatton Academies Trust	company:07949111
-3364	Healing Multi Academy Trust	company:07345756
-3368	Heartlands Community Trust	company:08482398
-3370	HEARTS Academy Trust	company:07851097
-3371	Heartwood Church of England Academy Trust	company:08627834
-3372	Heath Family (North West), The	company:07614421
-3375	Heathfield Academy Trust	company:08027885
-3377	Heathland Whitefriars Federation	company:09066965
-3395	Hereford Integrated Behaviour Outreach Service	company:09136556
-3396	Herefordshire Marches Federation of Academies, The	company:07578861
-3398	Hermitage Trust, The	company:08872698
-3403	Hessle Academy Community Trust, The	company:07665828
-3410	Highcliffe School	company:07631213
-3431	Brigantia Learning Trust Limited	company:08506178
-3432	Hinkler Academies Trust	company:08479066
-3457	Holy Family Catholic Academy Trust	company:08155184
-3458	Holy Family Catholic Multi Academy Trust	company:08269066
-3460	Holy Family of Nazareth Catholic Academy Trust, The	company:08307881
-3464	Holy Trinity Church Of England Academy (South Shields) Trust	company:09098446
-3477	Honywood Community Science School	company:07592309
-3483	Horizons Specialist Academy Trust	company:08608287
-3485	Hornbeam Academy Trust	company:08153765
-3493	Howard Partnership Trust, The	company:07597068
-3496	Spring Partnership Trust, The	company:07656245
-3502	Hull Collaborative Academy Trust	company:08542806
-3507	Hummersknott Academy Trust	company:07664322
-3511	The Education Alliance	company:07542211
-3527	Innovate Multi Academy Trust	company:09071405
-3528	Innovation Enterprise Academy	company:08278808
-3531	Inspiration Trust	company:08179349
-3532	Inspire Academy Trust	company:07781921
-3533	Inspire Learning Federation, The	company:09202445
-3534	Inspire Multi Academy Trust	company:08287012
-3535	Interserve Academies Trust Limited	company:09042916
-3538	Ironstone Academy Trust	company:09040348
-3539	Infinity Academies Trust Ltd	company:08358124
-3540	Iffley Academy Trust Company, The	company:08334718
-3543	Isle Education Trust	company:07814150
-3547	Ivybridge Academy Trust	company:07398467
-3552	Jefferys Education Trust	company:07690473
-3566	John Paul II Multi-academy	company:08706247
-3586	Kemnal Academies Trust, The	company:07348231
-3590	Kennet School Academies Trust	company:07543874
-3594	Kent Catholic Schools' Partnership	company:08176019
-3598	Kenton Schools Academy Trust	company:07964133
-3603	KESKOWETHYANS Multi Academy Trust	company:08872161
-3614	King Alfred Trust	company:08853971
-3628	King Ina Church of England Academy	company:08120037
-3643	Academies South West	company:07451553
-3651	Kingstone Academy Trust	company:07681857
-3652	Kingsway Community Trust	company:08339302
-3661	KJS Academy Trust, The	company:07559293
-3667	Knutsford Multi Academy Trust	company:07984413
-3668	Koinonia Academies Trust	company:08563153
-3670	L.E.A.D. Multi-Academy Trust	company:08296921
-3677	Laidlaw Schools Trust, The	company:05735093
-3684	Landau Forte Charitable Trust	company:02387916
-3688	Langley Academy Trust, The	company:05358533
-3694	Langtree School Academy Trust Company, The	company:07980335
-3698	AN Daras Multi Academy Trust	company:08156955
-3700	Launde Primary School Academy Trust	company:08515149
-3703	LDBS Academies Trust	company:08182235
-3705	LDBS Frays Academy Trust	company:08335073
-3706	LEAF Academy Trust	company:05037949
-3708	Leap Academy Trust, The	company:08482129
-3710	Learning Academy Partnership (South West)	company:07713540
-3711	Learning Alliance Academy Trust, The	company:07703829
-3713	LeAF Academy	company:08011930
-3714	Learning in Harmony Multi Academy Trust	company:09148738
-3715	Learning Pathways Academy	company:07984238
-3716	Learning Schools Trust	company:07145434
-3718	Lee Chapel Academy Trust	company:07673871
-3722	Diocese Of Leicester Academies Trust	company:08138372
-3725	Leigh Academies Trust	company:02336587
-3727	Leigh Trust	company:08779660
-3735	Magna Learning Trust	company:07491215
-3743	Lilac Sky Schools Trust, The	company:08289583
-3746	Lincoln Anglican Academy Trust	company:08737412
-3749	Lincolnshire Educational Trust Limited, The	company:07647805
-3758	Lion Academy Trust	company:08171341
-3759	Lion Education Trust	company:09161091
-3760	Lionheart Academies Trust	company:08473899
-3765	Little Mead Academy Trust	company:08245853
-3771	London Academies Enterprise Trust	company:07211219
-3782	Longfield Academy Trust	company:07700556
-3788	Lordswood Academies Trust	company:07567230
-3794	Lound Academy Trust	company:08550854
-3797	Loxford School Trust Limited	company:08743560
-3805	Lumen Learning Trust	company:08670599
-3806	Lutterworth Academies Trust, The	company:08038063
-3808	LWS Academy Trust	company:08915981
-3810	Lydiate Learning Trust	company:07732559
-3817	Macintyre Academies	company:08334745
-3834	Maltby Learning Trust	company:07033915
-3839	Manchester Creative And Media Academy	company:06888873
-3847	Manor Learning Trust	company:07816548
-3855	Marches Academy Trust	company:07680422
-3858	Marine Academy Plymouth	company:07194412
-3860	Marish Academy Trust	company:08073873
-3878	Matrix Academy Trust	company:07654219
-3884	Mead Academy Trust, The	company:08024396
-3892	Meopham Community Academies	company:07416211
-3899	Mercia Learning Trust	company:08119703
-3900	Mercia Primary Academy Trust	company:08748904
-3908	Midland Academies Trust, The	company:07191874
-3910	Midsomer Norton Schools Partnership	company:07365778
-3918	Milton Keynes Education Trust	company:07663689
-3921	Minerva Learning Trust	company:09200332
-3924	Mirfield Free Grammar and Sixth Form Multi-Academy Trust, The	company:07521584
-3931	Montsaye Community Learning Partnership	company:07670511
-3933	Moor End Academies Trust	company:07599308
-3939	Mossbourne Federation, The	company:04468267
-3940	Mossley Academy Trust, The	company:09104491
-3952	Mowbray Education Trust Limited	company:07796947
-3956	NAS Academies Trust	company:07954396
-3965	NET Academies Trust	company:08221088
-3975	New College Durham Academies Trust	company:07195175
-3977	New Dawn Trust	company:07842369
-3980	New Hall Multi Academy Trust	company:08643881
-3981	New Haw Community School	company:08718489
-3987	Newbury Academy Trust	company:08142572
-3991	Newman Catholic Collegiate, The	company:08550110
-3995	Newquay Education Trust	company:08961355
-3996	Newstead Multi Academy Trust	company:08657945
-4002	Nicholas Postgate Academy Trust	company:09203984
-4004	Ninestiles Academy Trust Limited	company:07348167
-4005	Nishkam School Trust	company:07522245
-4011	Norfolk Academies	company:07946986
-4014	North Carr Collaborative Academy Trust	company:08395383
-4017	North East Sheffield Trust	company:08863947
-4018	North Essex Multi-Academy Trust	company:07687474
-4020	North Hertfordshire Studio School Trust, The	company:07791933
-4024	North Norfolk Academy Trust	company:07800153
-4029	North West Academies Trust Limited	company:08852553
-4031	Northampton Primary Academy Trust	company:08172039
-4036	Northern Education Trust	company:07189647
-4038	Northern House School Academy Trust	company:08140768
-4039	Northern Lincolnshire Catholic Academy Trust, The	company:07973953
-4041	Northern Schools Trust	company:05067702
-4048	Northwick Park Trust	company:09154404
-4058	Nottingham University Samworth Academies Trust	company:06221293
-4065	Oak Wood Schools Academy	company:08425914
-4070	Oaks Academy Trust	company:08924656
-4073	Oakwood Learning Community Trust	company:08775996
-4074	Oakwood Park Grammar School	company:07584611
-4076	Oasis Community Learning	company:05398529
-4079	Odyssey Academy Trust, The	company:09139888
-4095	Olympus Academy Trust, The	company:07844791
-4100	Orchard Hill College Academy Trust	company:08476149
-4106	Ormiston Academies Trust	company:06982127
-4111	OUR Co-operative Academies Trust	company:08670427
-4114	Our Lady of Fatima Catholic Multi Academy Trust	company:07696069
-4115	Our Lady of Lourdes Catholic Multi-Academy Company	company:09064485
-4119	Outwood Grange Academies Trust	company:06995649
-4124	Oxford Diocesan Schools Trust	company:08143249
-4127	Painsley Catholic Academy, The	company:08146661
-4131	Paradigm Trust	company:08469218
-4132	Parallel Learning Trust	company:08605705
-4134	Park Federation Academy Trust, The	company:08146330
-4145	The Core Educational Trust	company:07949154
-4149	Parkroyal Academy Trust	company:08728422
-4151	Parkside Federation Academies	company:07557831
-4157	The Passmores Co-operative Learning Community	company:07736246
-4161	Pax Christi Catholic Academy Trust	company:08192900
-4163	Pear Tree Alliance	company:08916147
-4168	Pegasus Academy Trust, The	company:07542114
-4174	Pendle Education Trust	company:08263591
-4175	Peninsula Gateway Academy Trust	company:08095169
-4185	Perry Beeches The Academy Trust	company:07749786
-4186	Perry Hall Multi-Academy Trust	company:08566185
-4192	Peterborough Diocese Education Trust	company:08509710
-4197	Phoenix Family of Schools Academy Trust, The	company:08324412
-4208	Pioneer Academies Co-operative Trust (PACT)	company:08255683
-4209	Pioneer Academy, The	company:07691324
-4210	Plantsbrook Learning Trust	company:07655702
-4214	Plymouth CAST	company:08438686
-4219	Pokesdown Community Primary School	company:08425359
-4220	PolyMAT	company:09078530
-4223	Pontefract Academies Trust	company:08445158
-4227	Pope Francis Catholic Multi Academy Company, The	company:09113542
-4230	Portsmouth and Winchester Diocesan Academies Trust	company:08161468
-4232	Portswood Primary Academy Trust	company:08158400
-4243	Primary Academies Trust, The	company:07821367
-4244	Primary Excellence - A Catholic Education Trust	company:08068528
-4245	Primary First Trust, The	company:08738750
-4250	Priory Academy Trust, The	company:08032410
-4253	Priory Federation of Academies, The	company:06462935
-4257	Propeller Academy Trust, The	company:08340120
-4264	Pursuing Educational Excellence Together	company:08064698
-4269	QED Academy Trust	company:07493622
-4273	Quantock Academy, The	company:08767576
-4280	Queen Elizabeth's Grammar School Trust Faversham	company:07558466
-4292	Quinta Trust, The	company:08787650
-4301	Ralph Sadleir School	company:08663956
-4308	Apollo Learning Trust	company:07553596
-4320	REAch2 Academy Trust	company:08452281
-4335	Redditch RSA Academies Trust	company:08166526
-4336	Redditch West School Trust	company:07967402
-4338	Redhill Academy Trust	company:07430317
-4361	Ridings’ Federation of Academies Trust, The	company:06802948
-4362	RIGHTFORSUCCESS TRUST	company:08282834
-4365	Ringwood School	company:07552519
-4368	Rise Park Academy Trust	company:09051179
-4369	Rivers C of E Multi Academy Trust, The	company:09199371
-4372	RNIB Specialist Learning Trust	company:08478985
-4380	Robinswood Academy Trust, The	company:07530418
-4382	Robus Multi Academy Trust	company:07681811
-4384	Rochester Diocesan Multi-Academy Education Trust	company:08270657
-4386	Rodillian Multi Academy Trust, The	company:07990619
-4395	Rosebery School	company:07818029
-4397	Rosedale Hewens Academy Trust, The	company:07683702
-4405	Rowan Learning Trust, The	company:08010464
-4410	Royston Schools Academy Trust, The	company:07695881
-4417	Abingdon Learning Trust	company:07931886
-4421	Russell Education Trust	company:07452885
-4422	Rutland Learning Trust, The	company:09199785
-4426	Rye Academy Trust	company:08177657
-4437	Saffron Academy Trust	company:07618351
-4438	Saint Dominic's Catholic Academy Trust	company:08106388
-4441	Saint Nicholas Owen Catholic Multi Academy Company	company:09174154
-4442	Saint Robert Lawrence Catholic Academy Trust	company:07937154
-4443	Saints' Way Church of England Multi Academy Trust, The	company:08269215
-4447	Salford Academy Trust	company:08115121
-4449	Saltash Multi Academy Regional Trust	company:07542166
-4454	Samuel Ward Academy Trust	company:07400386
-4460	Sandhill Multi Academy Trust	company:08745045
-4473	School 21	company:07648389
-4474	School Partnership Trust Academies	company:07386086
-4477	Schoolsworks Academy Trust	company:07962974
-4482	Seckford Foundation Free Schools Trust, The	company:08077362
-4487	Sevak Education Trust Ltd	company:08267703
-4493	Shaftesbury Academy Trust	company:09040388
-4495	Sharnbrook Academy Federation	company:07500018
-4499	Shaw Education Trust, The	company:09067175
-4510	Shirebrook Academy	company:06628631
-4516	North East Learning Trust	company:07492165
-4518	Shrewsbury Academies Trust	company:08407961
-4519	Shropshire Gateway Educational Trust, The	company:09115941
-4521	Sidney Stringer Multi Academy Trust	company:06672920
-4524	Silver Birch Academy, The	company:08107310
-4528	Simon Balle Academies Trust	company:08661539
-4530	Aspire Learning Trust (Whittlesey)	company:08006711
-4533	Sir John Lawes Academies Trust, The	company:07697132
-4553	Slough and East Berkshire C of E Multi Academy Trust, The	company:07723151
-4556	Smallwood Academy Trust, The	company:09118770
-4559	Solent Academies Trust	company:08374351
-4567	South Dartmoor Academy	company:07561204
-4569	South East Essex Academy Trust	company:07527304
-4579	South Northamptonshire Church of England Multi Academy Trust	company:08569207
-4580	South Northamptonshire Village Schools Multi Academy Trust	company:08567252
-4581	South Nottingham Catholic Academy Trust	company:07743523
-4584	South Shropshire Academy Trust	company:08439425
-4586	South Tyneside Academy Trust Sponsored By South Tyneside College	company:08313162
-4593	Southfield Grange Trust, The	company:07754077
-4601	Southwark Primary Academy Trust	company:07726568
-4608	Specialist Education Trust, The	company:08610537
-4609	Spencer Academies Trust, The	company:07353824
-4610	Spiral Academies Trust	company:08322127
-4616	SS Simon and Jude Church of England Academy Trust	company:08240918
-4620	St Aidan's Education Trust	company:08442124
-4629	St. Anselm's Catholic Multi Academy Trust	company:08515862
-4636	St Barnabas Church of England Multi Academy Trust	company:08669464
-4638	St Bart's Multi Academy Trust	company:08735454
-4652	St Chad's Academies Trust	company:08526973
-4656	St Christopher's C of E (Primary) Multi Academy Trust	company:08538844
-4657	St Christopher's C of E (Secondary) Multi Academy Trust	company:08486531
-4662	St Clere's Co-operative Academy Trust	company:07703865
-4668	St Cuthbert's Roman Catholic Academy Trust	company:09023802
-4680	St Francis of Assisi Academies Trust	company:08462151
-4688	St Gilbert of Sempringham Catholic Academy Trust	company:08462512
-4697	St Hybald's Academy Trust	company:08003909
-4700	St James Church of England Academy Trust Company	company:08022455
-4703	St John Bosco Catholic Academy, The	company:08608177
-4717	Catholic Academy Trust in Aldershot, The	company:07728054
-4719	St. Joseph's Catholic Education Trust	company:08559647
-4742	St Mary's Academy Trust	company:07917752
-4750	St. Mary's Catholic School Trust	company:08599141
-4771	St Neots Learning Partnership, The	company:07703784
-4776	St. Oswald's Catholic Academy Trust	company:08924383
-4777	St Oswald's Church of England Academy	company:08176968
-4787	St Peter's Catholic Voluntary Academy Trust	company:07739194
-4791	St Piran's Cross Church of England Multi Academy Trust	company:08739625
-4797	St Thomas More Partnership of Schools	company:07900532
-4806	St Barnabas Catholic Academy Trust	company:08089246
-4813	Staffordshire University Academies Trust	company:07704020
-4815	Stamp Education Trust	company:07916297
-4819	Stanford & Corringham Schools Trust, The	company:07660783
-4822	Stanway Federation, The	company:07887953
-4824	Staploe Education Trust	company:07534901
-4828	Steel City Schools Partnership	company:08356745
-4836	Step Academy Trust	company:07612865
-4837	Stephenson (MK) Trust	company:07919427
-4850	Stour Academy Trust, The	company:08179242
-4851	Stour Federation, The	company:09174628
-4853	Stourfield Infant Academy Trust	company:08201675
-4858	Stranton Academy Trust	company:08561049
-4863	Stratton Education Trust	company:07798627
-4876	Surrey Heath Education Trust	company:08621310
-4885	Swale Academies Trust	company:07344732
-4888	Swanland Education Trust	company:07679051
-4892	Synaptic Trust	company:07588104
-4893	Talent & Enterprise Trust	company:08562954
-4895	Tall Oaks Academy Trust Ltd	company:08395421
-4899	Tapton School Academy Trust	company:07697171
-4903	Tauheedul Education Trust	company:07353849
-4908	TBAP Trust	company:08425513
-4909	Ted Wragg Multi Academy Trust, The	company:08545109
-4915	Teignmouth Learning Trust	company:07519888
-4916	Telford Co-operative Multi Academy Trust	company:08447216
-4920	Templer Academy Schools Trust	company:07518252
-4923	Thame Partnership Academy Trust	company:08154932
-4929	The Aquinas Catholic Academy Trust	company:08901256
-4935	The Bentley Wood Trust	company:07693936
-4936	The Black Pear Trust Academies	company:08922754
-4951	The Crabtree Academy Trust	company:08782792
-4955	Diocese of Chelmsford Vine Schools Trust, The	company:08709542
-4956	The Diocese of Liverpool Academies Trust (Merseyside)	company:09235635
-4958	The Dover Federation for the Arts	company:08039629
-4962	The English Martyrs Educational Trust	company:08962417
-4963	The Eveleigh Link Academy Trust	company:08823327
-4965	The Evolve Trust	company:07827747
-4986	The Kirkstead Education Trust	company:08977173
-4990	Lincoln College Academy Trust	company:08238194
-4996	The Meller Educational Trust	company:06933010
-5004	The Platanos Trust	company:07492094
-5011	The Queen Katherine School Multi Academy Trust	company:07472799
-5013	The Rainbow Multi Academy Trust	company:08909269
-5049	Thinking Schools Academy Trust, The	company:07359755
-5063	Three Rivers Learning Trust Limited, The	company:07838203
-5075	TIMU Academy Trust	company:09022463
-5079	Tollbar Multi Academy Trust	company:08085503
-5084	Torch Academy Gateway Trust	company:07635510
-5085	Torfield and Saxon Mount Academy Trust	company:09172115
-5086	Torquay Boys' Grammar School	company:07394671
-5098	Transform Trust	company:08671076
-5102	Learning Academy Trust, The	company:07394649
-5108	Trinitas Academy Trust	company:07554121
-5119	Truro & Penwith Academy Trust	company:08880841
-5122	Trust in Learning (Academies)	company:08089704
-5125	Tudhoe Learning Trust	company:08270151
-5126	Tudor Court Primary Academy Trust	company:09071607
-5128	Tudor Grange Academies Trust	company:07365748
-5132	Twyford Church of England Academies Trust	company:07648968
-5141	Uffculme Academy Trust	company:07338835
-5143	United Learning Trust	company:04439859
-5148	South Bank Academies	company:08589525
-5152	University of Chester Academies Trust	company:06929486
-5153	University of Chichester (Multi) Academy Trust	company:08595545
-5162	Upminster Academies Trust	company:08214798
-5165	Upton Court Educational Trust	company:07462530
-5176	Vale Academy Trust	company:07674473
-5178	Valley Invicta Academies Trust	company:07559256
-5183	Victoria Academies Trust	company:07887796
-5186	Village Academy, The	company:07738386
-5188	Violet Way Trust	company:07606026
-5195	Wakefield City Academies Trust	company:07462885
-5196	Wakefield Diocesan Academies Trust	company:07904096
-5199	Waldegrave Trust, The	company:08130508
-5203	Wallingford Schools Academy Trust	company:07727786
-5214	Sussex Learning Trust	company:07705100
-5222	Warrington Collegiate Education Trust	company:08298534
-5226	Washwood Heath Multi Academy Trust	company:08531479
-5228	Waterton Academy Trust	company:09124782
-5232	Waverley Education Foundation Ltd, The	company:08331922
-5238	Wearmouth Learning Trust	company:08767870
-5247	Wellington Academy Trust, The	company:06457394
-5252	Wellspring Academy Trust	company:08120960
-5253	Wellsway Multi Academy Trust	company:07746787
-5263	West Grantham Academies Trust, The	company:07489113
-5265	West Herts Community Free School Trust	company:08324782
-5271	West London Free School Academy Trust, The	company:07493696
-5273	West Newcastle Academy	company:07647538
-5275	West Norfolk Academies Trust	company:07546118
-5286	Westbrook Trust, The	company:09223515
-5299	Inspirational Futures Trust	company:08329993
-5303	South Essex Academy Trust	company:07681226
-5314	White Hills Park Federation Trust, The	company:08195720
-5315	White Horse Federation, The	company:08075785
-5316	White Rose Academies Trust	company:07958615
-5318	White Woods Primary Academy Trust	company:08589470
-5320	Whitefield Academy Trust	company:08878604
-5324	Whitehill Community Academy Multi-Academy Trust	company:07559439
-5328	Whittlesea Learning Trust	company:08795983
-5329	Wickersley Partnership Trust	company:08833508
-5333	Wigmore School	company:07466409
-5345	William Temple Multi Academy Trust	company:08813173
-5347	William Willett Learning Trust	company:07520128
-5348	Williamson Trust, The	company:07569727
-5351	Willows Academy Trust	company:09093035
-5361	Windsor Academy Trust	company:07523436
-5370	Wise Academies	company:07521946
-5372	Wise Owl Trust	company:08053288
-5385	Woodard Academies Trust	company:06415729
-5396	Woodland Academy Trust, The	company:07694050
-5402	Woodnewton Academy Trust	company:08034402
-5411	Wootton Academy Trust	company:07740758
-5418	Wrotham School	company:07662701
-5421	Wycombe High School Academies Trust	company:07597324
-5426	Wythenshawe Catholic Academy Trust, The	company:08440868
-5443	Carnovian Alliance, The	company:09221695
-5444	Keys Federation, The	company:09306360
-5445	AD Astra Academy Trust	company:09308398
-5446	Stanwix School	company:09341344
-5447	Somerset Road Education Trust	company:09343767
-5452	Greenshaw Learning Trust	company:07633694
-5453	Clevedon Learning Trust	company:07872799
-5454	Trent Academies Group	company:08128513
-5455	Cheshire Academies Trust Ltd	company:08108086
-5456	Transform Trust	company:08320065
-5461	Bridge Integrated Learning Space Ltd, The	company:08343491
-5470	Lime Academy Trust, The	company:09297519
-5471	Little Acorn Trust	company:09207180
-5473	Radcliffe Academy	company:09334026
-5476	Good Shepherd Multi Academy Trust, The	company:09341374
-5477	Ridings Trust, The	company:09290889
-5478	Learner Engagement and Achievement Partnership Multi-Academy Trust	company:07361021
-5479	Peninsula Learning Trust	company:07565242
-5480	Twynham Learning	company:07565088
-5481	South Farnham Educational Trust	company:07652902
-5482	Vyners Learning Trust	company:07796938
-5483	Bourton Meadow Education Trust, The	company:07867334
-5485	Partnership Learning	company:08339345
-5486	Wardle Academy	company:08368756
-5487	The Wulfrun Academies Trust	company:08881720
-5488	Diocese of Chichester Academy Trust, The	company:09201845
-5489	Rainbow Education Multi-Academy Trust	company:09265723
-5490	Learning Partnership Trust, The	company:09380027
-5494	Athelstan Trust, The	company:07699625
-5516	South Gloucestershire and Stroud Academy Trust	company:09353480
-5519	Invictus Education Trust	company:09284368
-5520	Sefton Education Trust	company:08307770
-5521	St Luke Academies Trust	company:09436283
-5522	SCHOOLSCOMPANY Trust, The	company:08304460
-5523	King Edward's Stourbridge Academy Trust	company:09361342
-5524	Holy Spirit Catholic Multi Academy, The	company:09432692
-5526	Wimborne Academy Trust	company:09362004
-5531	Viking Academy Trust	company:09449979
-5532	Pope John XXIII Catholic Multi Academy Company	company:09441910
-5533	St Martin's Multi Academy Trust	company:09443906
-5536	The Silk Academy Trust	company:09427476
-5537	Piper Hill Learning Trust	company:09392787
-5539	Pax Christi Catholic Partnership	company:09378390
-5540	Ipswich Primary Academies Trust	company:09434926
-5541	Future Generation Trust	company:09440033
-5542	Building Futures Enterprise Academy Trust	company:09408861
-5544	Windsor Learning Partnership	company:09409109
-5593	Derby Diocesan Academies Trust 2	company:09442311
-5594	Aspire Educational Trust, The	company:08689696
-5595	Eggbuckland Community College Academy Trust	company:08603078
-5596	Kirk Sandall Academy Trust	company:08248173
-5598	Redstart Learning Partnership, The	company:07649832
-5599	Yorkshire Causeway Schools Trust	company:07663935
-5600	Waycroft Multi Academy Trust	company:07683980
-5601	Dragonfly Education Trust	company:07728482
-5602	Levels Academy Trust, The	company:09437439
-5604	Richard Huish Trust	company:09320523
-5605	Olive Academies	company:08747464
-5606	Takely Education Trust	company:09451372
-5607	Amaya Trust	company:09155473
-5609	Lumen Christi Catholic Multi Academy Company	company:09471525
-5610	Greenacre School Trust	company:08102025
-5611	TEACH Poole	company:09484306
-5612	West Stafford Multi-Academy Trust	company:09422746
-5613	Willow Tree Academy	company:09440025
-5614	Yorkshire and Humberside Co-operative Academies Trust	company:09332738
-5615	University of Brighton Academies Trust	company:09466013
-5616	Fair Field Junior School	company:09434766
-5617	Irthlingborough And Finedon Learning Trust, The	company:09470229
-5618	Prestolee Multi Academy Trust	company:09481323
-5619	Shire Multi Academy Trust, The	company:09454169
-5620	St Catherine of SIENA Multi Academy Company	company:09497062
-5621	Our Lady Of Grace Catholic Academy Trust	company:09435396
-5622	Arete Learning Trust	company:09471240
-5630	Sirius Academy	company:06545396
-5631	Wirral Academy Trust	company:07472190
-5632	Hope Learning Trust, York	company:07559537
-5633	Langley Park Academies	company:07697400
-5634	South West Essex Community Education Trust Limited	company:07693309
-5635	SHARE Multi Academy Trust	company:07729878
-5636	Seax Trust	company:07747149
-5637	Aurum Academies Trust	company:07971651
-5638	Wigston Academies Trust	company:07975551
-5639	Legra Academy Trust	company:08066610
-5640	Greenwood Tree Academy Trust	company:08066324
-5641	TEAM Multi-Academy Trust	company:08110847
-5642	Academy Trust of Melksham, The	company:08153550
-5643	St Paul's (Astley Bridge) Church of England Primary School	company:08212263
-5644	CHS Learning Trust	company:08321679
-5645	Pelham Academy Trust	company:08439184
-5646	Engage Multi Academy Trust, The	company:08699493
-5647	Salterns Academy Trust, The	company:08921490
-5666	Cranmer Education Trust	company:07687709
-5667	Northern Star Academies Trust	company:07553531
-5668	Hackney New School Limited	company:07923624
-5669	Learning Together Trust, The	company:08561302
-5670	Castle Trust	company:08850163
-5671	Arden Multi Academy Trust	company:07375267
-5689	Trinity Academy Halifax	company:06897239
-5690	John Taylor MAT	company:07421140
-5692	Albany Learning Trust	company:08123168
-5693	South Cheshire Catholic Multi-academy Trust, The	company:08518704
-5702	Saturn Education Trust	company:09578698
-5704	Mayflower Specialist School Academy Trust	company:09610951
-5705	Bridgnorth Area Schools' Trust	company:09617166
-5708	Ocean Learning Trust	company:09628750
-5709	Salopia Catholic Schools Trust	company:09646093
-5711	Oakwood Academy Schools Trust, The	company:07982516
-5712	Southmoor Academy	company:08021855
+1	Eltham Green School Trust	
+2		company:08002136
+3		company:06625091
+4	The Copland Learning Partnership Trust	
+5	The Bourne Foundation	
+6		company:07007398
+7		company:06933903
+8		company:08530062
+9		company:09095872
+10		company:07361097
+11		company:07640639
+12		company:06318425
+13		company:06645806
+14		company:07175341
+15		company:06699254
+16		company:08510454
+17		company:08572909
+18	Wednesday Learning Community Trust	
+19		company:08124820
+20		company:07487384
+21		company:07112404
+22		company:06803262
+23	Lyndon School Humanities Trust Board	
+24	The Frank F Harrison Trust in the Beechdale Community Partnership	
+25	Brownhills School Trust	
+26	Best Futures	
+27		company:07030660
+28		company:06530527
+29		company:07031130
+30		company:07088409
+31		company:08180449
+32		company:07757429
+33	Bebington High Sports College a Co-operative Community Trust	
+34		company:05210075
+35	The Smile Trust (South Manchester International Learning Enterprise)	
+36	West Oldham Co-operative Trust	
+37		company:07210040
+38		company:07239650
+39	The Golbourne and Lowton Co-operative Learning Partnership Trust	
+40	The Golborne and Lowton Co-operative Learning Partnership Trust	
+41		company:07137803
+42		company:07147060
+43		company:07172612
+44		company:08647577
+45		company:07476344
+46		company:08645382
+47		company:08863947
+48		company:07422667
+49		company:08785019
+50		company:07112765
+51		company:07210410
+52	The Nab Wood Community Trust	
+53	Thornton Grammar and Queensbury School Learning Trust	
+54		company:07200314
+55		company:09010317
+56		company:08028340
+57		company:07632050
+58		company:09150163
+59		company:07137387
+60		company:08819550
+61	The Priesthope Co-operative Learning Trust	
+62		company:08822970
+63		company:08419368
+64		company:08159893
+65		company:08330167
+66		company:07323734
+67		company:07689558
+68		company:07490257
+69		company:08162626
+70		company:07871729
+71		company:08122838
+72		company:07155299
+73		company:07080464
+74		company:06655424
+75		company:07533785
+76		company:08942309
+77		company:08942398
+78		company:07353837
+79	The Bede Co-operative Learning Trust	
+80		company:07196462
+81		company:08160289
+82		company:08658047
+83		company:06610908
+84		company:08554335
+85	W W Trust	
+86		company:08669980
+87		company:06865093
+88		company:07066659
+89		company:06920399
+90		company:06406335
+91		company:07362459
+92		company:07810556
+93		company:06664132
+94		company:06722344
+95		company:07421249
+96		company:06736504
+97		company:09097648
+98		company:08670392
+99		company:07207094
+100		company:07048537
+101		company:07085883
+102		company:07359743
+103		company:07390424
+104		company:06981514
+105		company:07888193
+106		company:07220749
+107		company:07721328
+108		company:08668189
+109		company:07061055
+110		company:08013075
+111		company:07001690
+112		company:08368234
+113		company:08340994
+114		company:08159946
+115		company:08475586
+116		company:07321827
+117		company:08194273
+118		company:08156955
+119		company:08321322
+120		company:07890869
+121		company:07889474
+122		company:08160093
+123		company:06553173
+124		company:07470285
+125		company:07246485
+126		company:07109892
+127		company:07514639
+128		company:08647797
+129		company:08822622
+130		company:07229092
+131		company:08647735
+132		company:08752855
+133		company:08528298
+134		company:08656101
+135		company:08160189
+136		company:08264283
+137		company:08160286
+138		company:08160286
+139		company:06969482
+140		company:08871100
+141		company:08165701
+142		company:08334627
+143		company:08160073
+144		company:08167897
+145		company:07101375
+146	Westlands School Trust	
+147		company:08159859
+148		company:07512902
+149		company:07393006
+150		company:07240624
+151		company:06998729
+152		company:07388613
+153		company:09162295
+154		company:06997931
+155		company:07344436
+156		company:07337220
+157		company:07320062
+158		company:07217965
+159		company:07743582
+160		company:06314840
+161		company:06852829
+162		company:07000751
+163		company:07005864
+164		company:06861495
+165		company:07743582
+166		company:07415377
+167		company:08161698
+168		company:06893415
+169		company:07475330
+170		company:06893415
+171		company:06793576
+172		company:07035082
+173		company:07722857
+174		company:06841092
+175		company:06389366
+176		company:06770414
+177		company:06682621
+178		company:07654281
+179		company:07320081
+180		company:07182663
+181		company:06966733
+182		company:07701959
+183		company:06958522
+184		company:07265955
+185	The WELL (Wellbeing, Enterprise, Leadership and Learning) Trust	
+186		company:06672194
+187		company:07662251
+188		company:09180154
+189		company:07662251
+190		company:06910125
+191		company:08754672
+192		company:07041876
+193		company:06566468
+194	Lodge Park Technology College Trust	
+195		company:06356262
+196		company:08330680
+197		company:08124589
+198		company:06672308
+199		company:07322811
+200		company:07112008
+201		company:08160314
+202		company:07817715
+203		company:07299390
+204		company:08045239
+205		company:06953695
+206		company:08160117
+207		company:08159883
+208		company:09069228
+209		company:08011890
+210		company:09345706
+211		company:09648759
+212		company:06968373
+213		company:07210717
+214		company:07351263
+215		company:07299390
+216		company:08272480
+217		company:07066757
+218		company:06998382
+219	The SWISS Trust	
+220		company:07061920
+221		company:06809829
+222		company:06860258
+223		company:08645319
+224		company:04915796
+225		company:07365748
+226		company:04967658
+227		company:05319170
+228		company:07207113
+229		company:02236171
+230		company:02303464
+231		company:04439859
+232		company:08462144
+233		company:05342164
+234		company:05067702
+235		company:07131649
+236		company:07875308
+237		company:05102934
+238		company:07001636
+239		company:08624963
+240		company:05195911
+241		company:06794689
+242		company:06781652
+243		company:06228587
+244		company:05112090
+245		company:07054131
+246		company:05037949
+247	The Kings College of Arts Trust	
+248		company:07268568
+249		company:07267502
+250	Kings Community Trust	
+251		company:08684375
+252		company:07738951
+253		company:07680729
+254		company:05853746
+255		company:07163598
+256		company:07820834
+257		company:04930419
+258		company:04220486
+259		company:06590752
+260		company:06929638
+261		company:04251277
+262		company:07205479
+263		company:04357009
+264		company:04701198
+265		company:07468210
+266		company:06207590
+267		company:04504128
+268		company:04418245
+269		company:04268208
+270		company:04544722
+271		company:05398529
+272		company:05412502
+273		company:04444278
+274		company:07082675
+275	The Green Lane Co-operative Learning Trust	
+276		company:04468267
+277		company:07435548
+278		company:04302474
+279		company:04389132
+280		company:07004086
+281		company:08796668
+282	Christchurch Learning Partnership and Church of England	
+283		company:04798185
+284		company:05051218
+285		company:04916397
+286		company:06649728
+287		company:02535091
+288		company:02387916
+289		company:05978522
+290		company:06336693
+291		company:06000347
+292		company:06717593
+293		company:05115594
+294		company:06982127
+295		company:05090788
+296		company:05144640
+297	Marsh Academy Trust, The	
+298		company:06182612
+299		company:02336587
+300		company:06207067
+301		company:02400784
+302		company:06246929
+303		company:06162865
+304		company:02484729
+305		company:05958361
+306		company:05508735
+307		company:06272751
+308		company:02490773
+309		company:05735093
+310		company:06221748
+311		company:06422162
+312		company:06237630
+313		company:06176090
+314		company:06462935
+315		company:06516626
+316		company:05670663
+317		company:06511936
+318		company:06548296
+319		company:06091123
+320		company:06426966
+321		company:05598063
+322		company:06544825
+323		company:06311127
+324		company:05975733
+325		company:06269025
+326		company:05358533
+327		company:06627459
+328		company:08737435
+329		company:06625091
+330		company:08762217
+331		company:06192615
+332		company:08238194
+333		company:01532445
+334		company:06493485
+335		company:06621108
+336		company:06543442
+337		company:02268092
+338		company:06194070
+339		company:06616879
+340		company:06415729
+341		company:06221293
+342		company:06731593
+343		company:07498323
+344		company:06457394
+345		company:06705652
+346		company:06268570
+347		company:06964300
+348		company:06382192
+349	North East Lincolnshire Joint Church School Trust Limited	
+350	Endeavour Educational Trust	
+351		company:06731528
+352		company:06772181
+353		company:06740940
+354		company:06735003
+355		company:06933010
+356		company:07189647
+357		company:06745367
+358		company:06864339
+359		company:06653439
+360		company:06912857
+361		company:06308595
+362		company:06934137
+363		company:06888873
+364		company:06526376
+365		company:07958615
+366		company:06960253
+367		company:06895426
+368		company:06929486
+369		company:07386086
+370		company:06802948
+371		company:06545396
+372		company:06853140
+373		company:06976884
+374		company:06995649
+375		company:06914263
+376		company:07375267
+377		company:06929082
+378		company:06969900
+379	The EWO Community School Group	
+380	Cowes Parthfinder Partnership	
+381		company:06831538
+382		company:07033915
+383		company:07087804
+384		company:00097256
+385		company:07407883
+386		company:06969741
+387		company:06747095
+388		company:07035556
+389		company:06897239
+390		company:07747126
+391		company:07145434
+392		company:06754335
+393		company:07181660
+394		company:07185018
+395		company:07359755
+396		company:07034121
+397		company:07185357
+398		company:07148158
+399		company:06672920
+400		company:06628631
+401		company:07115882
+402		company:06543682
+403		company:07103919
+404		company:07035041
+405		company:07211219
+406		company:07599308
+407		company:07002160
+408		company:07348231
+409		company:07191874
+410		company:06741989
+411		company:07194412
+412		company:06397195
+413		company:07208598
+414		company:07209122
+415		company:07035327
+416		company:07346144
+417		company:07349394
+418		company:08085503
+419		company:09320523
+420		company:08144578
+421		company:07006159
+422		company:07134810
+423		company:08075785
+424		company:07451553
+425		company:07338780
+426		company:07278887
+427		company:08179349
+428		company:07977940
+429		company:07310176
+430		company:07852059
+431		company:07333133
+432		company:07346826
+433		company:07342848
+434		company:07344732
+435		company:07341583
+436		company:07347930
+437		company:07333089
+438		company:07345215
+439		company:07324340
+440		company:07348288
+441		company:07345756
+442		company:07344747
+443		company:07339625
+444		company:07352123
+445		company:07348329
+446		company:07355559
+447		company:07343156
+448		company:07338835
+449		company:07345831
+450		company:07348254
+451		company:07351253
+452		company:07353824
+453		company:07338767
+454		company:07351053
+455		company:07341553
+456		company:07341523
+457		company:07344277
+458		company:07335020
+459		company:07338707
+460		company:07333885
+461		company:08304460
+462		company:07361021
+463		company:07345430
+464		company:07380068
+465		company:07348116
+466		company:07331954
+467		company:07398941
+468		company:07375627
+469		company:07407844
+470		company:07365778
+471		company:07394649
+472		company:07384643
+473		company:07388635
+474		company:07400940
+475		company:07401373
+476		company:07387540
+477		company:07559901
+478		company:07401748
+479		company:07394671
+480		company:07400386
+481		company:07421140
+482		company:07343725
+483		company:07403352
+484		company:07380398
+485		company:07403361
+486		company:07416734
+487		company:07372222
+488		company:07372160
+489		company:07330691
+490		company:07379768
+491		company:07398467
+492		company:07401701
+493		company:07403271
+494		company:07363875
+495		company:07404747
+496		company:07345776
+497		company:07359630
+498		company:07414011
+499		company:07431423
+500		company:07368292
+501		company:07330058
+502		company:07416211
+503		company:07369704
+504		company:07318714
+505		company:07393519
+506		company:07437149
+507		company:07438425
+508		company:07419660
+509		company:07406122
+510		company:07430289
+511		company:07430317
+512		company:07453918
+513		company:07432995
+514		company:08364709
+515		company:07445493
+516		company:07461209
+517		company:07455732
+518		company:07466409
+519		company:07465343
+520		company:07411759
+521		company:07458631
+522		company:07386228
+523		company:07425374
+524		company:07452782
+525		company:07441463
+526		company:07455452
+527		company:07459742
+528		company:08961355
+529		company:07465520
+530		company:07451781
+531		company:07447459
+532		company:07452837
+533		company:07461173
+534		company:07451741
+535		company:07465701
+536		company:07441370
+537		company:07462885
+538		company:07458484
+539		company:07447497
+540		company:07464058
+541		company:07465249
+542		company:07185046
+543		company:07348167
+544		company:07466889
+545		company:07472190
+546		company:07445392
+547		company:07470621
+548		company:07442789
+549		company:07900244
+550		company:07469546
+551		company:07467445
+552		company:07455728
+553		company:07445586
+554		company:07451811
+555		company:07462530
+556		company:06477646
+557		company:07481145
+558		company:07477728
+559		company:07482650
+560		company:07485584
+561		company:07487455
+562		company:07498234
+563		company:07494754
+564		company:07475515
+565		company:07492094
+566		company:07492165
+567		company:08469218
+568		company:07477947
+569		company:07451660
+570		company:07483163
+571		company:07484717
+572		company:07472736
+573		company:07490390
+574		company:07484308
+575		company:07491945
+576		company:07520128
+577		company:07498923
+578		company:07525735
+579		company:07527090
+580		company:07527108
+581		company:07512962
+582		company:07500018
+583		company:07495541
+584		company:07489113
+585		company:07489127
+586		company:07466353
+587		company:07488870
+588		company:07495165
+589		company:07492198
+590		company:07504871
+591		company:07521946
+592		company:07525820
+593		company:07535683
+594		company:07527304
+595		company:07533362
+596		company:07530497
+597		company:07519888
+598		company:07518252
+599		company:07523546
+600		company:07523507
+601		company:07538380
+602		company:07517121
+603		company:07525856
+604		company:07539918
+605		company:07654346
+606		company:07524069
+607		company:07494620
+608		company:07546118
+609		company:07521640
+610		company:07553596
+611		company:07548791
+612		company:07557791
+613		company:07551986
+614		company:07536795
+615		company:07559818
+616		company:07548794
+617		company:07551989
+618		company:07533271
+619		company:07472799
+620		company:07524811
+621		company:07530418
+622		company:07545019
+623		company:07552631
+624		company:07552535
+625		company:07551088
+626		company:07551959
+627		company:07543202
+628		company:07557670
+629		company:07554121
+630		company:07556185
+631		company:07559170
+632		company:07563116
+633		company:07566298
+634		company:07570395
+635		company:07559537
+636		company:07554396
+637		company:07559439
+638		company:07563387
+639		company:07552598
+640		company:07563436
+641		company:07557883
+642		company:07557785
+643		company:07533308
+644		company:07559285
+645		company:07691947
+646		company:07561217
+647		company:07561268
+648		company:07566436
+649		company:07566455
+650		company:07561204
+651		company:07542114
+652		company:07557657
+653		company:07557886
+654		company:07558466
+655		company:07552665
+656		company:07557817
+657		company:07565242
+658		company:07536911
+659		company:07542166
+660		company:07566198
+661		company:07559293
+662		company:07489196
+663		company:07561574
+664		company:07552498
+665		company:07559256
+666		company:07552058
+667		company:07553717
+668		company:07515832
+669		company:07556657
+670		company:07523506
+671		company:07563329
+672		company:07564777
+673		company:07567230
+674		company:07511610
+675		company:07521636
+676		company:07559238
+677		company:07535379
+678		company:07547060
+679		company:07557900
+680		company:07566505
+681		company:07542155
+682		company:07566986
+683		company:07552735
+684		company:07563361
+685		company:07555066
+686		company:07552786
+687		company:07523557
+688		company:07534901
+689		company:07550425
+690		company:07554085
+691		company:07556117
+692		company:07525178
+693		company:07538459
+694		company:07538389
+695		company:07559610
+696		company:07523436
+697		company:07501579
+698		company:07544974
+699		company:07536970
+700		company:07485466
+701		company:07550474
+702		company:07664012
+703		company:07540256
+704		company:07557634
+705		company:07539214
+706		company:07530373
+707		company:07556159
+708		company:07557894
+709		company:07570315
+710		company:07556236
+711		company:07547039
+712		company:07560177
+713		company:07557831
+714		company:07548754
+715		company:07564519
+716		company:07547023
+717		company:07560175
+718		company:07561488
+719		company:07563345
+720		company:07535642
+721		company:07563213
+722		company:07523884
+723		company:07562194
+724		company:07543874
+725		company:07548734
+726		company:07565088
+727		company:07546874
+728		company:07531756
+729		company:07554117
+730		company:07538467
+731		company:07557868
+732		company:07552519
+733		company:07552702
+734		company:07566835
+735		company:07566528
+736		company:07573614
+737		company:07569727
+738		company:08743560
+739		company:07553531
+740		company:07531811
+741		company:07538730
+742		company:07542211
+743		company:07561306
+744		company:07540236
+745		company:07491215
+746		company:07543834
+747		company:07547393
+748		company:07560660
+749		company:07521584
+750		company:07564749
+751		company:07272906
+752		company:07559614
+753		company:07588418
+754		company:07493622
+755		company:07533254
+756		company:07546141
+757		company:07612865
+758		company:07562918
+759		company:07532146
+760		company:07604183
+761		company:07577113
+762		company:07596997
+763		company:07545681
+764		company:07597324
+765		company:07597390
+766		company:07524244
+767		company:07586346
+768		company:07584611
+769		company:07596422
+770		company:07592309
+771		company:07595434
+772		company:07588464
+773		company:07584063
+774		company:07606250
+775		company:07601846
+776		company:07597686
+777		company:07591948
+778		company:07601680
+779		company:07469330
+780		company:07195175
+781		company:07493696
+782		company:07627110
+783		company:07226557
+784		company:07628943
+785		company:07578861
+786		company:08782544
+787		company:07606026
+788		company:07631213
+789		company:07606409
+790		company:07621395
+791		company:07625308
+792		company:07623418
+793		company:07588104
+794		company:07638979
+795		company:07638999
+796		company:07633215
+797		company:07611347
+798		company:07630164
+799		company:07618351
+800		company:07611345
+801		company:07543893
+802		company:07614421
+803		company:07638417
+804		company:07625556
+805		company:07605059
+806		company:07348580
+807		company:07635527
+808		company:07588097
+809		company:07610791
+810		company:07633715
+811		company:07628903
+812		company:07627961
+813		company:07534695
+814		company:08098956
+815		company:07622171
+816		company:07629129
+817		company:07626526
+818		company:07635770
+819		company:07627302
+820		company:07635432
+821		company:07633694
+822		company:07631985
+823		company:07451568
+824		company:07313138
+825		company:07408229
+826		company:07452885
+827		company:07656715
+828		company:07657277
+829		company:07670723
+830		company:07626956
+831		company:07652476
+832		company:07597068
+833		company:07667407
+834		company:07658688
+835		company:07664322
+836		company:07657806
+837		company:07657794
+838		company:07664284
+839		company:07663689
+840		company:07611275
+841		company:07657307
+842		company:07633357
+843		company:07641618
+844		company:07662809
+845		company:07666111
+846		company:07660968
+847		company:07654298
+848		company:07660971
+849		company:07660783
+850		company:07610916
+851		company:07481956
+852		company:08187216
+853		company:07633379
+854		company:07659069
+855		company:07660247
+856		company:07666213
+857		company:07663795
+858		company:07654628
+859		company:07540802
+860		company:07540811
+861		company:07821367
+862		company:07633375
+863		company:07657605
+864		company:07657923
+865		company:07657741
+866		company:07638800
+867		company:07660159
+868		company:07650609
+869		company:07635510
+870		company:07655662
+871		company:07661205
+872		company:07652964
+873		company:07662289
+874		company:07655651
+875		company:07538386
+876		company:07654219
+877		company:07669035
+878		company:07665396
+879		company:07652902
+880		company:07628909
+881		company:07634426
+882		company:07682284
+883		company:07668923
+884		company:07654237
+885		company:07657910
+886		company:07652792
+887		company:07664288
+888		company:07657852
+889		company:07652306
+890		company:07662765
+891		company:07671404
+892		company:07671949
+893		company:07664297
+894		company:07662023
+895		company:07663864
+896		company:07649091
+897		company:07669416
+898		company:07661164
+899		company:07654164
+900		company:07547311
+901		company:07569743
+902		company:07665387
+903		company:07669314
+904		company:07635098
+905		company:07645774
+906		company:07657731
+907		company:07665225
+908		company:07657751
+909		company:07656245
+910		company:07553984
+911		company:07643712
+912		company:07677510
+913		company:07665364
+914		company:07649832
+915		company:07666185
+916		company:07506598
+917		company:07694050
+918		company:07556132
+919		company:07471707
+920		company:07246113
+921		company:06832416
+922		company:07463031
+923		company:07736425
+924		company:07680513
+925		company:07694080
+926		company:07680770
+927		company:07702211
+928		company:07697587
+929		company:07700317
+930		company:07690054
+931		company:07691820
+932		company:07671637
+933		company:07696114
+934		company:07683660
+935		company:07681739
+936		company:07694044
+937		company:07709270
+938		company:07698914
+939		company:07695458
+940		company:07660690
+941		company:07694399
+942		company:07695916
+943		company:07710532
+944		company:07680422
+945		company:07696999
+946		company:07696905
+947		company:07696728
+948		company:07697002
+949		company:07698974
+950		company:07694641
+951		company:07730920
+952		company:07633705
+953		company:07699775
+954		company:07697600
+955		company:07660995
+956		company:07703784
+957		company:07687619
+958		company:07688240
+959		company:07703931
+960		company:07678864
+961		company:07698578
+962		company:07689749
+963		company:07687722
+964		company:07646836
+965		company:07686458
+966		company:07687897
+967		company:07697400
+968		company:07693853
+969		company:07687663
+970		company:07867577
+971		company:07703829
+972		company:07635467
+973		company:07700494
+974		company:07687474
+975		company:07686515
+976		company:07413883
+977		company:07694358
+978		company:07697027
+979		company:07698718
+980		company:07697698
+981		company:07698504
+982		company:07690023
+983		company:07684902
+984		company:07681226
+985		company:07696498
+986		company:07698658
+987		company:07696921
+988		company:07698296
+989		company:07691324
+990		company:07705552
+991		company:07690473
+992		company:07690125
+993		company:07687135
+994		company:07693827
+995		company:07659444
+996		company:07656224
+997		company:07656265
+998		company:07656262
+999		company:07676490
+1000		company:07656363
+1001		company:07692668
+1002		company:07670511
+1003		company:07694547
+1004		company:07647327
+1005		company:07655702
+1006		company:07673903
+1007		company:07682294
+1008		company:07696069
+1009		company:07698410
+1010		company:07694563
+1011		company:07698037
+1012		company:07700838
+1013		company:07698904
+1014		company:07669263
+1015		company:07672441
+1016		company:07597883
+1017		company:07943613
+1018		company:07698731
+1019		company:07671255
+1020		company:07681857
+1021		company:07697045
+1022		company:07689613
+1023		company:07683702
+1024		company:07677142
+1025		company:07696148
+1026		company:07698789
+1027		company:07697798
+1028		company:07696155
+1029		company:07638756
+1030		company:07694228
+1031		company:07697482
+1032		company:07692440
+1033		company:07700362
+1034		company:07697044
+1035		company:07707979
+1036		company:07685923
+1037		company:07617529
+1038		company:07690414
+1039		company:07701920
+1040		company:07698506
+1041		company:07715613
+1042		company:07673871
+1043		company:07695624
+1044		company:07657427
+1045		company:07685645
+1046		company:07687235
+1047		company:07692130
+1048		company:07706667
+1049		company:07695364
+1050		company:07700556
+1051		company:07692339
+1052		company:07717015
+1053		company:07693860
+1054		company:07697356
+1055		company:07713512
+1056		company:07699705
+1057		company:07695684
+1058		company:07672980
+1059		company:07698875
+1060		company:07705259
+1061		company:07687709
+1062		company:07690250
+1063		company:07663935
+1064		company:07674473
+1065		company:07709271
+1066		company:07697658
+1067		company:07688230
+1068		company:07701954
+1069		company:07679051
+1070		company:07697086
+1071		company:07667168
+1072		company:07697367
+1073		company:07700776
+1074		company:07972029
+1075		company:07708713
+1076		company:07692325
+1077		company:07633402
+1078		company:07677838
+1079		company:07704020
+1080		company:07693574
+1081		company:07706900
+1082		company:07704968
+1083		company:07685796
+1084		company:07700206
+1085		company:07675238
+1086		company:07695736
+1087		company:07700251
+1088		company:07698978
+1089		company:07695401
+1090		company:07700773
+1091		company:07695709
+1092		company:07693936
+1093		company:07024902
+1094		company:07704001
+1095		company:07703941
+1096		company:07689986
+1097		company:07682819
+1098		company:07685652
+1099		company:07706741
+1100		company:07697504
+1101		company:07690119
+1102		company:07702119
+1103		company:07687178
+1104		company:07694362
+1105		company:07705438
+1106		company:07664348
+1107		company:07690395
+1108		company:07646748
+1109		company:07584372
+1110		company:07649769
+1111		company:07654882
+1112		company:07654273
+1113		company:07820566
+1114		company:07705100
+1115		company:07683980
+1116		company:07671174
+1117		company:07693309
+1118		company:07693365
+1119		company:07672683
+1120		company:07686390
+1121		company:07682993
+1122		company:07694530
+1123		company:07681811
+1124		company:07698859
+1125		company:07695977
+1126		company:07695796
+1127		company:07700728
+1128		company:07692638
+1129		company:07682311
+1130		company:07698197
+1131		company:07687770
+1132		company:07654902
+1133		company:07687583
+1134		company:07678672
+1135		company:07693743
+1136		company:07695172
+1137		company:07646003
+1138		company:07690776
+1139		company:07686145
+1140		company:07697070
+1141		company:07697483
+1142		company:07694325
+1143		company:07695505
+1144		company:07697158
+1145		company:07682300
+1146		company:07711826
+1147		company:07686371
+1148		company:07687947
+1149		company:07702046
+1150		company:07681848
+1151		company:07682332
+1152		company:07698461
+1153		company:07698631
+1154		company:07680823
+1155		company:07697618
+1156		company:07700611
+1157		company:07705878
+1158		company:07662414
+1159		company:07696117
+1160		company:07633408
+1161		company:07693870
+1162		company:07686578
+1163		company:07694023
+1164		company:07697067
+1165		company:07691867
+1166		company:07698406
+1167		company:07693715
+1168		company:07697132
+1169		company:07594562
+1170		company:07718351
+1171		company:07647805
+1172		company:07700909
+1173		company:07706776
+1174		company:07724780
+1175		company:07723151
+1176		company:07697117
+1177		company:07695771
+1178		company:07719857
+1179		company:07714121
+1180		company:07713345
+1181		company:07712850
+1182		company:07672781
+1183		company:07695504
+1184		company:07705465
+1185		company:07718002
+1186		company:07732889
+1187		company:07696173
+1188		company:07718480
+1189		company:07713540
+1190		company:07703797
+1191		company:07665828
+1192		company:07699625
+1193		company:07716057
+1194		company:07696989
+1195		company:07716911
+1196		company:07697023
+1197		company:07698729
+1198		company:07692394
+1199		company:07703800
+1200		company:07662709
+1201		company:07471734
+1202		company:07705402
+1203		company:07721594
+1204		company:07733196
+1205		company:07740632
+1206		company:07719076
+1207		company:07718680
+1208		company:07717189
+1209		company:07706760
+1210		company:07662135
+1211		company:07686209
+1212		company:07721932
+1213		company:07744525
+1214		company:07712946
+1215		company:07730938
+1216		company:07739194
+1217		company:07697177
+1218		company:07715667
+1219		company:07729878
+1220		company:07719620
+1221		company:07734360
+1222		company:07743646
+1223		company:07680339
+1224		company:07727786
+1225		company:07693338
+1226		company:07729766
+1227		company:07697281
+1228		company:07668839
+1229		company:07714867
+1230		company:07712779
+1231		company:07728828
+1232		company:07671440
+1233		company:07654127
+1234		company:07697485
+1235		company:07962974
+1236		company:07734205
+1237		company:07712579
+1238		company:07727826
+1239		company:07695342
+1240		company:07736524
+1241		company:07740516
+1242		company:07735863
+1243		company:07720181
+1244		company:07727974
+1245		company:07713287
+1246		company:07695544
+1247		company:07714167
+1248		company:07710807
+1249		company:07673775
+1250		company:07733200
+1251		company:07731186
+1252		company:07732879
+1253		company:07685660
+1254		company:07705363
+1255		company:07689980
+1256		company:07725629
+1257		company:07726649
+1258		company:07726907
+1259		company:07671486
+1260		company:07723349
+1261		company:07724916
+1262		company:07728940
+1263		company:07743523
+1264		company:07709421
+1265		company:07743627
+1266		company:07726858
+1267		company:07737159
+1268		company:07733363
+1269		company:07731277
+1270		company:07728029
+1271		company:07728054
+1272		company:07654130
+1273		company:07732537
+1274		company:07733864
+1275		company:07803969
+1276		company:07728265
+1277	Priory School	
+1278		company:07740815
+1279		company:07706726
+1280		company:07724342
+1281		company:07736180
+1282		company:07645519
+1283		company:07732888
+1284		company:08452281
+1285		company:07698419
+1286		company:08296921
+1287		company:07737429
+1288		company:07736246
+1289		company:07732027
+1290		company:07733109
+1291		company:07711928
+1292		company:07710870
+1293		company:07669751
+1294		company:07745881
+1295		company:07717215
+1296		company:07703865
+1297		company:07730940
+1298		company:07715043
+1299		company:07729412
+1300		company:07739514
+1301		company:07725111
+1302		company:07720110
+1303		company:08767870
+1304		company:07721470
+1305		company:07716479
+1306		company:07738386
+1307		company:07713374
+1308		company:07750051
+1309		company:07736212
+1310		company:07721109
+1311		company:07698469
+1312		company:07711925
+1313		company:07732319
+1314		company:07734231
+1315		company:08149299
+1316		company:07724160
+1317		company:07726568
+1318		company:07736448
+1319		company:07719938
+1320		company:07509409
+1321		company:03143086
+1322		company:06486255
+1323		company:07522245
+1324		company:07728112
+1325		company:01902341
+1326		company:07736095
+1327		company:07756219
+1328		company:07754698
+1329		company:07761675
+1330		company:07755713
+1331		company:07769026
+1332		company:07770592
+1333		company:07763421
+1334		company:07727564
+1335		company:07767222
+1336		company:07762548
+1337		company:07740758
+1338		company:07746787
+1339		company:07708890
+1340		company:07759302
+1341		company:07732559
+1342		company:07760509
+1343		company:08128513
+1344		company:07788628
+1345		company:07751232
+1346		company:07706488
+1347		company:07761713
+1348		company:07737398
+1349		company:07772327
+1350		company:07769085
+1351		company:07745167
+1352		company:07648968
+1353		company:07772516
+1354		company:07728482
+1355		company:07770970
+1356		company:07778406
+1357		company:07747149
+1358		company:07697481
+1359		company:07717482
+1360		company:07738801
+1361		company:07768645
+1362		company:07769232
+1363		company:07737302
+1364		company:07774109
+1365		company:07559187
+1366		company:08187058
+1367		company:07768726
+1368		company:07807248
+1369		company:07788995
+1370		company:07811354
+1371		company:07796829
+1372		company:07795736
+1373		company:07790934
+1374		company:07738845
+1375		company:07799872
+1376		company:07722445
+1377		company:07801612
+1378		company:07807811
+1379		company:07808707
+1380		company:07770687
+1381		company:07816548
+1382		company:07807158
+1383		company:07807291
+1384		company:07808705
+1385		company:07796947
+1386		company:07798639
+1387		company:07808765
+1388		company:07800153
+1389		company:07808732
+1390		company:07817746
+1391		company:07800306
+1392		company:07807218
+1393		company:07798550
+1394		company:07800431
+1395		company:07804282
+1396		company:07799811
+1397		company:07773693
+1398		company:07796938
+1399		company:07798183
+1400		company:07791971
+1401		company:07708603
+1402		company:07652661
+1403		company:07770605
+1404		company:07819870
+1405		company:07805262
+1406		company:07803827
+1407		company:07802563
+1408		company:07807398
+1409		company:07785550
+1410		company:07729759
+1411		company:07695881
+1412		company:07804043
+1413		company:07803743
+1414		company:07800252
+1415		company:07641004
+1416		company:07794825
+1417		company:07831395
+1418		company:07838151
+1419		company:07694573
+1420		company:07797058
+1421		company:07824714
+1422		company:07831414
+1423		company:07819872
+1424		company:07840925
+1425		company:07845283
+1426		company:07835788
+1427		company:07803789
+1428		company:07843166
+1429		company:07831255
+1430		company:07837770
+1431		company:07845627
+1432		company:07848566
+1433		company:08175471
+1434		company:07672607
+1435		company:07835950
+1436		company:07840838
+1437		company:07831080
+1438		company:07817806
+1439		company:07841414
+1440		company:07841435
+1441		company:07899845
+1442		company:07846848
+1443		company:07800664
+1444		company:07800029
+1445		company:07827368
+1446		company:07850551
+1447		company:07851471
+1448		company:07825856
+1449		company:07844795
+1450		company:07818029
+1451		company:07851205
+1452		company:07794423
+1453		company:07834715
+1454		company:07814065
+1455		company:07814150
+1456		company:07851097
+1457		company:07831292
+1458		company:07838203
+1459		company:07840060
+1460		company:07844791
+1461		company:07843573
+1462		company:09299975
+1463		company:07851337
+1464		company:07831507
+1465		company:07840804
+1466		company:07772345
+1467		company:07835845
+1468		company:07848632
+1469		company:07827747
+1470		company:07846823
+1471		company:07825848
+1472		company:07848338
+1473		company:07849858
+1474		company:07848372
+1475		company:07844587
+1476		company:07848367
+1477		company:07837778
+1478		company:07844874
+1479		company:07847454
+1480		company:07849654
+1481		company:07852122
+1482		company:07824369
+1483		company:07805677
+1484		company:07851937
+1485		company:07856680
+1486		company:07849731
+1487		company:07834711
+1488		company:07817708
+1489		company:07850292
+1490		company:07777372
+1491		company:07848445
+1492		company:07875164
+1493		company:07819429
+1494		company:07827591
+1495		company:07878966
+1496		company:07809637
+1497		company:07865663
+1498		company:07842369
+1499		company:07769103
+1500		company:07847190
+1501		company:07806338
+1502		company:07899393
+1503		company:07865850
+1504		company:07877078
+1505		company:07892678
+1506		company:07909140
+1507		company:07897108
+1508		company:07898331
+1509		company:07900248
+1510		company:07899198
+1511		company:07882159
+1512		company:07849180
+1513		company:07909371
+1514		company:07872725
+1515		company:07902880
+1516		company:07885568
+1517		company:07907463
+1518		company:07719016
+1519		company:08120960
+1520		company:07900439
+1521		company:07905433
+1522		company:07902662
+1523		company:07887259
+1524		company:07900532
+1525		company:07890590
+1526		company:07897243
+1527		company:07836684
+1528		company:07886416
+1529		company:07907633
+1530		company:07891230
+1531		company:07892732
+1532		company:07727695
+1533		company:07895684
+1534		company:07982966
+1535		company:07883174
+1536		company:07917752
+1537		company:07847021
+1538		company:07907388
+1539		company:07834300
+1540		company:08538844
+1541		company:07898905
+1542		company:07900254
+1543		company:07798627
+1544		company:07872799
+1545		company:07890769
+1546		company:07944160
+1547		company:07939260
+1548		company:07901900
+1549		company:07950949
+1550		company:07939747
+1551		company:07918561
+1552		company:07921744
+1553		company:07935515
+1554		company:07928558
+1555		company:07695419
+1556		company:07931627
+1557		company:07944253
+1558		company:07954211
+1559		company:07937154
+1560		company:07951293
+1561		company:07949111
+1562		company:07913261
+1563		company:07943555
+1564		company:07914400
+1565		company:07950827
+1566		company:07776910
+1567		company:07943378
+1568		company:07939655
+1569		company:07931886
+1570		company:07954417
+1571		company:07947961
+1572		company:07941524
+1573		company:07933810
+1574		company:07947381
+1575		company:07887953
+1576		company:07950851
+1577		company:07952451
+1578		company:07937317
+1579		company:07941899
+1580		company:07937266
+1581		company:07916763
+1582		company:07941140
+1583		company:07929429
+1584		company:07867334
+1585		company:07962216
+1586		company:07668955
+1587		company:07908404
+1588		company:07917745
+1589		company:07912930
+1590		company:07883446
+1591		company:07881889
+1592		company:07928028
+1593		company:07946986
+1594		company:07976516
+1595		company:07937939
+1596		company:07967402
+1597		company:07966182
+1598		company:07992440
+1599		company:07984125
+1600		company:07974098
+1601		company:07984073
+1602		company:07966187
+1603		company:07992372
+1604		company:07992438
+1605		company:07966500
+1606		company:07973327
+1607		company:07987596
+1608		company:07983995
+1609		company:07984843
+1610		company:07980335
+1611		company:07971651
+1612		company:07971665
+1613		company:07977442
+1614		company:07959980
+1615		company:07988521
+1616		company:07975551
+1617		company:07990029
+1618		company:07998451
+1619		company:07988495
+1620		company:07986921
+1621		company:07988497
+1622		company:07986090
+1623		company:07977368
+1624		company:08056907
+1625		company:07988540
+1626		company:07984221
+1627		company:07984413
+1628		company:07883254
+1629		company:07977150
+1630		company:07986805
+1631		company:09583593
+1632		company:07988376
+1633		company:07973953
+1634		company:07992899
+1635		company:07990655
+1636		company:07890613
+1637		company:07999942
+1638		company:07994219
+1639		company:07999988
+1640		company:07984453
+1641		company:07959096
+1642		company:07996350
+1643		company:07984238
+1644		company:07923329
+1645		company:07982740
+1646		company:07969062
+1647		company:07887796
+1648		company:07974434
+1649		company:07988355
+1650		company:07943227
+1651		company:07994514
+1652		company:07954363
+1653		company:07982312
+1654		company:07991877
+1655		company:07989226
+1656		company:08003969
+1657		company:07972070
+1658		company:07973980
+1659		company:07965316
+1660		company:07992842
+1661		company:08006711
+1662		company:07968898
+1663		company:07718539
+1664		company:07998122
+1665		company:07994012
+1666		company:07827237
+1667		company:07949154
+1668		company:07930349
+1669		company:07978124
+1670		company:07697171
+1671		company:07990434
+1672		company:07964360
+1673		company:07987239
+1674		company:07976179
+1675		company:07976019
+1676		company:07926573
+1677		company:08003909
+1678		company:08258994
+1679		company:07748248
+1680		company:07988444
+1681		company:08021855
+1682		company:08025958
+1683		company:08020070
+1684		company:08028084
+1685		company:08024353
+1686		company:08028789
+1687		company:08045401
+1688		company:08010464
+1689		company:07990619
+1690		company:08020467
+1691		company:08032410
+1692		company:07736364
+1693		company:07964133
+1694		company:08043695
+1695		company:08027943
+1696		company:09791051
+1697		company:08026134
+1698		company:08027879
+1699		company:07982516
+1700		company:08024396
+1701		company:07827963
+1702		company:07875747
+1703		company:07749786
+1704		company:08041135
+1705		company:08038063
+1706		company:08059055
+1707		company:07986218
+1708		company:08034402
+1709		company:08054506
+1710		company:08023322
+1711		company:08071851
+1712		company:08036395
+1713		company:08047328
+1714		company:08066451
+1715		company:08029445
+1716		company:08068528
+1717		company:08066279
+1718		company:08073873
+1719		company:08039629
+1720		company:08080096
+1721		company:08062065
+1722		company:08049033
+1723		company:08066610
+1724		company:08027205
+1725		company:07994038
+1726		company:08058921
+1727		company:08027885
+1728		company:08002543
+1729		company:08028387
+1730		company:08021829
+1731		company:08059041
+1732		company:08053276
+1733		company:08056328
+1734		company:08066324
+1735		company:08060671
+1736		company:07648389
+1737		company:07635438
+1738		company:07651573
+1739		company:07648654
+1740		company:07412515
+1741		company:07829616
+1742		company:08028375
+1743		company:07929335
+1744		company:08039319
+1745		company:08006892
+1746		company:08060721
+1747		company:08063683
+1748		company:08063334
+1749		company:09299605
+1750		company:08033193
+1751		company:08064698
+1752		company:07838126
+1753		company:08049062
+1754		company:07353849
+1755		company:08061075
+1756		company:07166427
+1757		company:07791933
+1758		company:07643477
+1759		company:07337888
+1760		company:07644208
+1761		company:07885963
+1762		company:08096798
+1763		company:07638748
+1764		company:07432586
+1765		company:07919427
+1766		company:07575016
+1767		company:07640769
+1768		company:07413872
+1769		company:08111431
+1770		company:07649385
+1771		company:07217174
+1772		company:07722672
+1773		company:07634106
+1774		company:07640198
+1775		company:07649335
+1776		company:07643890
+1777		company:08077362
+1778		company:08062508
+1779		company:07972037
+1780		company:08105941
+1781		company:08099606
+1782		company:08104080
+1783		company:08104190
+1784		company:08062622
+1785		company:08082185
+1786		company:08106388
+1787		company:08097265
+1788		company:08090890
+1789		company:08087508
+1790		company:08100149
+1791		company:08105758
+1792		company:08055393
+1793		company:09042916
+1794		company:08084557
+1795		company:08111345
+1796		company:08100409
+1797		company:08099098
+1798		company:09495671
+1799		company:08110847
+1800		company:08082405
+1801		company:08100578
+1802		company:08146330
+1803		company:08076310
+1804		company:08089397
+1805		company:08737412
+1806		company:08107310
+1807		company:08102628
+1808		company:08095169
+1809		company:08098352
+1810		company:08096750
+1811		company:07980317
+1812		company:08083620
+1813		company:08085808
+1814		company:08100620
+1815		company:08101591
+1816		company:08089246
+1817		company:08107655
+1818		company:08077289
+1819		company:08073889
+1820		company:08104111
+1821		company:08061303
+1822		company:08041206
+1823		company:08100518
+1824		company:07652211
+1825		company:08056991
+1826		company:08076374
+1827		company:08075363
+1828		company:08092358
+1829		company:08095439
+1830		company:07999861
+1831		company:08098354
+1832		company:08096699
+1833		company:07893665
+1834		company:07903002
+1835		company:07664278
+1836		company:07591868
+1837		company:08102584
+1838		company:08011930
+1839		company:07927423
+1840		company:08107711
+1841		company:07643795
+1842		company:08115121
+1843		company:07846852
+1844		company:08116706
+1845		company:08165736
+1846		company:08177570
+1847		company:08089704
+1848		company:08153765
+1849		company:08137772
+1850		company:08134861
+1851		company:07966826
+1852		company:08130502
+1853		company:08130508
+1854		company:08104539
+1855		company:08137421
+1856		company:08125396
+1857		company:08135761
+1858		company:08084047
+1859		company:08018275
+1860		company:08018237
+1861		company:08133360
+1862		company:08096772
+1863		company:08107212
+1864		company:08130468
+1865		company:08127108
+1866		company:08122579
+1867		company:08130302
+1868		company:08135372
+1869		company:08135868
+1870		company:08121030
+1871		company:08114513
+1872		company:08117139
+1873		company:08142275
+1874		company:08124416
+1875		company:08100344
+1876		company:08124615
+1877		company:08130253
+1878		company:08131708
+1879		company:08128214
+1880		company:08104201
+1881		company:08144566
+1882		company:08116954
+1883		company:08168307
+1884		company:09353480
+1885		company:08166526
+1886		company:08169229
+1887		company:08161468
+1888		company:08004986
+1889		company:08172988
+1890		company:08138965
+1891		company:08061092
+1892		company:08085993
+1893		company:08137363
+1894		company:08162613
+1895		company:08142572
+1896		company:08098007
+1897		company:08135389
+1898		company:08137451
+1899		company:08135122
+1900		company:08130158
+1901		company:08132067
+1902		company:08158718
+1903		company:08148546
+1904		company:08094234
+1905		company:08161246
+1906		company:08128432
+1907		company:08120037
+1908		company:08018146
+1909		company:08133686
+1910		company:08123168
+1911		company:07933749
+1912		company:08133047
+1913		company:07845470
+1914		company:07746561
+1915		company:07896123
+1916		company:07735646
+1917		company:08270151
+1918		company:08168245
+1919		company:09630999
+1920		company:07649122
+1921		company:05530130
+1922		company:08132137
+1923		company:07793458
+1924		company:08179242
+1925		company:07904096
+1926		company:08291666
+1927		company:08329993
+1928		company:08149829
+1929		company:08137486
+1930		company:08156535
+1931		company:08147330
+1932		company:08146138
+1933		company:08163458
+1934		company:08163424
+1935		company:08137701
+1936		company:08152109
+1937		company:08128803
+1938		company:08165319
+1939		company:08132338
+1940		company:08155184
+1941		company:08146633
+1942		company:08177657
+1943		company:08152049
+1944		company:08158400
+1945		company:08133601
+1946		company:08158582
+1947		company:08171632
+1948		company:08132353
+1949		company:08068464
+1950		company:08163445
+1951		company:08139885
+1952		company:08151355
+1953		company:08133675
+1954		company:08163457
+1955		company:08166270
+1956		company:08158619
+1957		company:08140768
+1958		company:08151601
+1959		company:08164849
+1960		company:08088957
+1961		company:08165744
+1962		company:08168042
+1963		company:08053288
+1964		company:08120128
+1965		company:08149765
+1966		company:08146452
+1967		company:08158232
+1968		company:08151281
+1969		company:08156927
+1970		company:08163448
+1971		company:08160225
+1972		company:08175402
+1973		company:08154932
+1974		company:08180623
+1975		company:08190187
+1976		company:08163191
+1977		company:08161745
+1978		company:08135633
+1979		company:08171341
+1980		company:08179498
+1981		company:08146396
+1982		company:08144490
+1983		company:08173271
+1984		company:08166938
+1985		company:08131158
+1986		company:08140850
+1987		company:08175642
+1988		company:08176968
+1989		company:08082204
+1990		company:08164889
+1991		company:08139427
+1992		company:08144135
+1993		company:08161921
+1994		company:08123602
+1995		company:08167333
+1996		company:08153776
+1997		company:08036151
+1998		company:08135574
+1999		company:08146661
+2000		company:08153550
+2001		company:08171068
+2002		company:08135395
+2003		company:08187197
+2004		company:08183461
+2005		company:08144271
+2006		company:08151859
+2007		company:08168813
+2008		company:08163499
+2009		company:08108086
+2010		company:08126953
+2011		company:08178033
+2012		company:08144420
+2013		company:08153177
+2014		company:07992852
+2015		company:08141618
+2016		company:08158309
+2017		company:08169622
+2018		company:08149761
+2019		company:08169571
+2020		company:08142724
+2021		company:08132405
+2022		company:08163433
+2023		company:08174462
+2024		company:08143249
+2025		company:07665550
+2026		company:07970052
+2027		company:08156759
+2028		company:08246275
+2029		company:08197381
+2030		company:08168510
+2031		company:08181149
+2032		company:08168237
+2033		company:08177181
+2034		company:08197353
+2035		company:08192900
+2036		company:08201675
+2037		company:08210494
+2038		company:08194349
+2039		company:08172647
+2040		company:08165692
+2041		company:08203218
+2042		company:08158225
+2043		company:08199843
+2044		company:08208767
+2045		company:08185432
+2046		company:08221351
+2047		company:08180450
+2048		company:08181927
+2049		company:08198980
+2050		company:08182289
+2051		company:08140747
+2052		company:08195720
+2053		company:08126868
+2054		company:08212425
+2055		company:08205021
+2056		company:07913309
+2057		company:08204075
+2058		company:08208522
+2059		company:08119703
+2060		company:08149796
+2061		company:08210739
+2062		company:08224216
+2063		company:08188507
+2064		company:08221228
+2065		company:08181858
+2066		company:08210466
+2067		company:08160433
+2068		company:08212263
+2069		company:08172888
+2070		company:07775671
+2071		company:08203318
+2072		company:08196566
+2073		company:07848783
+2074		company:08255653
+2075		company:08240680
+2076		company:09148479
+2077		company:08242198
+2078		company:08237106
+2079		company:08234858
+2080		company:08245853
+2081		company:08182064
+2082		company:08233527
+2083		company:08259654
+2084		company:08150822
+2085		company:08237807
+2086		company:08219443
+2087		company:08210410
+2088		company:08248173
+2089		company:08249250
+2090		company:07964015
+2091		company:08090074
+2092		company:08248063
+2093		company:08228024
+2094		company:08248059
+2095		company:08183463
+2096		company:08242856
+2097		company:08235194
+2098		company:08246313
+2099		company:08231964
+2100		company:08261780
+2101		company:08231721
+2102		company:08248966
+2103		company:08253770
+2104		company:08249992
+2105		company:08214798
+2106		company:08133703
+2107		company:08172039
+2108		company:08208801
+2109		company:08240918
+2110		company:08073959
+2111		company:08160195
+2112		company:08160034
+2113		company:08247528
+2114		company:08270802
+2115		company:08190591
+2116		company:08022455
+2117		company:08304433
+2118		company:08255492
+2119		company:08277622
+2120		company:08291623
+2121		company:08281046
+2122		company:08284164
+2123		company:08252316
+2124		company:08269066
+2125		company:08278118
+2126		company:08260020
+2127		company:08240864
+2128		company:08284371
+2129		company:08271760
+2130		company:08188239
+2131		company:08282041
+2132		company:08296540
+2133		company:08296506
+2134		company:08286418
+2135		company:08072758
+2136		company:08309965
+2137		company:08263591
+2138		company:08221088
+2139		company:08340120
+2140		company:08255683
+2141		company:07817737
+2142		company:08269215
+2143		company:08286030
+2144		company:08249884
+2145		company:08270314
+2146		company:08295240
+2147		company:08282834
+2148		company:08265058
+2149		company:08273802
+2150		company:08287012
+2151		company:08249779
+2152		company:08239056
+2153		company:08272256
+2154		company:08291492
+2155		company:08276210
+2156		company:08299166
+2157		company:07657235
+2158		company:08313162
+2159		company:08328369
+2160		company:08309048
+2161		company:08356745
+2162		company:08310900
+2163		company:08307881
+2164		company:08314283
+2165		company:08305764
+2166		company:08296889
+2167		company:08332696
+2168		company:08319810
+2169		company:08311200
+2170		company:08321679
+2171		company:08327233
+2172		company:08322915
+2173		company:07723861
+2174		company:08313108
+2175		company:08330173
+2176		company:08286295
+2177		company:08150106
+2178		company:08316633
+2179		company:08322127
+2180		company:08316719
+2181		company:08326476
+2182		company:08314293
+2183		company:08310027
+2184		company:08318511
+2185		company:08322813
+2186		company:08333159
+2187		company:08289609
+2188		company:08182235
+2189		company:08322707
+2190		company:08316327
+2191		company:08270275
+2192		company:08326570
+2193		company:08321824
+2194		company:08314056
+2195		company:08326579
+2196		company:08225755
+2197		company:08310825
+2198		company:08319098
+2199		company:09692191
+2200		company:08314146
+2201		company:07793019
+2202		company:08324412
+2203		company:08303773
+2204		company:08138372
+2205		company:08298534
+2206		company:08231006
+2207		company:08207095
+2208		company:08671076
+2209		company:08320065
+2210		company:08310694
+2211		company:08407961
+2212		company:06346630
+2213		company:07745424
+2213		company:08643881
+2214		company:08574692
+2215		company:08544741
+2216		company:08438964
+2217		company:07667999
+2218		company:08509022
+2219		company:07652565
+2220		company:08528914
+2221		company:08335073
+2222		company:08293293
+2223		company:08355037
+2224		company:08353034
+2225		company:08330578
+2226		company:08360915
+2227		company:08321599
+2228		company:08331385
+2229		company:08354009
+2230		company:08358124
+2231		company:08319686
+2232		company:08359889
+2233		company:08261114
+2234		company:08368979
+2235		company:08357352
+2236		company:08337745
+2237		company:08347877
+2238		company:08352159
+2239		company:08347874
+2240		company:08334718
+2241		company:08333208
+2242		company:08354212
+2243		company:08351355
+2244		company:08357097
+2245		company:08366005
+2246		company:08359584
+2247		company:08156641
+2248		company:08395421
+2249		company:08385139
+2250		company:08383047
+2251		company:08391101
+2252		company:08375925
+2253		company:08384805
+2254		company:08397975
+2255		company:08379788
+2256		company:08379733
+2257		company:08399801
+2258		company:08071176
+2259		company:08403703
+2260		company:08148675
+2261		company:08399769
+2262		company:08398143
+2263		company:08387242
+2264		company:08257392
+2265		company:08278808
+2266		company:08303681
+2267		company:08285812
+2268		company:07637061
+2269		company:08397744
+2270		company:07613612
+2271		company:08203228
+2272		company:08407989
+2273		company:08422015
+2274		company:08438686
+2275		company:08174233
+2276		company:08432486
+2277		company:07948348
+2278		company:07950891
+2279		company:07906423
+2280		company:08619729
+2281		company:07956455
+2282		company:07645326
+2283		company:08353051
+2284		company:07648803
+2285		company:08526973
+2286		company:09035788
+2287		company:08423518
+2288		company:08423539
+2289		company:08424090
+2290		company:08414933
+2291		company:08403949
+2292		company:08436371
+2293		company:08434359
+2294		company:08444133
+2295		company:08447216
+2296		company:08425359
+2297		company:08405075
+2298		company:08439425
+2299		company:08440868
+2300		company:08437300
+2301		company:08407889
+2302		company:08441554
+2303		company:08441736
+2304		company:08446789
+2305		company:08441458
+2306		company:08425914
+2307		company:08432565
+2308		company:08425918
+2309		company:08391057
+2310		company:08287618
+2311		company:08008193
+2312		company:08453966
+2313		company:08407871
+2314		company:08432347
+2315		company:08436037
+2316		company:08418435
+2317		company:08432234
+2318		company:08364273
+2319		company:08204680
+2320		company:08441848
+2321		company:08286818
+2322		company:08444770
+2323		company:08439184
+2324		company:08447546
+2325		company:09017776
+2326		company:08424154
+2327		company:08382383
+2328		company:08445158
+2329		company:08422944
+2330		company:08438991
+2331		company:08240619
+2332		company:08411590
+2333		company:08425513
+2334		company:08370592
+2335		company:08395383
+2336		company:08542806
+2337		company:08353730
+2338		company:08462151
+2339		company:08248830
+2340		company:08434113
+2341		company:08410002
+2342		company:08434199
+2343		company:08434141
+2344		company:08434233
+2345		company:07844694
+2346		company:08401607
+2347		company:08454781
+2348		company:08442124
+2349		company:08445776
+2350		company:08426682
+2351		company:07662701
+2352		company:08445314
+2353		company:08436788
+2354		company:07916297
+2355		company:08486531
+2356		company:07949294
+2357		company:07963778
+2358		company:07958546
+2359		company:08497028
+2360		company:08561049
+2361		company:07644380
+2362		company:07781921
+2363		company:07962246
+2364		company:07952786
+2365		company:07923624
+2366		company:07641673
+2367		company:07937849
+2368		company:08270125
+2369		company:08484553
+2370		company:08372064
+2371		company:08426360
+2372		company:08472117
+2373		company:08451827
+2374		company:08462512
+2375		company:08174123
+2376		company:08476253
+2377		company:07909397
+2378		company:08482398
+2379		company:08441991
+2380		company:08466505
+2381		company:08479066
+2382		company:08474090
+2383		company:08473899
+2384		company:08432506
+2385		company:08426992
+2386		company:08239113
+2387		company:08228379
+2388		company:08623002
+2389		company:08840373
+2390		company:07962209
+2391		company:07956691
+2392		company:07311261
+2393		company:07955870
+2394		company:08699493
+2395		company:07941664
+2396		company:07874411
+2397		company:07638089
+2398		company:07960515
+2399		company:08528776
+2400		company:08545109
+2401		company:08565932
+2402		company:07864383
+2403		company:07954683
+2404		company:07649183
+2405		company:07652696
+2406		company:07923267
+2407		company:07645462
+2408		company:06846720
+2409		company:08562954
+2410		company:08366199
+2411		company:08476149
+2412		company:07954396
+2413		company:07647538
+2414		company:07947806
+2415		company:08515862
+2416		company:08510814
+2417		company:08512087
+2418		company:08482129
+2419		company:08511781
+2420		company:08418341
+2421		company:08428466
+2422		company:08527173
+2423		company:08528845
+2424		company:08512105
+2425		company:08508903
+2426		company:08431840
+2427		company:08496781
+2428		company:08517429
+2429		company:08515149
+2430		company:08500778
+2431		company:08483768
+2432		company:08516551
+2433		company:08517255
+2434		company:08524638
+2435		company:08518704
+2436		company:08472283
+2437		company:08514901
+2438		company:08520569
+2439		company:08516562
+2440		company:07647432
+2441		company:07654340
+2442		company:07956784
+2443		company:07956473
+2444		company:07960235
+2445		company:07650619
+2446		company:07742547
+2447		company:08331922
+2448		company:08285206
+2449		company:07945230
+2450		company:08339345
+2451		company:07653051
+2452		company:07952925
+2453		company:08436285
+2454		company:08578428
+2455		company:07945060
+2456		company:07962059
+2457		company:08521080
+2458		company:08426967
+2459		company:08534233
+2460		company:08550180
+2461		company:08464996
+2462		company:08170071
+2463		company:08567252
+2464		company:08565046
+2465		company:08561360
+2466		company:08557883
+2467		company:08563159
+2468		company:08540699
+2469		company:08537140
+2470		company:08506178
+2471		company:08560721
+2472		company:08565187
+2473		company:08550854
+2474		company:08561329
+2475		company:08572815
+2476		company:08520286
+2477		company:08566185
+2478		company:08579939
+2479		company:08536774
+2480		company:08572898
+2481		company:08388074
+2482		company:08543210
+2483		company:08543748
+2484		company:08559647
+2485		company:08514898
+2486		company:08543115
+2487		company:08543217
+2488		company:08561153
+2489		company:08561302
+2490		company:08531479
+2491		company:08523370
+2492		company:08220540
+2493		company:07549443
+2494		company:07954295
+2495		company:08735454
+2496		company:08478985
+2497		company:08610377
+2498		company:07953395
+2499		company:07949213
+2500		company:08644023
+2501		company:08595545
+2502		company:08374351
+2503		company:08178309
+2504		company:07930340
+2505		company:08334593
+2506		company:08608287
+2507		company:08155088
+2508		company:08604037
+2509		company:07754077
+2510		company:08602255
+2511		company:08612100
+2512		company:08563153
+2513		company:08576916
+2514		company:08621334
+2515		company:08608665
+2516		company:00198131
+2517		company:08606536
+2518		company:08259069
+2519		company:08550403
+2520		company:08586085
+2521		company:08496504
+2522		company:07926597
+2523		company:08769073
+2524		company:07959449
+2525		company:08670427
+2526		company:08665067
+2527		company:08670599
+2528		company:08603388
+2529		company:08526440
+2530		company:08556180
+2531		company:08638158
+2532		company:08368756
+2533		company:08569207
+2534		company:08549807
+2535		company:08610504
+2536		company:08488749
+2537		company:08621035
+2538		company:08599141
+2539		company:08632733
+2540		company:08587865
+2541		company:08622047
+2542		company:08628905
+2543		company:08638766
+2544		company:08314692
+2545		company:08594520
+2546		company:08604799
+2547		company:08564471
+2548		company:09476660
+2549		company:08612061
+2550		company:08617343
+2551		company:08603078
+2552		company:08597784
+2553		company:08589470
+2554		company:08638398
+2555		company:08623229
+2556		company:08634384
+2557		company:08550110
+2558		company:08621310
+2559		company:08611863
+2560		company:08597962
+2561		company:08627834
+2562		company:08608177
+2563		company:08599777
+2564		company:08339302
+2565		company:08624157
+2566		company:08588099
+2567		company:08644320
+2568		company:08591050
+2569		company:08593820
+2570		company:08623343
+2571		company:08621160
+2572		company:07898669
+2573		company:08813173
+2574		company:08709542
+2575		company:08709656
+2576		company:08786812
+2577		company:08878604
+2578		company:07649550
+2579		company:05888220
+2580		company:08232396
+2581		company:07925067
+2582		company:07951118
+2583		company:07702460
+2584		company:08334745
+2585		company:08589525
+2586		company:08702006
+2587		company:08682513
+2588		company:08674696
+2589		company:08554393
+2590		company:08669464
+2591		company:08682863
+2592		company:08640614
+2593		company:08658210
+2594		company:08610537
+2595		company:08654591
+2596		company:08657975
+2597		company:08684289
+2598		company:08682547
+2599		company:08682479
+2600		company:08678162
+2601		company:08663956
+2602		company:08423592
+2603		company:08430135
+2604		company:08290708
+2605		company:08576427
+2606		company:08657831
+2607		company:08637890
+2608		company:08661374
+2609		company:08658515
+2610	Robin Hood Academy	
+2611		company:07911604
+2612		company:08859774
+2613		company:08699391
+2614		company:08722556
+2615		company:08722647
+2616		company:08732018
+2617		company:08713217
+2618		company:08657945
+2619		company:08712137
+2620		company:08709352
+2621		company:08663011
+2622		company:08714452
+2623		company:08684300
+2624		company:08714241
+2625		company:08565135
+2626		company:08661539
+2627		company:08731777
+2628		company:08615792
+2629		company:08713214
+2630		company:08727883
+2631		company:08701329
+2632		company:08667123
+2633		company:08741704
+2634		company:08738750
+2635		company:08698831
+2636		company:08702056
+2637		company:08693259
+2638		company:08681270
+2639		company:08718104
+2640		company:08529006
+2641		company:08289583
+2642		company:08745639
+2643		company:08656655
+2644		company:08881720
+2645		company:08335297
+2646		company:08823327
+2647		company:08451787
+2648		company:09007740
+2649		company:09323071
+2650		company:08711161
+2651		company:08775910
+2652		company:08728422
+2653		company:08719689
+2654		company:08722529
+2655		company:08722710
+2656		company:08603037
+2657		company:08689696
+2658		company:08597878
+2659		company:08745045
+2660		company:08763832
+2661		company:08760817
+2662		company:08753719
+2663		company:08752701
+2664		company:08759430
+2665		company:08741949
+2666		company:08781513
+2667		company:08756412
+2668		company:08725920
+2669		company:08775996
+2670		company:08769758
+2671		company:08612065
+2672		company:08738224
+2673		company:08739625
+2674		company:08766799
+2675		company:08749379
+2676		company:08217604
+2677		company:08795983
+2678		company:08718062
+2679		company:08787650
+2680		company:08779660
+2681		company:08803924
+2682		company:08803916
+2683		company:08803858
+2684		company:08791046
+2685		company:08749901
+2686		company:08591532
+2687		company:08792831
+2688		company:08156955
+2689		company:08795464
+2690		company:08601624
+2691		company:08176019
+2692		company:08748904
+2693		company:08706247
+2694		company:08802427
+2695		company:08810960
+2696		company:08738846
+2697		company:08792911
+2698		company:08754658
+2699		company:08582084
+2700		company:08798425
+2701		company:08803871
+2702		company:07652401
+2703		company:08738949
+2704		company:08833508
+2705		company:08822760
+2706		company:08806335
+2707		company:08475184
+2708		company:07653629
+2709		company:08840094
+2710		company:08842867
+2711		company:08789220
+2712		company:08786136
+2713		company:08842629
+2714		company:08820308
+2715		company:08683500
+2716		company:08721728
+2717		company:08441646
+2718		company:08809624
+2719		company:08833097
+2720		company:08830753
+2721		company:08811135
+2722		company:08813021
+2723		company:07912940
+2724		company:08257461
+2725		company:08872161
+2726		company:08767576
+2727		company:08842936
+2728		company:08882544
+2729		company:08812257
+2730		company:08852553
+2731		company:08880841
+2732		company:08803983
+2733		company:08265245
+2734		company:08921490
+2735		company:08901256
+2736		company:08929419
+2737		company:08929065
+2738		company:08899707
+2739		company:08921898
+2740		company:08891864
+2741		company:08936173
+2742		company:08782792
+2743		company:08899140
+2744		company:08916979
+2745		company:08850163
+2746		company:08895870
+2747		company:08906809
+2748		company:08809385
+2749		company:08934482
+2750		company:08920008
+2751		company:08474688
+2752		company:08927321
+2753		company:08919795
+2754		company:08876009
+2755		company:08872698
+2756		company:08920557
+2757		company:08915981
+2758		company:08886004
+2759		company:08922305
+2760		company:08916147
+2761		company:08909269
+2762		company:08853971
+2763		company:08919697
+2764		company:08924383
+2765		company:08704162
+2766		company:08895977
+2767		company:08920320
+2768		company:08590916
+2769		company:08749821
+2770		company:08905350
+2771		company:08918836
+2772		company:08933913
+2773		company:08924656
+2774		company:08337041
+2775		company:08509710
+2776		company:08614382
+2777		company:08980079
+2778		company:09023802
+2779		company:08747464
+2780		company:07645701
+2781		company:07960887
+2782		company:08936511
+2783		company:08927324
+2784		company:08920524
+2785		company:08962417
+2786		company:08936256
+2787		company:08927009
+2788		company:08922806
+2789		company:08979902
+2790		company:08718489
+2791		company:08941338
+2792		company:08339142
+2793		company:08679235
+2794		company:09118770
+2795		company:09024278
+2796		company:09040388
+2797		company:09022463
+2798		company:09349525
+2799		company:09349673
+2800		company:09437420
+2801		company:08605705
+2802		company:09023805
+2803		company:09060417
+2804		company:09040348
+2805		company:09040156
+2806		company:09102276
+2807		company:08976748
+2808		company:09065312
+2809		company:08998917
+2810		company:08977173
+2811		company:09161532
+2812		company:08765738
+2813		company:09119526
+2814		company:08943457
+2815		company:08922754
+2816		company:08264865
+2817		company:07510578
+2818		company:07649596
+2819		company:07898536
+2820		company:08991357
+2821		company:08324782
+2822		company:07937014
+2823		company:08333406
+2824		company:08344767
+2825		company:07847013
+2826		company:07626303
+2827		company:08291601
+2828		company:08337776
+2829		company:08515877
+2830		company:07941864
+2831		company:07650604
+2832		company:08305242
+2833		company:09030028
+2834		company:08240435
+2835		company:09067175
+2836		company:08599329
+2837		company:07956692
+2838		company:08334743
+2839		company:08336324
+2840		company:08221258
+2841		company:08333424
+2842		company:08330636
+2843		company:08339290
+2844		company:09050439
+2845		company:09083904
+2846		company:09053713
+2847		company:09068218
+2848		company:09066965
+2849		company:08954620
+2850		company:09058698
+2851		company:09064485
+2852		company:09066969
+2853		company:09071607
+2854		company:09071405
+2855		company:09055607
+2856		company:08684162
+2857		company:08318962
+2858		company:07911472
+2859		company:08246407
+2860		company:09071623
+2861		company:08314083
+2862		company:08267703
+2863		company:07953354
+2864		company:08963816
+2865		company:08339878
+2866		company:08300393
+2867		company:08641815
+2868		company:08296556
+2869		company:09111449
+2870		company:09028122
+2871		company:08299181
+2872		company:08337957
+2873		company:08333607
+2874		company:08632527
+2875		company:07650064
+2876		company:08341194
+2877		company:09113542
+2878		company:09050751
+2879		company:09123741
+2880		company:09104491
+2881		company:09077521
+2882		company:09104225
+2883		company:08938098
+2884		company:09098446
+2885		company:09106277
+2886		company:09078530
+2887		company:07949464
+2888		company:08331789
+2889		company:09051179
+2890		company:09023653
+2891		company:09101036
+2892		company:09142556
+2893		company:08913502
+2894		company:09161091
+2895		company:09187505
+2896		company:09451372
+2897		company:08270657
+2898		company:09079258
+2899		company:09199371
+2900		company:09150568
+2901		company:09141878
+2902		company:09064864
+2903		company:09148738
+2904		company:09081030
+2905		company:09119498
+2906		company:09108745
+2907		company:09166463
+2908		company:09142319
+2909		company:08963659
+2910		company:09174628
+2911		company:09124782
+2912		company:09021722
+2913		company:09129775
+2914		company:09139888
+2915		company:09141452
+2916		company:09154494
+2917		company:09040380
+2918		company:09227333
+2919		company:09284368
+2920		company:09154404
+2921		company:09265723
+2922		company:09235635
+2923		company:08291429
+2924		company:09396402
+2925		company:09174154
+2926		company:09115941
+2927		company:09199785
+2928		company:09203984
+2929		company:09175427
+2930		company:09223515
+2931		company:09068195
+2932		company:09202445
+2933		company:09172115
+2934		company:08934887
+2935		company:09218084
+2936		company:08863406
+2937		company:09136556
+2938		company:09150608
+2939		company:09200332
+2940		company:09146848
+2941		company:08557665
+2942		company:09253218
+2943		company:08696394
+2944		company:09148900
+2945		company:09258843
+2946		company:09061804
+2947		company:09093035
+2948		company:09250922
+2949		company:09254238
+2950		company:09301212
+2951		company:09221695
+2952		company:09269589
+2953		company:09295450
+2954		company:09155473
+2955		company:08382992
+2956		company:09289718
+2957		company:09280654
+2958		company:09279884
+2959		company:09286883
+2960		company:08343491
+2961		company:09333191
+2962		company:09333163
+2963		company:08307770
+2964		company:09341344
+2965		company:09308398
+2966		company:09326643
+2967		company:09212934
+2968		company:09436283
+2969		company:09306360
+2970		company:09343767
+2971		company:09341839
+2972		company:09201845
+2973		company:09471525
+2974		company:09442311
+2975		company:09380027
+2976		company:09318755
+2977		company:08102025
+2978		company:09207180
+2979		company:09361618
+2980		company:09341374
+2981		company:09361342
+2982		company:09350239
+2983		company:09319299
+2984		company:09334026
+2985		company:09290889
+2986		company:09362801
+2987		company:09297519
+2988		company:08561222
+2989		company:09432692
+2990		company:08293776
+2991		company:09404783
+2992		company:09484306
+2993		company:09362004
+2994		company:09388819
+2995		company:09443602
+2996		company:09332834
+2997		company:09425197
+2998		company:09449979
+2999		company:09441910
+3000		company:09378112
+3001		company:09443906
+3002		company:09422746
+3003		company:09437439
+3004		company:09440025
+3005		company:09392862
+3006		company:09427476
+3007		company:09392787
+3008		company:09413691
+3009		company:08257814
+3010		company:09378390
+3011		company:09434926
+3012		company:09440033
+3013		company:09408861
+3014		company:09434988
+3015		company:09409109
+3016		company:09433068
+3017		company:09482529
+3018		company:09323792
+3019		company:08334023
+3020		company:08449062
+3021		company:10065284
+3022		company:09332738
+3023		company:08816454
+3024		company:09498825
+3025		company:09466013
+3026		company:09434766
+3027		company:09470229
+3028		company:09483921
+3029		company:09468412
+3030		company:09481323
+3031		company:09454169
+3032		company:09497062
+3033		company:09435396
+3034		company:09471240
+3035		company:09482572
+3036		company:09474500
+3037		company:08827502
+3038		company:09027131
+3039		company:08292380
+3040		company:09017575
+3041		company:07654452
+3042		company:08953180
+3043		company:09000501
+3044		company:09494940
+3045		company:08282488
+3046		company:08652284
+3047		company:09700223
+3048		company:09270040
+3049		company:09284055
+3050		company:09646093
+3051		company:09702162
+3052		company:08833418
+3053		company:07893811
+3054		company:08707909
+3055		company:09499496
+3056		company:09728614
+3057		company:09686896
+3058		company:09659808
+3059		company:08872579
+3060		company:08829472
+3061		company:07911362
+3062		company:09709935
+3063		company:09613632
+3064		company:09628750
+3065		company:09591931
+3066		company:09012630
+3067		company:08628019
+3068		company:08318068
+3069		company:09200220
+3070		company:08346116
+3071		company:08289534
+3072		company:08351953
+3073		company:09610951
+3074		company:09628754
+3075		company:09604912
+3076		company:09611796
+3077		company:09578698
+3078		company:09617166
+3079		company:09626002
+3080		company:09622777
+3081		company:09620043
+3082		company:09461655
+3083		company:08829554
+3084		company:09642581
+3085		company:09668526
+3086		company:09696059
+3087		company:10013691
+3088		company:09690231
+3089		company:09693822
+3090		company:09662313
+3091		company:09718257
+3092		company:09677469
+3093		company:09749664
+3094		company:09712111
+3095		company:09679683
+3096		company:09648418
+3097		company:09587693
+3098		company:09683218
+3099		company:09692208
+3100		company:09791050
+3101		company:09635397
+3102		company:09691510
+3103		company:09662303
+3104		company:09635329
+3105		company:09660515
+3106		company:09646939
+3107		company:09679560
+3108		company:09676023
+3109		company:09702333
+3110		company:09666511
+3111		company:09677480
+3112		company:09323096
+3113		company:09617195
+3114		company:09679536
+3115		company:09691946
+3116		company:09625982
+3117		company:09527057
+3118		company:09811711
+3119		company:09785186
+3120		company:09782388
+3121		company:09780473
+3122		company:09754024
+3123		company:09683579
+3124		company:09751294
+3125		company:09771413
+3126		company:09741508
+3127		company:09878928
+3128		company:08709369
+3129		company:09872178
+3130		company:09874674
+3131		company:09801986
+3132		company:09881224
+3133		company:09872386
+3134		company:09795288
+3135		company:09675372
+3136		company:09875389
+3137		company:09894699
+3138		company:09903139
+3139		company:09379253
+3140		company:09861442
+3141		company:09809895
+3142		company:09912859
+3143		company:09680241
+3144		company:09889819
+3145		company:09913676
+3146		company:09916360
+3147		company:09896672
+3148		company:09853252
+3149		company:09896071
+3150		company:09887971
+3151		company:09648420
+3152		company:09896945
+3153		company:09946495
+3154		company:09918358
+3155		company:09950137
+3156		company:09888339
+3157		company:09940352
+3158		company:09606079
+3159		company:10028278
+3160		company:10067116
+3161		company:10049068
+3162		company:10052450
+3163		company:09952066
+3164		company:10034419
+3165		company:10056460
+3166		company:09996478
+3167		company:10004115
+3168		company:09999238
+3169		company:09971348
+3170		company:10035934
+3171		company:10035844
+3172		company:09978459
+3173		company:10039553
+3174		company:10045230
+3175		company:10037192
+3176		company:09980467
+3177		company:10034058
+3178		company:10042321
+3179		company:10070417
+3180		company:10049139
+3181		company:10075893
+3182		company:08702099
+3183		company:10098444
+3184		company:10038640
+3185		company:10226712
+3186		company:10160645
+3187		company:10155032
+3188		company:10261477
+3189		company:10201636
+3190		company:10161526
+3191		company:10224802
+3192		company:10225404
+3193		company:10178490
+3194		company:10174100
+3195		company:10163646
+3196		company:10227910
+3197		company:10259334
+3198		company:10249712
+3199		company:10181707
+3200		company:10255142
+3201		company:10253931
+3202		company:10081995

--- a/lib/school_trust.ex
+++ b/lib/school_trust.ex
@@ -46,4 +46,22 @@ defmodule SchoolTrust do
     |> DataMorph.puts_tsv(~w[edubase-school-trust name organisation])
   end
 
+  defp suppress_name(["school-trust", "name", "organisation"]) do
+    ["school-trust", "name", "organisation"]
+  end
+  defp suppress_name([key, name, ""]) do
+    [key, name, ""]
+  end
+  defp suppress_name([key, _, organisation]) do
+    [key, "", organisation]
+  end
+
+  def final_trust_tsv do
+    :stdio
+    |> IO.stream(:line)
+    |> CSV.decode(headers: false)
+    |> Stream.map(&suppress_name/1)
+    |> DataMorph.puts_tsv
+  end
+
 end

--- a/lib/school_trust.ex
+++ b/lib/school_trust.ex
@@ -27,20 +27,14 @@ defmodule SchoolTrust do
   end
 
   def trust_rows do
-    trust_htmls |> Stream.map(& trust_row(&1) ) |> Stream.reject(& (&1 |> Enum.at(3)) == "School sponsor" )
+    trust_htmls
+    |> Stream.map(&trust_row/1)
+    |> Stream.reject(& (&1 |> Enum.at(3)) == "School sponsor" )
   end
 
   def trust_tsv do
     headers = ~w[school-trust name company type urn]
     trust_rows |> Stream.uniq |> Enum.sort_by(& &1 |> List.first) |> DataMorph.puts_tsv(headers)
-  end
-
-  def trust_map_tsv do
-    :stdio
-    |> IO.stream(:line)
-    |> DataMorph.structs_from_tsv(:dfe, :school_trust)
-    |> Stream.map(& [&1.urn, &1.school_trust])
-    |> DataMorph.puts_tsv(~w[school school-trust])
   end
 
   def trust_data_tsv do
@@ -49,7 +43,7 @@ defmodule SchoolTrust do
     |> DataMorph.structs_from_tsv(:dfe, :school_trust)
     |> Stream.map(& [&1.school_trust, &1.name, "company:"<>&1.company])
     |> Enum.uniq
-    |> DataMorph.puts_tsv(~w[school-trust name organisation])
+    |> DataMorph.puts_tsv(~w[edubase-school-trust name organisation])
   end
 
 end

--- a/lib/school_trust.rb
+++ b/lib/school_trust.rb
@@ -1,0 +1,105 @@
+require 'morph'
+
+csv = `csvcut -c 'URN,Trusts (name)' ./cache/edubase.csv | awk NF \
+| sed 's/St Hildas Catholic Academy Trust/St Hilda’s Catholic Academy Trust/' \
+| sed 's/Ridings Federation of Academies Trust, The/Ridings’ Federation of Academies Trust, The/' \
+| sed 's/The Helston and Lizard Peninsula Trust~The Helston and Lizard Peninsula Education Trust/The Helston and Lizard Peninsula Education Trust/' \
+| sed 's/The Helston and Lizard Peninsula Trust/The Helston and Lizard Peninsula Education Trust/' \
+| sed 's/South Cheshire Catholic Multi-academy Trust, The~South Cheshire Catholic Multi-Academy Trust/South Cheshire Catholic Multi-academy Trust, The/' \
+| sed 's/created in error-//' \
+| sed 's/Co_Operative/Co Operative/'` ; nil
+
+urn_to_trust_name = Morph.
+  from_csv(csv, :urn_trust_name).
+  select{|x| x.trusts_name != nil} ; nil
+# @urn="100188", @trusts_name="Eltham Green School Trust"
+
+trusts_with_company = Morph.
+  from_csv(IO.read('./lists/edubase-school-trust/trusts-with-matched-company.csv'), :trust) ; nil
+# @school_trust="1", @name="Eltham Green School Trust", @type="trust", @is_umbrella=nil, @organisation=nil, @edubase_school_trust=nil, @company=nil, @company_name=nil
+
+edubase_trust_to_company = Morph.
+  from_tsv(IO.read('./lists/edubase-multi-academy-trust/trusts.tsv'), :edubase_trust).
+  group_by(&:edubase_school_trust) ; nil
+# @edubase_school_trust="15710", @name="Activate Learning Education Trust", @organisation="company:08707909"
+
+urn_to_edubase_trust = Morph.
+  from_tsv(IO.read('./maps/school-to-edubase-school-trust.tsv'), :school_edubase_trust).
+  group_by(&:school) ; nil
+# @school="101857", @edubase_school_trust="15885"
+
+def edubase_trust_match urn, urn_to_edubase_trust, edubase_trust_to_company, trusts_with_company
+  if edubase_trust_id = urn_to_edubase_trust[urn].try(:first).try(:edubase_school_trust)
+    if company_no = edubase_trust_to_company[edubase_trust_id].try(:first).try(:organisation)
+      if trusts = trusts_with_company.select{|x| x.organisation == company_no}
+        if trusts.size == 1
+          trusts.first.school_trust
+        else
+          raise "multiple trusts found for company: #{company_no} | urn: #{urn}"
+        end
+      else
+        raise "no trust found for company: #{company_no} | urn: #{urn}"
+      end
+    else
+      raise "no company found for edubase_trust_id: #{edubase_trust_id} | urn: #{urn}"
+    end
+  end
+end
+
+def trust_names_match names, trusts_with_company
+  n1, n2 = names.split('~')
+  m1 = trust_name_match n1, trusts_with_company
+  m2 = trust_name_match n2, trusts_with_company
+  match = [m1, m2].select{|x| !x.is_umbrella}
+  if match.size == 1
+    match.first
+  elsif match.size > 1
+    raise "multiple matches for trusts: #{names}"
+  else
+    raise "no match for trusts: #{names}"
+  end
+end
+
+def trust_name_match name, trusts_with_company
+  if name.include?('~')
+    trust_names_match name, trusts_with_company
+  else
+    matches = trusts_with_company.select{|x| x.name == name}
+    if matches.size > 1
+      raise "multiple matches for trust: #{name}"
+    elsif matches.size == 1
+      matches.first
+    else
+      raise "no match for trust: #{name}"
+    end
+  end
+end
+
+def school_trust_id school, urn_to_edubase_trust, edubase_trust_to_company, trusts_with_company
+  if trust_id = edubase_trust_match(school.urn, urn_to_edubase_trust, edubase_trust_to_company, trusts_with_company)
+    trust_id
+  else
+    trust_name_match(school.trusts_name, trusts_with_company).try(:school_trust)
+  end
+end
+
+def add_school_trust! urn_to_trust_name, urn_to_edubase_trust, edubase_trust_to_company, trusts_with_company
+  urn_to_trust_name.each do |school|
+    begin
+      school.school_trust = school_trust_id(school,
+        urn_to_edubase_trust, edubase_trust_to_company, trusts_with_company)
+    rescue Exception => e
+      puts e.to_s
+      raise " school: #{school.try(:urn).to_s}"
+    end
+  end ; nil
+end
+
+if true
+  add_school_trust! urn_to_trust_name, urn_to_edubase_trust, edubase_trust_to_company, trusts_with_company
+
+  puts ["school", "school-trust"].join("\t") ; nil
+  urn_to_trust_name.each do |school|
+    puts [school.urn, school.school_trust].join("\t")
+  end ; nil
+end

--- a/lists/edubase-school-trust/trusts-with-matched-company.csv
+++ b/lists/edubase-school-trust/trusts-with-matched-company.csv
@@ -1,0 +1,3204 @@
+school-trust,name,type,is-umbrella,organisation,edubase-school-trust,company,company-name
+1,Eltham Green School Trust,trust,,,,,
+2,*Co-op Brent Knoll and Watergate Co-operative Trust,trust,,,,company:08002136,BRENT KNOLL AND WATERGATE CO-OPERATIVE TRUST
+3,The Academies Enterprise Trust,trust,,,,company:06625091,ACADEMIES ENTERPRISE TRUST
+4,The Copland Learning Partnership Trust,trust,,,,,
+5,The Bourne Foundation,trust,,,,,
+6,The Liverpool Joint Catholic and Church of England Academies Trust,multi-academy trust,,company:07007398,15885,company:07007398,THE LIVERPOOL JOINT CATHOLIC AND CHURCH OF ENGLAND ACADEMIES TRUST
+7,The Buxton School Learning Trust,trust,,,,company:06933903,BUXTON SCHOOL LEARNING TRUST
+8,Four Oaks Learning Trust For Excellence,trust,,,,company:08530062,FOUR OAKS LEARNING TRUST FOR EXCELLENCE
+9,The Endeavour Co-operative Learning Trust,trust,,,,company:09095872,THE ENDEAVOUR CO-OPERATIVE LEARNING TRUST
+10,The Quinton Co-operative Learning Village Trust,trust,,,,company:07361097,THE QUINTON CO-OPERATIVE LEARNING VILLAGE TRUST
+11,Mainland Trust,trust,,,,company:07640639,MAINLAND TRUST
+12,The Selly Oak School Trust,trust,,,,company:06318425,THE REAL LIFE 4 ME TRUST
+13,Stoke Park School Trust,trust,,,,company:06645806,STOKE PARK SCHOOL TRUST
+14,Foxford School Trust Limited,trust,,,,company:07175341,FOXFORD SCHOOL TRUST
+15,The Stourbridge Educational Trust,trust,,,,company:06699254,THE STOURBRIDGE EDUCATIONAL TRUST LIMITED
+16,The Coseley Co-operative Learning Trust,trust,,,,company:08510454,THE COSELEY CO-OPERATIVE LEARNING TRUST
+17,Peoples Field Trust,trust,,,,company:08572909,THE PEOPLES FIELD TRUST
+18,Wednesday Learning Community Trust,trust,,,,,
+19,The Rowley Learning Trust,trust,,,,company:08124820,THE ROWLEY LEARNING TRUST
+20,Moat Farm Junior School Trust,trust,,,,company:07487384,THE MOAT FARM JUNIOR SCHOOL TRUST
+21,The Sandwell Excellence Trust,trust,,,,company:07112404,SANDWELL EXCELLENCE TRUST
+22,The Smethwick Health and Wellbeing Education Trust,trust,,,,company:06803262,SMETHWICK HEALTH AND WELLBEING EDUCATION TRUST
+23,Lyndon School Humanities Trust Board,trust,,,,,
+24,The Frank F Harrison Trust in the Beechdale Community Partnership,trust,,,,,
+25,Brownhills School Trust,trust,,,,,
+26,Best Futures,trust,,,,,
+27,South Liverpool Education Trust,trust,,,,company:07030660,SOUTH LIVERPOOL EDUCATION TRUST
+28,The Fiveways Trust,trust,,,,company:06530527,THE FIVEWAYS TRUST
+29,Parklands Trust,trust,,,,company:07031130,PARKLANDS TRUST
+30,Rainhill Learning Village Trust,trust,,,,company:07088409,RAINHILL LEARNING VILLAGE TRUST
+31,The Wrekin Co-operative Learning Trust,trust,,,,company:08180449,THE WREKIN CO-OPERATIVE LEARNING TRUST
+32,Litherland High School Trust,trust,,,,company:07757429,LITHERLAND HIGH SCHOOL TRUST
+33,Bebington High Sports College a Co-operative Community Trust,trust,,,,,
+34,St Paul's Academy Limited,single-academy trust,,,,company:05210075,ST PAUL'S ACADEMY LIMITED
+35,The Smile Trust (South Manchester International Learning Enterprise),trust,,,,,
+36,West Oldham Co-operative Trust,trust,,,,,
+37,Failsworth Learning Partnership,trust,,,,company:07210040,FAILSWORTH LEARNING PARTNERSHIP
+38,The Radclyffe Co-operative Learning Trust,trust,,,,company:07239650,THE RADCLYFFE CO-OPERATIVE LEARNING TRUST
+39,The Golbourne and Lowton Co-operative Learning Partnership Trust,trust,,,,,
+40,The Golborne and Lowton Co-operative Learning Partnership Trust,trust,,,,,
+41,Winstanley Abraham Guest Trust,trust,,,,company:07137803,WINSTANLEY ABRAHAM GUEST TRUST
+42,Brighter Futures Learning Partnership Trust,trust,,,,company:07147060,BRIGHTER FUTURES LEARNING PARTNERSHIP TRUST
+43,The Doncaster Co-operative Learning Partnership,trust,,,,company:07172612,DONCASTER CO-OPERATIVE LEARNING PARTNERSHIP
+44,The Wath Community Co-operative Trust,trust,,,,company:08647577,THE WATH LEARNING COMMUNITY CO-OPERATIVE TRUST
+45,City Community Learning Trust,trust,,,,company:07476344,CITY COMMUNITY LEARNING TRUST
+46,The Birley Learning Community Co-operative Trust,trust,,,,company:08645382,THE BIRLEY LEARNING COMMUNITY CO-OPERATIVE TRUST
+47,North East Sheffield Trust,trust,,company:08863947,4017,company:08863947,NORTH EAST SHEFFIELD TRUST
+48,Westfield Learning Community Trust,trust,,,,company:07422667,WESTFIELD LEARNING COMMUNITY TRUST
+49,Lidget Green Community Co-operative Learning Trust,trust,,,,company:08785019,THE LIDGET GREEN COMMUNITY CO-OPERATIVE LEARNING TRUST
+50,The Buttershaw Learning and Achievement Trust,trust,,,,company:07112765,BUTTERSHAW LEARNING AND ACHIEVEMENT TRUST
+51,Tong High School Trust,trust,,,,company:07210410,TONG HIGH SCHOOL TRUST
+52,The Nab Wood Community Trust,trust,,,,,
+53,Thornton Grammar and Queensbury School Learning Trust,trust,,,,,
+54,The Park Lane Learning Trust,trust,,,,company:07200314,THE PARK LANE LEARNING TRUST
+55,Calder Learning Trust,trust,,,,company:09010317,THE CALDER LEARNING TRUST
+56,The Spenborough Co-operative Trust,trust,,,,company:08028340,THE SPENBOROUGH CO-OPERATIVE TRUST
+57,Aspire Cooperative Learning Trust,trust,,,,company:07632050,ASPIRE CO-OPERATIVE LEARNING TRUST
+58,The Honley Co-operative Learning Trust,trust,,,,company:09150163,THE HONLEY CO-OPERATIVE LEARNING TRUST
+59,The Dewsbury Learning Trust,trust,,,,company:07137387,THE DEWSBURY LEARNING TRUST
+60,Aireborough Learning Partnership,trust,,,,company:08819550,THE AIREBOROUGH LEARNING PARTNERSHIP - A CO-OPERATIVE TRUST
+61,The Priesthope Co-operative Learning Trust,trust,,,,,
+62,Wharfe Valley Learning Partnership,trust,,,,company:08822970,THE WHARFE VALLEY LEARNING PARTNERSHIP
+63,The Lantern Learning Trust (Inner North West Leeds),trust,,,,company:08419368,"THE LANTERN LEARNING TRUST (INNER CITY NORTH, LEEDS)"
+64,The Leeds North West Education Partnership Foundation,trust,,,,company:08159893,THE LEEDS NORTH WEST EDUCATION PARTNERSHIP
+65,The Leeds East Primary Partnership,trust,,,,company:08330167,THE LEEDS EAST PRIMARY PARTNERSHIP: A CO-OPERATIVE TRUST
+66,The Temple Newsam Learning Partnership,trust,,,,company:07323734,THE TEMPLE NEWSAM LEARNING PARTNERSHIP: A CO-OPERATIVE SCHOOLS TRUST
+67,The Learning Trust (South Leeds),trust,,,,company:07689558,THE LEARNING TRUST (SOUTH LEEDS)
+68,21st Century Learning Partnership,trust,,,,company:07490257,21ST CENTURY LEARNING PARTNERSHIP
+69,The Royds Learning Trust,trust,,,,company:08162626,THE ROYDS LEARNING TRUST
+70,The Bruntcliffe Co-operative Learning Trust,trust,,,,company:07871729,THE BRUNTCLIFFE CO-OPERATIVE LEARNING TRUST
+71,Co-op The Priesthorpe Co-operative Learning Trust,trust,,,,company:08122838,THE INSPIRE CO-OPERATIVE LEARNING TRUST
+72,The Education Trust for Wetherby,trust,,,,company:07155299,THE EDUCATION TRUST FOR WETHERBY
+73,Excel Learning Trust,trust,,,,company:07080464,EXCEL LEARNING TRUST
+74,Education Ossett - Community Trust,trust,,,,company:06655424,EDUCATION OSSETT - COMMUNITY TRUST
+75,Pontefract Education Trust,trust,,,,company:07533785,PONTEFRACT EDUCATION TRUST
+76,Gosforth Schools' Trust,trust,,,,company:08942309,GOSFORTH SCHOOLS' TRUST
+77,Outer West Learning Trust,trust,,,,company:08942398,OUTER WEST LEARNING TRUST
+78,The North Tyneside Learning Trust,trust,,,,company:07353837,NORTH TYNESIDE LEARNING TRUST
+79,The Bede Co-operative Learning Trust,trust,,,,,
+80,South West Bristol Co-operative Learning Trust,trust,,,,company:07196462,SOUTH WEST BRISTOL CO-OPERATIVE LEARNING TRUST
+81,South East Bristol Educational Trust,trust,,,,company:08160289,SOUTH EAST BRISTOL EDUCATIONAL TRUST
+82,Weston-super-Mare Education Trust,trust,,,,company:08658047,WESTON-SUPER-MARE EDUCATION TRUST
+83,Trust in Learning,trust,,,,company:06610908,TRUST IN LEARNING
+84,The Platinum Co-operative Trust,trust,,,,company:08554335,THE PLATINUM CO-OPERATIVE LEARNING TRUST
+85,W W Trust,trust,,,,,
+86,Chipping Sodbury School Co-operative Trust,trust,,,,company:08669980,CHIPPING SODBURY SCHOOL CO-OPERATIVE TRUST
+87,Bedfordshire East Schools Trust (BEST),trust,,,,company:06865093,BEDFORDSHIRE EAST SCHOOLS TRUST LIMITED
+88,The Leap Trust,trust,,,,company:07066659,LEAP COMMUNITY TRUST
+89,North East Bedford Learning Trust,trust,,,,company:06920399,NORTH EAST BEDFORD LEARNING TRUST
+90,North Bedfordshire Schools Trust (NBST),trust,,,,company:06406335,NORTH BEDFORDSHIRE SCHOOLS TRUST
+91,The Vale of Marston Schools' Trust,trust,,,,company:07362459,THE VALE OF MARSTON SCHOOLS' TRUST
+92,Pinnacle Trust,trust,,,,company:07810556,THE PINNACLE TRUST
+93,The Harlington Area Schools Trust,trust,,,,company:06664132,THE HARLINGTON AREA SCHOOLS TRUST
+94,The Kempston Education Trust (KET),trust,,,,company:06722344,KEMPSTON EDUCATION TRUST
+95,The Biddenham Campus Trust,trust,,,,company:07421249,THE BIDDENHAM CAMPUS TRUST
+96,Girls' Trust for Educational Excellence and Enterprise,trust,,,,company:06736504,GIRLS' TRUST FOR EDUCATIONAL EXCELLENCE AND ENTERPRISE
+97,Wolverton Learning Trust,trust,,,,company:09097648,WOLVERTON LEARNING TRUST
+98,The Aylesbury Learning Partnership,trust,,,,company:08670392,THE AYLESBURY LEARNING PARTNERSHIP
+99,Cressex Co-operative Learning Partnership,trust,,,,company:07207094,THE CRESSEX CO-OPERATIVE LEARNING TRUST
+100,Leon Learning Trust,trust,,,,company:07048537,THE LEON LEARNING TRUST
+101,The Henry Morris Community Trust,trust,,,,company:07085883,THE HENRY MORRIS COMMUNITY TRUST
+102,The North Cambridge Community Trust,trust,,,,company:07359743,THE NORTH CAMBRIDGE COMMUNITY TRUST
+103,Jack Hunt Community Learning Trust,trust,,,,company:07390424,THE JACK HUNT COMMUNITY LEARNING TRUST
+104,Alsager Community Trust,trust,,,,company:06981514,THE ALSAGER COMMUNITY TRUST
+105,Crewe South Co-operative Learning Partnership,trust,,,,company:07888193,CREWE SOUTH CO-OPERATIVE LEARNING PARTNERSHIP
+106,Blacon High School Trust,trust,,,,company:07220749,BLACON HIGH SCHOOL TRUST
+107,Seahorse Educational Trust,trust,,,,company:07721328,SEAHORSE EDUCATIONAL TRUST
+108,The East Cleveland Co-operative Learning Trust,trust,,,,company:08668189,THE EAST CLEVELAND CO-OPERATIVE LEARNING TRUST
+109,The Redcar and Marske Specialist Schools Trust,trust,,,,company:07061055,TRUST4LEARNING
+110,The Penwith Education Trust (PET),trust,,,,company:08013075,THE PENWITH EDUCATION TRUST
+111,The Helston and Lizard Peninsula Education Trust,trust,,,,company:07001690,SOUTHERLY POINT CO-OPERATIVE EDUCATIONAL TRUST
+112,The Redruth Learning Group Trust,trust,,,,company:08368234,THE REDRUTH LEARNING GROUP TRUST
+113,Crofty Learning Trust,trust,,,,company:08340994,THE CROFTY LEARNING TRUST
+114,Mid Cornwall Co-operative Learning Trust,trust,,,,company:08159946,THE MID CORNWALL CO-OPERATIVE LEARNING TRUST
+115,The Lanhydrock Schools Partnership,trust,,,,company:08475586,THE LANHYDROCK SCHOOLS PARTNERSHIP
+116,The Camelford Co-operative Learning Trust,trust,,,,company:07321827,MOOR AND COASTAL PARTNERSHIP TRUST
+117,The Launceston Rural Learning Trust,trust,,,,company:08194273,THE LAUNCESTON RURAL LEARNING TRUST
+118,Launceston Primary Schools Trust,trust,,,,company:08156955,AN DARAS MULTI ACADEMY TRUST
+119,The Caradon Co Operative Trust,trust,,,,company:08321322,THE CARADON CO-OPERATIVE EDUCATIONAL TRUST
+120,Liskeard Community Co-operative Learning Trust (LCCLT),trust,,,,company:07890869,THE LISKEARD COMMUNITY CO-OPERATIVE LEARNING TRUST
+121,Torpoint and Rame Co-operative Trust,trust,,,,company:07889474,TORPOINT AND RAME CO-OPERATIVE LEARNING TRUST
+122,St Austell Educational Trust,trust,,,,company:08160093,THE ST AUSTELL EDUCATION TRUST
+123,North Pennine Learning Partnership Trust,trust,,,,company:06553173,NORTH PENNINE LEARNING PARTNERSHIP
+124,The Sinfin Chellaston Partnership Trust,trust,,,,company:07470285,THE SINFIN CHELLASTON PARTNERSHIP EDUCATIONAL TRUST
+125,The Bemrose Littleover Partnership Educational Trust,trust,,,,company:07246485,BEMROSE EDUCATIONAL TRUST
+126,Derby Pride Trust,trust,,company:07109892,2880,company:07109892,DERBY PRIDE TRUST
+127,The Merrill and Derby College Partnership Trust,trust,,,,company:07514639,THE MERRILL & DERBY COLLEGE PARTNERSHIP TRUST
+128,Culm Co=operative Learning Partnership,trust,,,,company:08647797,CULM CO-OPERATIVE LEARNING PARTNERSHIP
+129,Exeter Learning Trust,trust,,,,company:08822622,EXETER LEARNING TRUST
+130,The Ted Wragg Trust,trust,,,,company:07229092,TED WRAGG TRUST
+131,The Avocet Learning Trust,trust,,,,company:08647735,THE AVOCET LEARNING TRUST
+132,Smile Learning Trust,trust,,,,company:08752855,THE SMILE LEARNING TRUST
+133,Atlantic Coast Co-Operative Trust,trust,,,,company:08528298,ATLANTIC COAST CO-OPERATIVE TRUST
+134,The Two Moors Learning Partnership,trust,,,,company:08656101,THE TWO MOORS LEARNING PARTNERSHIP
+135,Tavistock Co-Operative Learning Trust,trust,,,,company:08160189,TAVISTOCK CO-OPERATIVE LEARNING TRUST
+136,Dartmoor Co-operative Learning Trust,trust,,,,company:08264283,THE DARTMOOR CO-OPERATIVE LEARNING TRUST
+137,South West Plymouth Education Trust,trust,,,,company:08160286,THE SOUTH WEST PLYMOUTH EDUCATION TRUST
+138,The South West Plymouth Education Trust,trust,,,,company:08160286,THE SOUTH WEST PLYMOUTH EDUCATION TRUST
+139,The Lipson Learning Co-operative Trust,trust,,,,company:06969482,LIPSON LEARNING CO-OPERATIVE TRUST
+140,Education Through Enterprise Trust,trust,,,,company:08871100,EDUCATION THROUGH ENTERPRISE TRUST
+141,The Holsworthy Co-operative Learning Trust Foundation,trust,,,,company:08165701,THE HOLSWORTHY CO-OPERATIVE LEARNING TRUST
+142,South Molton Co-operative Learning Trust,trust,,,,company:08334627,SOUTH MOLTON CO-OPERATIVE LEARNING TRUST
+143,The Park Community Co-Operative Learning Trust,trust,,,,company:08160073,THE PARK COMMUNITY CO-OPERATIVE LEARNING TRUST
+144,The Exe Estuary Academic Co-operative Trust,trust,,,,company:08167897,THE EXE ESTUARY ACADEMIC CO-OPERATIVE TRUST
+145,The Torquay Community College Trust,trust,,,,company:07101375,TORQUAY COMMUNITY COLLEGE TRUST
+146,Westlands School Trust,trust,,,,,
+147,SENtient Trust,trust,,,,company:08159859,SENTIENT TRUST
+148,The North Bournemouth Learning and Achievement Trust,trust,,,,company:07512902,THE NORTH BOURNEMOUTH LEARNING AND ACHIEVEMENT TRUST
+149,The Glenmoor and Winton Educational Trust,trust,,,,company:07393006,GLENMOOR AND WINTON EDUCATIONAL TRUST
+150,Spennymoor Learning Community Trust,trust,,,,company:07240624,SPENNYMOOR LEARNING COMMUNITY TRUST
+151,Aycliffe and Shildon Schools Education Trust,trust,,,,company:06998729,AYCLIFFE AND SHILDON SCHOOLS EDUCATION TRUST
+152,The Hailsham Co-operative Learning Trust,trust,,,,company:07388613,THE HAILSHAM CO-OPERATIVE LEARNING TRUST
+153,The Lewes Co-operative Learning Partnership,trust,,,,company:09162295,THE LEWES CO-OPERATIVE LEARNING PARTNERSHIP
+154,Billericay Community Trust,trust,,,,company:06997931,BILLERICAY COMMUNITY TRUST
+155,The Harlow Education Trust,trust,,,,company:07344436,THE HARLOW EDUCATION TRUST
+156,The South Gloucester Learning Trust,trust,,,,company:07337220,THE SOUTH GLOUCESTER LEARNING TRUST
+157,The Lakers Family Co-operative College,trust,,,,company:07320062,THE LAKERS FAMILY CO-OPERATIVE LEARNING TRUST
+158,The Vale of Berkeley Co-operative Learning Trust,trust,,,,company:07217965,THE VALE OF BERKELEY CO-OPERATIVE LEARNING TRUST
+159,Regents Park Learning Trust,trust,,,,company:07743582,SOUTHAMPTON CO-OPERATIVE LEARNING TRUST
+160,Southampton Education Trust,trust,,,,company:06314840,THE SOUTHAMPTON EDUCATION TRUST LIMITED
+161,The Upper Shirley Learning Community Trust,trust,,,,company:06852829,UPPER SHIRLEY LEARNING COMMUNITY TRUST
+162,The King Richard School Trust,trust,,,,company:07000751,THE KING RICHARD SCHOOL TRUST
+163,The City of Portsmouth Boys' Trust,trust,,,,company:07005864,THE CITY OF PORTSMOUTH BOYS' SCHOOL TRUST
+164,The Purbrook Park Learning Trust,trust,,,,company:06861495,THE PURBROOK PARK LEARNING TRUST
+165,Southampton Co-operative Learning Trust,trust,,,,company:07743582,SOUTHAMPTON CO-OPERATIVE LEARNING TRUST
+166,Education for Bromyard: A Co-operative Trust,trust,,,,company:07415377,EDUCATION FOR BROMYARD: A CO-OPERATIVE TRUST
+167,The East Hull Co-Operative Trust,trust,,,,company:08161698,THE EAST HULL CO-OPERATIVE LEARNING TRUST
+168,Pioneer Co-operative Trust,trust,,,,company:06893415,PIONEER CO-OPERATIVE TRUST
+169,West of Hull - Co-operative Learning Trust,trust,,,,company:07475330,WEST HULL COOPERATIVE LEARNING TRUST
+170,The Pioneer Co-Operative Trust,trust,,,,company:06893415,PIONEER CO-OPERATIVE TRUST
+171,Medina Innovation Trust AKA Island Innovation Trust,trust,,,,company:06793576,ISLAND INNOVATION TRUST
+172,Rochester Learning Trust,trust,,,,company:07035082,ROCHESTER LEARNING TRUST
+173,The Northfleet School for Girls Co-operative Learning Trust,trust,,,,company:07722857,THE NORTHFLEET SCHOOL FOR GIRLS CO-OPERATIVE LEARNING TRUST
+174,The Malling Holmesdale Federation Trust,trust,,,,company:06841092,THE MALLING HOLMESDALE FEDERATION TRUST
+175,The Hundred of Hoo School Trust,trust,,,,company:06389366,THE HUNDRED OF HOO NURSERY AND KIDS CLUB LIMITED
+176,The Futures Learning Trust,trust,,,,company:06770414,FUTURES LEARNING TRUST
+177,Collegiate High School Raising Aspirations Trust,trust,,,,company:06682621,COLLEGIATE HIGH SCHOOL RAISING ASPIRATIONS TRUST
+178,TFSP LSA Learning Trust,trust,,,,company:07654281,LYTHAM ST ANNES LEARNING TRUST
+179,Glenburn Education Trust,trust,,,,company:07320081,GLENBURN EDUCATION TRUST
+180,The Palatine Achievement Trust,trust,,,,company:07182663,PALATINE SPORTS COLLEGE - A LEARNING & ACHIEVEMENT TRUST
+181,Fleetwood Education Trust,trust,,,,company:06966733,FLEETWOOD EDUCATION TRUST
+182,The Lathom Trust,trust,,,,company:07701959,THE LATHOM TRUST
+183,The Loughborough Learning Trust,trust,,,,company:06958522,LOUGHBOROUGH LEARNING TRUST
+184,Fullhurst Co-operative Learning Partnership,trust,,,,company:07265955,FULLHURST LEARNING PARTNERSHIP
+185,"The WELL (Wellbeing, Enterprise, Leadership and Learning) Trust",trust,,,,,
+186,Wolds and East Education Trust,trust,,,,company:06672194,WOLDS AND EAST EDUCATION TRUST
+187,Co-op The Aylsham Cluster Trust,trust,,,,company:07662251,AYLSHAM CLUSTER TRUST
+188,Acorn Co-operative Learning Alliance,trust,,,,company:09180154,THE ACORN CO-OPERATIVE LEARNING ALLIANCE
+189,The Aylsham Cluster Trust,trust,,,,company:07662251,AYLSHAM CLUSTER TRUST
+190,The Central Norwich Foundation Trust,trust,,,,company:06910125,CENTRAL NORWICH FOUNDATION TRUST
+191,Trust Norfolk,trust,,,,company:08754672,TRUST NORFOLK-SEN
+192,The Parkside Community Trust,trust,,,,company:07041876,PARKSIDE COMMUNITY TRUST
+193,George Pindar Community Sports College Trust,trust,,,,company:06566468,GEORGE PINDAR COMMUNITY SPORTS COLLEGE TRUST
+194,Lodge Park Technology College Trust,trust,,,,,
+195,The Ashington Learning Partnership Trust,trust,,,,company:06356262,ASHINGTON LEARNING PARTNERSHIP TRUST
+196,The Beacon Co-operative Learning trust,trust,,,,company:08330680,THE BEACON CO-OPERATIVE LEARNING TRUST
+197,Severn Community Co-operative Learning Trust,trust,,,,company:08124589,THE SEVERN COMMUNITY CO-OPERATIVE LEARNING TRUST
+198,Bridgwater Education Trust,trust,,,,company:06672308,BRIDGWATER EDUCATION TRUST LIMITED
+199,Brymore School Trust,trust,,,,company:07322811,BRYMORE SCHOOL TRUST
+200,Trust for Innovative Learning and Training,trust,,,,company:07112008,TRUST FOR INNOVATIVE LEARNING AND TRAINING (TILT)
+201,Mill Hill Co-operative Learning Trust,trust,,,,company:08160314,MILL HILL CO-OPERATIVE LEARNING TRUST
+202,Burton Co-operative Learning Trust,trust,,,,company:07817715,BURTON CO-OPERATIVE LEARNING TRUST
+203,The Thomas Boughey Co-operative Learning Trust,trust,,,,company:07299390,THE SIR THOMAS BOUGHEY CO-OPERATIVE LEARNING TRUST
+204,Biddulph Schools Partnership Trust,trust,,,,company:08045239,BIDDULPH SCHOOLS PARTNERSHIP TRUST
+205,Chase Learning Trust,trust,,,,company:06953695,CHASE LEARNING TRUST
+206,Tame Valley Co-Operative Learning Trust,trust,,,,company:08160117,TAME VALLEY CO-OPERATIVE LEARNING TRUST
+207,The Newcastle Co-operative Learning Trust,trust,,,,company:08159883,THE NEWCASTLE CO-OPERATIVE LEARNING TRUST
+208,Minster Spires Co-operative Learning Trust,trust,,,,company:09069228,THE MINSTER SPIRES CO-OPERATIVE LEARNING TRUST
+209,Chase Co-operative Trust,trust,,,,company:08011890,CHASE CO-OPERATIVE LEARNING TRUST
+210,The Aston Brooke Co-operative Trust,trust,,,,company:09345706,THE ASTON BROOKE CO-OPERATIVE LEARNING TRUST
+211,Stafford Community Learning Trust,trust,,,,company:09648759,STAFFORD COMMUNITY LEARNING TRUST
+212,Burnley Education Trust,trust,,,,company:06968373,BURNLEY EDUCATION TRUST
+213,Trentham Co-operative Trust,trust,,,,company:07210717,TRENTHAM CO-OPERATIVE TRUST
+214,Sandon Learning Partnership Trust,trust,,,,company:07351263,THE SANDON LEARNING PARTNERSHIP TRUST
+215,The Sir Thomas Boughey Co-operative Learning Trust,trust,,,,company:07299390,THE SIR THOMAS BOUGHEY CO-OPERATIVE LEARNING TRUST
+216,Blythe Bridge High School Music Trust,trust,,,,company:08272480,BLYTHE BRIDGE HIGH SCHOOL MUSIC TRUST
+217,Stour Education Trust (SET),trust,,,,company:07066757,STOUR EDUCATION TRUST
+218,Felixstowe Learning Trust,trust,,,,company:06998382,FELIXSTOWE LEARNING TRUST
+219,The SWISS Trust,trust,,,,,
+220,Voice Education Trust,trust,,,,company:07061920,THE VOICE EDUCATION TRUST
+221,The Kenilworth Education Trust,trust,,,,company:06809829,KENILWORTH EDUCATION TRUST
+222,Bourne Community Trust,trust,,,,company:06860258,BOURNE COMMUNITY TRUST
+223,North Wiltshire Learning Trust,trust,,,,company:08645319,NORTH WILTSHIRE LEARNING TRUST
+224,Marlowe Academy,single-academy trust,,,,company:04915796,MARLOWE ACADEMY
+225,Tudor Grange Academies Trust,multi-academy trust,,company:07365748,5128,company:07365748,TUDOR GRANGE ACADEMIES TRUST
+226,Grace Academy,multi-academy trust,,company:04967658,3211,company:04967658,GRACE ACADEMY
+227,John Madejski Academy,single-academy trust,,,,company:05319170,JOHN MADEJSKI ACADEMY
+228,The Voyager Learning Cooperative,trust,,,,company:07207113,THE VOYAGER LEARNING CO-OPERATIVE
+229,Macmillan Academy,single-academy trust,,,,company:02236171,MACMILLAN ACADEMY
+230,Dixons Academies Charitable Trust Ltd,multi-academy trust,,company:02303464,2939,company:02303464,DIXONS ACADEMIES CHARITABLE TRUST LTD
+231,United Learning Trust,multi-academy trust,,company:04439859,5143,company:04439859,UNITED LEARNING TRUST
+232,The Chickenley Community Co-operative Learning Trust,trust,,,,company:08462144,THE CHICKENLEY COMMUNITY CO-OPERATIVE LEARNING TRUST
+233,Petchey Academy,single-academy trust,,,,company:05342164,PETCHEY ACADEMY
+234,Northern Schools Trust,multi-academy trust,,company:05067702,4041,company:05067702,NORTHERN SCHOOLS TRUST
+235,Chase High Trust,trust,,,,company:07131649,CHASE HIGH TRUST
+236,Child and Family Learning Trust,trust,,,,company:07875308,CHILD AND FAMILY LEARNING TRUST
+237,"Westminster Academy (Westbourne Green), The",single-academy trust,,,,company:05102934,THE WESTMINSTER ACADEMY (WESTBOURNE GREEN)
+238,The Magnus Learning Trust,trust,,,,company:07001636,THE MAGNUS LEARNING TRUST
+239,Peacehaven Co-operative Learning Trust,trust,,,,company:08624963,THE PEACEHAVEN CO-OPERATIVE LEARNING TRUST
+240,"Bridge Academy, Hackney, The",single-academy trust,,,,company:05195911,"THE BRIDGE ACADEMY, HACKNEY"
+241,Islington Arts and Media Trust,trust,,,,company:06794689,THE ARTS AND MEDIA SCHOOL ISLINGTON TRUST LTD
+242,Lever Park Learning Trust,trust,,,,company:06781652,LEVER PARK LEARNING TRUST
+243,Harris Federation,multi-academy trust,,company:06228587,3320,company:06228587,HARRIS FEDERATION
+244,ARK Schools,multi-academy trust,,company:05112090,2157,company:05112090,ARK SCHOOLS
+245,Bishopsford Educational Trust,trust,,,,company:07054131,BISHOPSFORD EDUCATIONAL TRUST
+246,LEAF Academy Trust,multi-academy trust,,company:05037949,3706,company:05037949,LEAF ACADEMY TRUST
+247,The Kings College of Arts Trust,trust,,,,,
+248,The Royal Docks Co-operative Learning Partnership,trust,,,,company:07268568,THE ROYAL DOCKS CO-OPERATIVE LEARNING PARTNERSHIP
+249,New College Leicester Trust,trust,,,,company:07267502,NEW COLLEGE LEICESTER TRUST
+250,Kings Community Trust,trust,,,,,
+251,The Newcastle Special Schools Trust,trust,,,,company:08684375,NEWCASTLE SPECIAL SCHOOLS TRUST
+252,Parkside Creative Learning Trust,trust,,,,company:07738951,PARKSIDE CREATIVE LEARNING TRUST
+253,The Link - Beyond The Gate Trust,trust,,,,company:07680729,THE LINK BEYOND THE GATE TRUST
+254,Gateway Learning Community,multi-academy trust,,company:05853746,3163,company:05853746,GATEWAY LEARNING COMMUNITY
+255,The Hadden Park Co-operative Learning Partnership,trust,,,,company:07163598,THE HADDEN PARK CO-OPERATIVE LEARNING PARTNERSHIP
+256,All Saints Church of England College Trust,trust,,,,company:07820834,THE ALL SAINTS CHURCH OF ENGLAND COLLEGE TRUST
+257,The City of Cambridge Education Foundation,trust,,,,company:04930419,CITY OF CAMBRIDGE EDUCATION FOUNDATION
+258,Greig City Academy,single-academy trust,,,,company:04220486,GREIG CITY ACADEMY
+259,Nord Anglia Education Plc.,trust,,,,company:06590752,NORD ANGLIA EDUCATION (UK) HOLDINGS PLC
+260,Meadowhead Community Learning Trust,trust,,,,company:06929638,MEADOWHEAD COMMUNITY LEARNING TRUST
+261,Walsall City Academy Trust,single-academy trust,,,,company:04251277,WALSALL CITY ACADEMY TRUST
+262,Jarrow School Trust,trust,,,,company:07205479,JARROW SCHOOL TRUST
+263,Unity City Academy Trust,single-academy trust,,,,company:04357009,UNITY CITY ACADEMY TRUST
+264,Bexley Business Academy Limited,single-academy trust,,,,company:04701198,BEXLEY BUSINESS ACADEMY EDUCATION SERVICES LIMITED
+265,CFBT Schools Trust,multi-academy trust,,company:07468210,2597,company:07468210,CFBT SCHOOLS TRUST
+266,Cabot Learning Federation,multi-academy trust,,company:06207590,2516,company:06207590,CABOT LEARNING FEDERATION
+267,City of London Academies Trust,multi-academy trust,,company:04504128,2705,company:04504128,CITY OF LONDON ACADEMIES TRUST
+268,"King's Academy, The",single-academy trust,,,,company:04418245,THE KING'S ACADEMY
+269,"Capital City Academy Trust, The",single-academy trust,,,,company:04268208,THE CAPITAL CITY ACADEMY TRUST
+270,Djanogly Learning Trust,multi-academy trust,,company:04544722,2941,company:04544722,DJANOGLY LEARNING TRUST
+271,Oasis Community Learning,multi-academy trust,,company:05398529,4076,company:05398529,OASIS COMMUNITY LEARNING
+272,"St Mary Magdalene Academy, The",single-academy trust,,,,company:05412502,THE ST MARY MAGDALENE ACADEMY
+273,"Alec Reed Academy, The",single-academy trust,,,,company:04444278,THE ALEC REED ACADEMY
+274,The School Partnership Trust (SPT),trust,,,,company:07082675,SCHOOL PARTNERSHIP TRUST
+275,The Green Lane Co-operative Learning Trust,trust,,,,,
+276,"Mossbourne Federation, The",multi-academy trust,,company:04468267,3939,company:04468267,THE MOSSBOURNE FEDERATION
+277,The da Vinci Community College Learning Foundation,trust,,,,company:07435548,DERBY CO-OPERATIVE LEARNING TRUST
+278,Stockley Academy,single-academy trust,,,,company:04302474,STOCKLEY ACADEMY
+279,Barnet City Academy,multi-academy trust,,company:04389132,2232,company:04389132,BARNET CITY ACADEMY
+280,East Blackburn Learning Community Trust,trust,,,,company:07004086,EAST BLACKBURN LEARNING COMMUNITY TRUST
+281,The Norwich Co-operative Learning Trust,trust,,,,company:08796668,THE NORWICH CO-OPERATIVE LEARNING TRUST
+282,Christchurch Learning Partnership and Church of England,trust,,,,,
+283,Sandwell Academy Trust Limited,single-academy trust,,,,company:04798185,SANDWELL ACADEMY TRUST LIMITED
+284,Harefield Academy Trust,single-academy trust,,,,company:05051218,HAREFIELD ACADEMY TRUST
+285,Trinity Academy,single-academy trust,,,,company:04916397,TRINITY ACADEMY
+286,ContinU Trust,trust,,,,company:06649728,CONTINU TRUST
+287,Haberdashers' Aske's Federation Trust,multi-academy trust,,company:02535091,3279,company:02535091,HABERDASHERS' ASKE'S FEDERATION TRUST
+288,Landau Forte Charitable Trust,multi-academy trust,,company:02387916,3684,company:02387916,LANDAU FORTE CHARITABLE TRUST
+289,Madeley Academy Trust Limited,single-academy trust,,,,company:05978522,MADELEY ACADEMY TRUST LIMITED
+290,"Collegiate Academy Trust, The",multi-academy trust,,company:06336693,2744,company:06336693,THE COLLEGIATE ACADEMY TRUST
+291,GDST Academy Trust,multi-academy trust,,company:06000347,3166,company:06000347,GDST ACADEMY TRUST
+292,Thomas Clarkson Educational Trust,trust,,,,company:06717593,THOMAS CLARKSON EDUCATIONAL TRUST LIMITED
+293,Folkestone Academy,single-academy trust,,,,company:05115594,FOLKESTONE ACADEMY
+294,Ormiston Academies Trust,multi-academy trust,,company:06982127,4106,company:06982127,ORMISTON ACADEMIES TRUST
+295,"Thomas Deacon Academy, The",single-academy trust,,,,company:05090788,THE THOMAS DEACON ACADEMY
+296,"St Matthew Academy Limited, The",single-academy trust,,,,company:05144640,THE ST MATTHEW ACADEMY LIMITED
+297,"Marsh Academy Trust, The",single-academy trust,,,,,
+298,"David Ross Education Trust, The",multi-academy trust,,company:06182612,2854,company:06182612,THE DAVID ROSS EDUCATION TRUST
+299,Leigh Academies Trust,multi-academy trust,,company:02336587,3725,company:02336587,LEIGH ACADEMIES TRUST
+300,Spires Academy,single-academy trust,,,,company:06207067,SPIRES ACADEMY
+301,"Brooke Weston Trust, The",multi-academy trust,,company:02400784,2471,company:02400784,THE BROOKE WESTON TRUST
+302,Middleton Academy Limited,single-academy trust,,,,company:06246929,MIDDLETON ACADEMY LIMITED
+303,St Aidan's Church of England Academy Limited,single-academy trust,,,,company:06162865,ST AIDAN'S CHURCH OF ENGLAND ACADEMY LIMITED
+304,Prospect Education (Technology) Trust Limited,single-academy trust,,,,company:02484729,PROSPECT EDUCATION (TECHNOLOGY) TRUST LIMITED
+305,The Shared Learning Trust,multi-academy trust,,company:05958361,2233,company:05958361,THE SHARED LEARNING TRUST
+306,Bradford Academy Trust,multi-academy trust,,company:05508735,2404,company:05508735,BRADFORD ACADEMY TRUST
+307,Future Schools Trust,multi-academy trust,,company:06272751,3154,company:06272751,FUTURE SCHOOLS TRUST
+308,Bacon's College,single-academy trust,,,,company:02490773,BACON'S COLLEGE
+309,"Laidlaw Schools Trust, The",multi-academy trust,,company:05735093,3677,company:05735093,THE LAIDLAW SCHOOLS TRUST
+310,"Quaerere Academy Trust, The",single-academy trust,,,,company:06221748,QUAERERE ACADEMIES TRUST
+311,Wren Academy,single-academy trust,,,,company:06422162,WREN ACADEMY
+312,Great Academies Education Trust,multi-academy trust,,company:06237630,3225,company:06237630,GREAT ACADEMIES EDUCATION TRUST
+313,"Chelsea Academy (A Science Academy), The",single-academy trust,,,,company:06176090,THE CHELSEA ACADEMY (A SCIENCE ACADEMY)
+314,"Priory Federation of Academies, The",multi-academy trust,,company:06462935,4253,company:06462935,THE PRIORY FEDERATION OF ACADEMIES
+315,Cathedral Schools Trust,multi-academy trust,,company:06516626,16026,company:06516626,CATHEDRAL SCHOOLS TRUST
+316,Aldridge North West Education Trust,multi-academy trust,,company:05670663,2096,company:05670663,ALDRIDGE EDUCATION
+317,Colston's Girls' School Trust,multi-academy trust,,company:06511936,2748,company:06511936,COLSTON'S GIRLS' SCHOOL TRUST
+318,Haberdashers' Adams' Federation Trust,multi-academy trust,,company:06548296,3277,company:06548296,HABERDASHERS' ADAMS' FEDERATION TRUST
+319,"Samworth Church Academy, The",single-academy trust,,,,company:06091123,THE SAMWORTH CHURCH ACADEMY
+320,City of London Academy Islington Limited,single-academy trust,,,,company:06426966,CITY OF LONDON ACADEMY ISLINGTON LIMITED
+321,Merchants' Academy Withywood,single-academy trust,,,,company:05598063,MERCHANTS' ACADEMY TRUST
+322,Sentamu Academy Learning Trust,multi-academy trust,,company:06544825,2147,company:06544825,SENTAMU ACADEMY LEARNING TRUST
+323,"RSA Academy at Tipton, The",single-academy trust,,,,company:06311127,THE RSA ACADEMY AT TIPTON
+324,Bede Academy,single-academy trust,,,,company:05975733,BEDE ACADEMY
+325,Academy 360,single-academy trust,,,,company:06269025,ACADEMY 360
+326,"Langley Academy Trust, The",multi-academy trust,,company:05358533,3688,company:05358533,THE LANGLEY ACADEMY TRUST
+327,West Lakes Academy,single-academy trust,,,,company:06627459,WEST LAKES ACADEMY
+328,The Diocese of Norwich Education and Academies Trust,multi-academy trust,,company:08737435,2918,company:08737435,THE DIOCESE OF NORWICH EDUCATION AND ACADEMIES TRUST
+329,Academies Enterprise Trust,multi-academy trust,,company:06625091,2053,company:06625091,ACADEMIES ENTERPRISE TRUST
+330,"Bishop Anthony Educational Trust, The",multi-academy trust,,company:08762217,2326,company:08762217,THE BISHOP ANTHONY EDUCATIONAL TRUST
+331,Milton Keynes Academy Trust,single-academy trust,,,,company:06192615,MILTON KEYNES ACADEMY TRUST
+332,Lincoln College Academy Trust,multi-academy trust,,company:08238194,4990,company:08238194,LINCOLN COLLEGE ACADEMY TRUST
+333,"Steiner Academy, Hereford",single-academy trust,,,,company:01532445,"STEINER ACADEMY, HEREFORD"
+334,"St Lawrence Academy, Scunthorpe, The",single-academy trust,,,,company:06493485,"THE ST LAWRENCE ACADEMY, SCUNTHORPE"
+335,"Oxford Academy Trust, The",single-academy trust,,,,company:06621108,THE OXFORD ACADEMY TRUST
+336,Future Academies,multi-academy trust,,company:06543442,3152,company:06543442,FUTURE ACADEMIES
+337,CTC Kingshurst Academy,single-academy trust,,,,company:02268092,CTC KINGSHURST ACADEMY
+338,Bulwell Academy Trust,single-academy trust,,,,company:06194070,BULWELL ACADEMY TRUST
+339,Cambridge Meridian Educational Trust,trust,,,,company:06616879,CAMBRIDGE MERIDIAN EDUCATIONAL TRUST
+340,Woodard Academies Trust,multi-academy trust,,company:06415729,5385,company:06415729,WOODARD ACADEMIES TRUST
+341,Nottingham University Samworth Academies Trust,multi-academy trust,,company:06221293,4058,company:06221293,NOTTINGHAM UNIVERSITY SAMWORTH ACADEMIES TRUST
+342,Essa Foundation Academies Trust,multi-academy trust,,company:06731593,3055,company:06731593,ESSA FOUNDATION ACADEMIES TRUST
+343,Kingsway Learning Trust Limited,trust,,,,company:07498323,KINGSWAY LEARNING TRUST LIMITED
+344,"Wellington Academy Trust, The",multi-academy trust,,company:06457394,5247,company:06457394,WELLINGTON COLLEGE ACADEMY TRUST
+345,Comberton Educational Trust,trust,,,,company:06705652,COMBERTON EDUCATIONAL TRUST
+346,Castle View Enterprise Academy,single-academy trust,,,,company:06268570,CASTLE VIEW ENTERPRISE ACADEMY
+347,The Local Learning Trust,trust,,,,company:06964300,THE LOCAL LEARNING TRUST
+348,"City Academy, Hackney, The",single-academy trust,,,,company:06382192,"THE CITY ACADEMY, HACKNEY"
+349,North East Lincolnshire Joint Church School Trust Limited,trust,,,,,
+350,Endeavour Educational Trust,trust,,,,,
+351,Droylsden Academy,single-academy trust,,,,company:06731528,DROYLSDEN ACADEMY
+352,Bradford College Education Trust,multi-academy trust,,company:06772181,2406,company:06772181,BRADFORD COLLEGE EDUCATION TRUST
+353,The Altius Trust,single-academy trust,,,,company:06740940,THE ALTIUS TRUST
+354,Manchester Health Academy,single-academy trust,,,,company:06735003,MANCHESTER HEALTH ACADEMY
+355,The Meller Educational Trust,multi-academy trust,,company:06933010,4996,company:06933010,THE MELLER EDUCATIONAL TRUST
+356,Northern Education Trust,multi-academy trust,,company:07189647,4036,company:07189647,NORTHERN EDUCATION TRUST
+357,"Aylesbury Vale Academy, The",single-academy trust,,,,company:06745367,THE AYLESBURY VALE ACADEMY
+358,Greenwood Academies Trust,multi-academy trust,,company:06864339,3252,company:06864339,GREENWOOD ACADEMIES TRUST
+359,"Northumberland Church of England Academy, The",single-academy trust,,,,company:06653439,THE NORTHUMBERLAND CHURCH OF ENGLAND ACADEMY
+360,"Skinners' Kent Academy, The",multi-academy trust,,company:06912857,15760,company:06912857,THE SKINNERS' KENT ACADEMY
+361,"Basildon Academies, The",multi-academy trust,,company:06308595,2248,company:06308595,THE BASILDON ACADEMIES
+362,City Academy Norwich,single-academy trust,,,,company:06934137,CITY ACADEMY NORWICH
+363,Manchester Creative And Media Academy,multi-academy trust,,company:06888873,3839,company:06888873,MARCH 2016 LIMITED
+364,E-ACT,multi-academy trust,,company:06526376,2974,company:06526376,E-ACT
+365,White Rose Academies Trust,multi-academy trust,,company:07958615,5316,company:07958615,WHITE ROSE ACADEMIES TRUST
+366,"Fulwood Academy, The",multi-academy trust,,company:06960253,3147,company:06960253,THE FULWOOD ACADEMY
+367,Furness Academies Trust,multi-academy trust,,company:06895426,15877,company:06895426,FURNESS ACADEMIES TRUST
+368,University of Chester Academies Trust,multi-academy trust,,company:06929486,5152,company:06929486,UNIVERSITY OF CHESTER ACADEMIES TRUST
+369,School Partnership Trust Academies,multi-academy trust,,company:07386086,4474,company:07386086,SCHOOL PARTNERSHIP TRUST ACADEMIES
+370,"Ridings’ Federation of Academies Trust, The",multi-academy trust,,company:06802948,4361,company:06802948,THE RIDINGS' FEDERATION OF ACADEMIES
+371,Sirius Academy,multi-academy trust,,company:06545396,5630,company:06545396,SIRIUS ACADEMY
+372,All Saints Academy Dunstable,single-academy trust,,,,company:06853140,ALL SAINTS ACADEMY DUNSTABLE
+373,George Eliot Trust,trust,,,,company:06976884,THE GEORGE ELIOT SCHOOL TRUST
+374,Outwood Grange Academies Trust,multi-academy trust,,company:06995649,4119,company:06995649,OUTWOOD GRANGE ACADEMIES TRUST
+375,Strood Academy,single-academy trust,,,,company:06914263,STROOD ACADEMY
+376,Arden Multi Academy Trust,multi-academy trust,,company:07375267,5671,company:07375267,ARDEN MULTI ACADEMY TRUST
+377,Bolton St Catherine's Academy,single-academy trust,,,,company:06929082,BOLTON ST CATHERINE'S ACADEMY
+378,City of Wolverhampton Academy Trust,multi-academy trust,,company:06969900,2709,company:06969900,CITY OF WOLVERHAMPTON ACADEMY TRUST
+379,The EWO Community School Group,trust,,,,,
+380,Cowes Parthfinder Partnership,trust,,,,,
+381,"All Saints' Academy, Cheltenham",single-academy trust,,,,company:06831538,"ALL SAINTS' ACADEMY, CHELTENHAM"
+382,Maltby Learning Trust,multi-academy trust,,company:07033915,3834,company:07033915,MALTBY LEARNING TRUST
+383,St George's Academy Trust,single-academy trust,,,,company:07087804,ST GEORGE'S ACADEMY TRUST
+384,Lincoln Diocesan Trust and Board of Finance Ltd,trust,,,,company:00097256,LINCOLN DIOCESAN TRUST AND BOARD OF FINANCE LIMITED
+385,The Coopers Edge Trust,trust,,,,company:07407883,THE COOPERS EDGE TRUST
+386,"Bedford Academy, The",single-academy trust,,,,company:06969741,THE BEDFORD ACADEMY
+387,East Manchester Academy,single-academy trust,,,,company:06747095,EAST MANCHESTER ACADEMY
+388,Drapers' Multi-Academy Trust,multi-academy trust,,company:07035556,2958,company:07035556,DRAPERS' MULTI-ACADEMY TRUST
+389,Trinity Academy Halifax,multi-academy trust,,company:06897239,5689,company:06897239,TRINITY ACADEMY HALIFAX
+390,"Co-operative Academies Trust, The",multi-academy trust,,company:07747126,2777,company:07747126,THE CO-OPERATIVE ACADEMIES TRUST
+391,Learning Schools Trust,multi-academy trust,,company:07145434,3716,company:07145434,LEARNING SCHOOLS TRUST
+392,Manchester Communication Academy,multi-academy trust,,company:06754335,16245,company:06754335,MANCHESTER COMMUNICATION ACADEMY
+393,"Eastbourne Academy, The",single-academy trust,,,,company:07181660,THE EASTBOURNE ACADEMY
+394,Brompton Academy,single-academy trust,,,,company:07185018,BROMPTON ACADEMY
+395,"Thinking Schools Academy Trust, The",multi-academy trust,,company:07359755,5049,company:07359755,THE THINKING SCHOOLS ACADEMY TRUST
+396,"Bishop of Winchester Academy Trust, The",single-academy trust,,,,company:07034121,THE BISHOP OF WINCHESTER ACADEMY TRUST
+397,Teesside Learning Trust,multi-academy trust,,company:07185357,16246,company:07185357,TEESSIDE LEARNING TRUST
+398,"Bourne Academy, The",single-academy trust,,,,company:07148158,THE BOURNE ACADEMY
+399,Sidney Stringer Multi Academy Trust,multi-academy trust,,company:06672920,4521,company:06672920,SIDNEY STRINGER MULTI ACADEMY TRUST
+400,Shirebrook Academy,multi-academy trust,,company:06628631,4510,company:06628631,SHIREBROOK ACADEMY
+401,Knole Academy Trust,single-academy trust,,,,company:07115882,KNOLE ACADEMY TRUST
+402,"Skinners' Academy, The",single-academy trust,,,,company:06543682,THE SKINNERS' ACADEMY
+403,"Sutton Academy, The",single-academy trust,,,,company:07103919,THE SUTTON ACADEMY
+404,"ALL SAINTS CHURCH OF ENGLAND ACADEMY, PLYMOUTH",single-academy trust,,,,company:07035041,"ALL SAINTS CHURCH OF ENGLAND ACADEMY, PLYMOUTH"
+405,London Academies Enterprise Trust,multi-academy trust,,company:07211219,3771,company:07211219,LONDON ACADEMIES ENTERPRISE TRUST
+406,Moor End Academies Trust,multi-academy trust,,company:07599308,3933,company:07599308,MOOR END ACADEMIES TRUST
+407,King Edward VI Sheldon Heath Academy,single-academy trust,,,,company:07002160,KING EDWARD VI SHELDON HEATH ACADEMY
+408,"Kemnal Academies Trust, The",multi-academy trust,,company:07348231,3586,company:07348231,THE KEMNAL ACADEMIES TRUST
+409,"Midland Academies Trust, The",multi-academy trust,,company:07191874,3908,company:07191874,THE MIDLAND ACADEMIES TRUST
+410,Brighton Aldridge Community Academy,single-academy trust,,,,company:06741989,BRIGHTON ALDRIDGE COMMUNITY ACADEMY
+411,Marine Academy Plymouth,multi-academy trust,,company:07194412,3858,company:07194412,MARINE ACADEMY PLYMOUTH
+412,Hammersmith Academy Trust,single-academy trust,,,,company:06397195,HAMMERSMITH ACADEMY TRUST
+413,Dover Christ Church Academy,single-academy trust,,,,company:07208598,DOVER CHRIST CHURCH ACADEMY
+414,DYRMS - An Academy with Military Traditions,single-academy trust,,,,company:07209122,DYRMS - AN ACADEMY WITH MILITARY TRADITIONS
+415,Sarum Academy,single-academy trust,,,,company:07035327,SARUM ACADEMY
+416,"Fallibroome Trust, The",multi-academy trust,,company:07346144,3080,company:07346144,THE FALLIBROOME TRUST
+417,Ormiston Bolingbroke Academy Trust,single-academy trust,,,,company:07349394,ORMISTON BOLINGBROKE ACADEMY TRUST
+418,Tollbar Multi Academy Trust,multi-academy trust,,company:08085503,5079,company:08085503,TOLLBAR MULTI ACADEMY TRUST
+419,Richard Huish Trust,multi-academy trust,,company:09320523,5604,company:09320523,RICHARD HUISH TRUST
+420,Bright Tribe Trust,multi-academy trust,,company:08144578,2439,company:08144578,BRIGHT TRIBE TRUST
+421,"John Wallis Church of England Academy, Ashford, The",single-academy trust,,,,company:07006159,"THE JOHN WALLIS CHURCH OF ENGLAND ACADEMY, ASHFORD"
+422,University Academy Keighley,single-academy trust,,,,company:07134810,UNIVERSITY ACADEMY KEIGHLEY
+423,"White Horse Federation, The",multi-academy trust,,company:08075785,5315,company:08075785,THE WHITE HORSE FEDERATION
+424,Academies South West,multi-academy trust,,company:07451553,3643,company:07451553,ACADEMIES SOUTH WEST
+425,CWA Academy Trust,multi-academy trust,,company:07338780,2840,company:07338780,CWA ACADEMY TRUST
+426,"Quest Academy - Coloma Trust, The",single-academy trust,,,,company:07278887,THE QUEST ACADEMY - COLOMA TRUST
+427,Inspiration Trust,multi-academy trust,,company:08179349,3531,company:08179349,INSPIRATION TRUST
+428,Ambitions Academies Trust,multi-academy trust,,company:07977940,2128,company:07977940,AMBITIONS ACADEMIES TRUST
+429,Harborne Academy,single-academy trust,,,,company:07310176,HARBORNE ACADEMY
+430,South Tyneside Co-Operative Special School Trust,trust,,,,company:07852059,SOUTH TYNESIDE CO-OPERATIVE SPECIAL SCHOOL TRUST
+431,Arthur Mellows Village College,single-academy trust,,,,company:07333133,ARTHUR MELLOWS VILLAGE COLLEGE
+432,Chadwell Heath Academy,single-academy trust,,,,company:07346826,CHADWELL HEATH ACADEMY
+433,St Buryan Academy Primary School,single-academy trust,,,,company:07342848,ST BURYAN ACADEMY PRIMARY SCHOOL
+434,Swale Academies Trust,multi-academy trust,,company:07344732,4885,company:07344732,SWALE ACADEMIES TRUST
+435,Hartismere Family of Schools,multi-academy trust,,company:07341583,16115,company:07341583,HARTISMERE FAMILY OF SCHOOLS
+436,Westcliff High School for Boys Limited,single-academy trust,,,,company:07347930,WESTCLIFF HIGH SCHOOL FOR BOYS LIMITED
+437,Audenshaw School Academy Trust,single-academy trust,,,,company:07333089,AUDENSHAW SCHOOL ACADEMY TRUST
+438,"Barnby Road Trust, The",single-academy trust,,,,company:07345215,THE BARNBY ROAD TRUST
+439,"Premier Academy Limited, The",single-academy trust,,,,company:07324340,THE PREMIER ACADEMY LIMITED
+440,Watford Grammar School for Boys,single-academy trust,,,,company:07348288,WATFORD GRAMMAR SCHOOL FOR BOYS
+441,Healing Multi Academy Trust,multi-academy trust,,company:07345756,3364,company:07345756,HEALING MULTI ACADEMY TRUST
+442,Brine Multi Academy Trust,multi-academy trust,,company:07344747,16159,company:07344747,BRINE MULTI ACADEMY TRUST
+443,Cornerstone Academy Trust,multi-academy trust,,company:07339625,15879,company:07339625,CORNERSTONE ACADEMY TRUST
+444,"Giles Academy, The",single-academy trust,,,,company:07352123,THE GILES ACADEMY
+445,Heckmondwike Grammar School Academy Trust,single-academy trust,,,,company:07348329,HECKMONDWIKE GRAMMAR SCHOOL ACADEMY TRUST
+446,Cuckoo Hall Academies Trust,multi-academy trust,,company:07355559,2837,company:07355559,CUCKOO HALL ACADEMIES TRUST
+447,Seaton Academy,single-academy trust,,,,company:07343156,SEATON ACADEMY
+448,Uffculme Academy Trust,multi-academy trust,,company:07338835,5141,company:07338835,UFFCULME ACADEMY TRUST
+449,Durand Academy Trust,single-academy trust,,,,company:07345831,DURAND ACADEMY TRUST
+450,Watford Grammar School for Girls,single-academy trust,,,,company:07348254,WATFORD GRAMMAR SCHOOL FOR GIRLS
+451,Queen Elizabeth's School Barnet,single-academy trust,,,,company:07351253,QUEEN ELIZABETH'S SCHOOL BARNET
+452,"Spencer Academies Trust, The",multi-academy trust,,company:07353824,4609,company:07353824,THE SPENCER ACADEMIES TRUST
+453,"Cotswold School Academy Trust, The",single-academy trust,,,,company:07338767,THE COTSWOLD SCHOOL ACADEMY TRUST
+454,Goddard Park Community Primary School Academy Trust,single-academy trust,,,,company:07351053,GODDARD PARK COMMUNITY PRIMARY SCHOOL ACADEMY TRUST
+455,Huish Episcopi Academy,single-academy trust,,,,company:07341553,HUISH EPISCOPI ACADEMY
+456,Holyrood Academy Trust,single-academy trust,,,,company:07341523,HOLYROOD ACADEMY TRUST
+457,Hardenhuish School Limited,single-academy trust,,,,company:07344277,HARDENHUISH SCHOOL LIMITED
+458,Urmston Grammar,single-academy trust,,,,company:07335020,URMSTON GRAMMAR
+459,"Charter School Educational Trust, The",single-academy trust,,,,company:07338707,THE CHARTER SCHOOLS EDUCATIONAL TRUST
+460,Northampton School for Boys,single-academy trust,,,,company:07333885,NORTHAMPTON SCHOOL FOR BOYS
+461,"SCHOOLSCOMPANY Trust, The",multi-academy trust,,company:08304460,5522,company:08304460,THE SCHOOLSCOMPANY TRUST
+462,Learner Engagement and Achievement Partnership Multi-Academy Trust,multi-academy trust,,company:07361021,5478,company:07361021,LEARNER ENGAGEMENT AND ACHIEVEMENT PARTNERSHIP MULTI-ACADEMY TRUST
+463,"Canterbury Academy, The",multi-academy trust,,company:07345430,2539,company:07345430,THE CANTERBURY ACADEMY
+464,Park Hall Infant Academy,single-academy trust,,,,company:07380068,PARK HALL INFANT ACADEMY
+465,Highsted Academy Trust,single-academy trust,,,,company:07348116,HIGHSTED ACADEMY TRUST
+466,Sir Thomas Rich's School,single-academy trust,,,,company:07331954,SIR THOMAS RICH'S SCHOOL
+467,Highdown School and Sixth Form Centre,single-academy trust,,,,company:07398941,HIGHDOWN SCHOOL AND SIXTH FORM CENTRE
+468,Ashmole Academy,single-academy trust,,,,company:07375627,ASHMOLE ACADEMY TRUST LTD
+469,"Kingsdale Foundation, The",single-academy trust,,,,company:07407844,THE KINGSDALE FOUNDATION
+470,Midsomer Norton Schools Partnership,multi-academy trust,,company:07365778,3910,company:07365778,MIDSOMER NORTON SCHOOLS PARTNERSHIP
+471,"Learning Academy Trust, The",multi-academy trust,,company:07394649,5102,company:07394649,THE LEARNING ACADEMY TRUST
+472,"Westborough Academy, The",single-academy trust,,,,company:07384643,THE WESTBOROUGH ACADEMY
+473,"Queen Elizabeth's Grammar, Alford - A Selective Academy Limited",single-academy trust,,,,company:07388635,"QUEEN ELIZABETH'S GRAMMAR, ALFORD - A SELECTIVE ACADEMY LIMITED"
+474,Forest Academy,single-academy trust,,,,company:07400940,FOREST ACADEMY
+475,Sandwich Technology School,single-academy trust,,,,company:07401373,SANDWICH TECHNOLOGY SCHOOL
+476,ASPIRE Academy Trust,multi-academy trust,,company:07387540,2192,company:07387540,ASPIRE ACADEMY TRUST
+477,Chiltern Learning Trust,multi-academy trust,,company:07559901,2661,company:07559901,CHILTERN LEARNING TRUST
+478,St Patrick's Church of England Primary Academy,single-academy trust,,,,company:07401748,ST PATRICK'S CHURCH OF ENGLAND PRIMARY ACADEMY
+479,Torquay Boys' Grammar School,multi-academy trust,,company:07394671,5086,company:07394671,TORQUAY BOYS' GRAMMAR SCHOOL
+480,Samuel Ward Academy Trust,multi-academy trust,,company:07400386,4454,company:07400386,SAMUEL WARD ACADEMY TRUST
+481,John Taylor MAT,multi-academy trust,,company:07421140,5690,company:07421140,JOHN TAYLOR MAT
+482,Fulston Manor Academies Trust,multi-academy trust,,company:07343725,3145,company:07343725,FULSTON MANOR ACADEMIES TRUST
+483,R A Butler Infant School,single-academy trust,,,,company:07403352,R A BUTLER INFANT SCHOOL
+484,Kingsmead School,single-academy trust,,,,company:07380398,KINGSMEAD SCHOOL
+485,R A Butler Junior School,single-academy trust,,,,company:07403361,R A BUTLER JUNIOR SCHOOL
+486,Guru Nanak Sikh Academy Limited,multi-academy trust,,company:07416734,3275,company:07416734,GURU NANAK SIKH ACADEMY LIMITED
+487,Erith School,single-academy trust,,,,company:07372222,ERITH SCHOOL
+488,Wales High School Academy Trust,single-academy trust,,,,company:07372160,WALES HIGH SCHOOL ACADEMY TRUST
+489,Crosshall Infant School Academy Trust,single-academy trust,,,,company:07330691,CROSSHALL INFANT SCHOOL ACADEMY TRUST
+490,Beths Grammar School,single-academy trust,,,,company:07379768,BETHS GRAMMAR SCHOOL
+491,Ivybridge Academy Trust,multi-academy trust,,company:07398467,3547,company:07398467,IVYBRIDGE ACADEMY TRUST
+492,Fort Pitt Grammar School Academy Trust,multi-academy trust,,company:07401701,3123,company:07401701,FORT PITT THOMAS AVELING ACADEMIES
+493,Cleves Academy Trust,single-academy trust,,,,company:07403271,CLEVES ACADEMY TRUST
+494,Crosshall Junior School Limited,single-academy trust,,,,company:07363875,CROSSHALL JUNIOR SCHOOL LIMITED
+495,Sandbach High School and Sixth Form College,single-academy trust,,,,company:07404747,SANDBACH HIGH SCHOOL AND SIXTH FORM COLLEGE
+496,Lampton School Academy Trust,single-academy trust,,,,company:07345776,LAMPTON SCHOOL ACADEMY TRUST
+497,"Lark Rise Academy Trust, Dunstable",single-academy trust,,,,company:07359630,"LARK RISE ACADEMY TRUST, DUNSTABLE"
+498,"John Henry Newman Catholic College, The",single-academy trust,,,,company:07414011,THE JOHN HENRY NEWMAN CATHOLIC COLLEGE
+499,"Gosforth Federated Academies Limited, The",multi-academy trust,,company:07431423,3209,company:07431423,THE GOSFORTH FEDERATED ACADEMIES LIMITED
+500,Brook Learning Trust,multi-academy trust,,company:07368292,2468,company:07368292,BROOK LEARNING TRUST
+501,Caistor Grammar School,single-academy trust,,,,company:07330058,CAISTOR GRAMMAR SCHOOL
+502,Meopham Community Academies,multi-academy trust,,company:07416211,3892,company:07416211,MEOPHAM COMMUNITY ACADEMIES
+503,Pate's Grammar School,single-academy trust,,,,company:07369704,PATE'S GRAMMAR SCHOOL
+504,Abbey Academies Trust,multi-academy trust,,company:07318714,2044,company:07318714,ABBEY ACADEMIES TRUST
+505,Darrick Wood School,single-academy trust,,,,company:07393519,DARRICK WOOD SCHOOL
+506,Martham Primary & Nursery School Trust,single-academy trust,,,,company:07437149,MARTHAM PRIMARY & NURSERY SCHOOL TRUST
+507,"Queen Elizabeth School, Kirkby Lonsdale",single-academy trust,,,,company:07438425,"QUEEN ELIZABETH SCHOOL, KIRKBY LONSDALE"
+508,Branston Academy Trust,single-academy trust,,,,company:07419660,BRANSTON ACADEMY TRUST
+509,Dartford Grammar School,single-academy trust,,,,company:07406122,DARTFORD GRAMMAR SCHOOL
+510,Chellaston Academy,single-academy trust,,,,company:07430289,CHELLASTON ACADEMY
+511,Redhill Academy Trust,multi-academy trust,,company:07430317,4338,company:07430317,REDHILL ACADEMY TRUST
+512,Roger Ascham Primary School,single-academy trust,,,,company:07453918,ROGER ASCHAM PRIMARY SCHOOL
+513,Yardley Primary School,single-academy trust,,,,company:07432995,YARDLEY PRIMARY SCHOOL
+514,Fylde Coast Academy Trust,multi-academy trust,,company:08364709,3155,company:08364709,FYLDE COAST ACADEMY TRUST
+515,Colyton Grammar School Academy Trust,single-academy trust,,,,company:07445493,COLYTON GRAMMAR SCHOOL ACADEMY TRUST
+516,Parkstone Grammar School Trust,single-academy trust,,,,company:07461209,PARKSTONE GRAMMAR SCHOOL TRUST
+517,Bexley Grammar School,single-academy trust,,,,company:07455732,BEXLEY GRAMMAR SCHOOL
+518,Wigmore School,multi-academy trust,,company:07466409,5333,company:07466409,WIGMORE SCHOOL
+519,"Greetland Academy, The",single-academy trust,,,,company:07465343,THE GREETLAND ACADEMY
+520,Park Road Academy Primary School,single-academy trust,,,,company:07411759,PARK ROAD ACADEMY PRIMARY SCHOOL
+521,Wellington School,single-academy trust,,,,company:07458631,WELLINGTON SCHOOL
+522,Wellacre Technology Academy Trust,single-academy trust,,,,company:07386228,WELLACRE TECHNOLOGY ACADEMY TRUST
+523,Highworth Grammar School Trust,single-academy trust,,,,company:07425374,HIGHWORTH GRAMMAR SCHOOL TRUST
+524,Oreston Community Academy,single-academy trust,,,,company:07452782,ORESTON COMMUNITY ACADEMY
+525,Lancaster Girls' Grammar School,single-academy trust,,,,company:07441463,LANCASTER GIRLS' GRAMMAR SCHOOL
+526,"Chatham & Clarendon Grammar School Federation, The",multi-academy trust,,company:07455452,2622,company:07455452,CHATHAM & CLARENDON GRAMMAR SCHOOL
+527,Bodmin College,single-academy trust,,,,company:07459742,BODMIN COLLEGE
+528,Newquay Education Trust,multi-academy trust,,company:08961355,3995,company:08961355,NEWQUAY EDUCATION TRUST
+529,Whitburn Church of England Academy,single-academy trust,,,,company:07465520,WHITBURN CHURCH OF ENGLAND ACADEMY
+530,"Ockendon Academy, The",single-academy trust,,,,company:07451781,THE OCKENDON ACADEMY
+531,Churston Ferrers Grammar School,single-academy trust,,,,company:07447459,CHURSTON FERRERS GRAMMAR SCHOOL
+532,Lavington School Limited,single-academy trust,,,,company:07452837,LAVINGTON SCHOOL LIMITED
+533,Clitheroe Royal Grammar School,single-academy trust,,,,company:07461173,CLITHEROE ROYAL GRAMMAR SCHOOL
+534,South Wilts Grammar School For Girls,single-academy trust,,,,company:07451741,SOUTH WILTS GRAMMAR SCHOOL FOR GIRLS
+535,"GORSE Academies Trust, The",multi-academy trust,,company:07465701,3206,company:07465701,THE GORSE ACADEMIES TRUST
+536,St Stephen's Academy Canterbury,single-academy trust,,,,company:07441370,ST STEPHEN'S ACADEMY CANTERBURY
+537,Wakefield City Academies Trust,multi-academy trust,,company:07462885,5195,company:07462885,WAKEFIELD CITY ACADEMIES TRUST
+538,Lever Edge Primary Academy,single-academy trust,,,,company:07458484,LEVER EDGE PRIMARY ACADEMY
+539,"Broxbourne School, The",single-academy trust,,,,company:07447497,THE BROXBOURNE SCHOOL
+540,"King's (The Catherdral) School, Peterborough, The",single-academy trust,,,,company:07464058,"THE KING'S (THE CATHEDRAL) SCHOOL, PETERBOROUGH"
+541,John Kyrle High School & Sixth Form Centre,single-academy trust,,,,company:07465249,JOHN KYRLE HIGH SCHOOL & SIXTH FORM CENTRE
+542,Hastings Academies Trust,multi-academy trust,,company:07185046,3339,company:07185046,HASTINGS ACADEMIES TRUST
+543,Ninestiles Academy Trust Limited,multi-academy trust,,company:07348167,4004,company:07348167,NINESTILES ACADEMY TRUST LIMITED
+544,De La Salle Academy Trust,single-academy trust,,,,company:07466889,DE LA SALLE ACADEMY TRUST
+545,Wirral Academy Trust,multi-academy trust,,company:07472190,5631,company:07472190,WIRRAL ACADEMY TRUST
+546,Chelmsford County High School for Girls,single-academy trust,,,,company:07445392,CHELMSFORD COUNTY HIGH SCHOOL FOR GIRLS
+547,Hillyfield Primary Academy,single-academy trust,,,,company:07470621,HILLYFIELD PRIMARY ACADEMY
+548,The De Ferrers Trust,multi-academy trust,,company:07442789,15884,company:07442789,THE DE FERRERS TRUST
+549,Wakefield Diocesan Umbrella Trust,single-academy trust + umbrella trust,yes,,,company:07900244,WAKEFIELD DIOCESAN UMBRELLA TRUST
+550,William Farr Church of England Comprehensive School,single-academy trust + umbrella trust,,,,company:07469546,WILLIAM FARR CHURCH OF ENGLAND COMPREHENSIVE SCHOOL
+551,Debenham High School,single-academy trust,,,,company:07467445,DEBENHAM HIGH SCHOOL
+552,Tonbridge Grammar School,single-academy trust,,,,company:07455728,TONBRIDGE GRAMMAR SCHOOL
+553,"Compton School, The",single-academy trust,,,,company:07445586,THE COMPTON SCHOOL
+554,Dr Challoner's Grammar School,single-academy trust,,,,company:07451811,DR CHALLONER'S GRAMMAR SCHOOL
+555,Upton Court Educational Trust,multi-academy trust,,company:07462530,5165,company:07462530,UPTON COURT EDUCATIONAL TRUST
+556,Newton Academy Trust,single-academy trust,,,,company:06477646,NEWTON ACADEMY TRUST
+557,Priorslee Multi-Academy Trust,multi-academy trust,,company:07481145,16032,company:07481145,PRIORSLEE MULTI-ACADEMY TRUST
+558,"Flitch Green Academy, The",single-academy trust,,,,company:07477728,THE FLITCH GREEN ACADEMY
+559,Chilford Hundred Education Trust,multi-academy trust,,company:07482650,2659,company:07482650,CHILFORD HUNDRED EDUCATION TRUST
+560,Southend High School for Boys Academy trust,single-academy trust,,,,company:07485584,SOUTHEND HIGH SCHOOL FOR BOYS ACADEMY TRUST
+561,Southend High School for Girls Academy Trust,single-academy trust,,,,company:07487455,SOUTHEND HIGH SCHOOL FOR GIRLS ACADEMY TRUST
+562,"Priory Primary Academy Trust, The",single-academy trust,,,,company:07498234,THE PRIORY PRIMARY ACADEMY TRUST
+563,Kendrick School,single-academy trust,,,,company:07494754,KENDRICK SCHOOL
+564,Reading School,single-academy trust,,,,company:07475515,READING SCHOOL
+565,The Platanos Trust,multi-academy trust,,company:07492094,5004,company:07492094,THE PLATANOS TRUST
+566,North East Learning Trust,multi-academy trust,,company:07492165,4516,company:07492165,NORTH EAST LEARNING TRUST
+567,Paradigm Trust,multi-academy trust,,company:08469218,4131,company:08469218,PARADIGM TRUST
+568,Oakgrove School,single-academy trust,,,,company:07477947,OAKGROVE SCHOOL
+569,Weald of Kent Grammar School Academy Trust,single-academy trust,,,,company:07451660,WEALD OF KENT GRAMMAR SCHOOL ACADEMY TRUST
+570,Churchend Primary Academy Trust,single-academy trust,,,,company:07483163,CHURCHEND PRIMARY ACADEMY TRUST
+571,The Hamblin Education Trust,multi-academy trust,,company:07484717,15880,company:07484717,THE HAMBLIN EDUCATION TRUST
+572,Community Academies Trust,multi-academy trust,,company:07472736,2755,company:07472736,COMMUNITY ACADEMIES TRUST
+573,St. Joseph's College Edmund Rice Academy Trust,single-academy trust,,,,company:07490390,ST. JOSEPH'S COLLEGE EDMUND RICE ACADEMY TRUST
+574,Accord Multi Academy Trust,multi-academy trust,,company:07484308,16259,company:07484308,ACCORD MULTI ACADEMY TRUST
+575,Comberton Academy Trust,multi-academy trust,,company:07491945,2753,company:07491945,THE CAM ACADEMY TRUST
+576,William Willett Learning Trust,multi-academy trust,,company:07520128,5347,company:07520128,WILLIAM WILLETT LEARNING TRUST
+577,Herne Bay High School,single-academy trust,,,,company:07498923,HERNE BAY HIGH SCHOOL
+578,Aquinas Church of England Education Trust Limited,multi-academy trust,,company:07525735,2143,company:07525735,AQUINAS CHURCH OF ENGLAND EDUCATION TRUST LIMITED
+579,Chislehurst School For Girls,single-academy trust,,,,company:07527090,CHISLEHURST SCHOOL FOR GIRLS
+580,Denbigh School,single-academy trust,,,,company:07527108,DENBIGH SCHOOL
+581,"Prince Henry's High School Academy Trust, The",single-academy trust,,,,company:07512962,THE PRINCE HENRY'S HIGH SCHOOL ACADEMY TRUST
+582,Sharnbrook Academy Federation,multi-academy trust,,company:07500018,4495,company:07500018,SHARNBROOK ACADEMY FEDERATION
+583,Balcarras School,single-academy trust,,,,company:07495541,BALCARRAS SCHOOL
+584,"West Grantham Academies Trust, The",multi-academy trust,,company:07489113,5263,company:07489113,THE WEST GRANTHAM ACADEMIES TRUST
+585,Nicholas Hawksmoor Primary School,single-academy trust,,,,company:07489127,NICHOLAS HAWKSMOOR PRIMARY SCHOOL
+586,Wymondham College Academy Trust,single-academy trust,,,,company:07466353,SAPIENTIA EDUCATION TRUST
+587,Hockerill College Academy Trust,single-academy trust,,,,company:07488870,HOCKERILL COLLEGE ACADEMY TRUST
+588,Oldfield School,single-academy trust,,,,company:07495165,OLDFIELD SCHOOL
+589,Royal Grammar School High Wycombe,single-academy trust,,,,company:07492198,ROYAL GRAMMAR SCHOOL HIGH WYCOMBE
+590,Kirk Hallam Community Academy,single-academy trust,,,,company:07504871,KIRK HALLAM COMMUNITY ACADEMY
+591,Wise Academies,multi-academy trust,,company:07521946,5370,company:07521946,WISE ACADEMIES
+592,Tove Learning Trust,multi-academy trust,,company:07525820,16243,company:07525820,TOVE LEARNING TRUST
+593,Guilsborough Multi Academy Trust,multi-academy trust,,company:07535683,3273,company:07535683,GUILSBOROUGH MULTI ACADEMY TRUST
+594,South East Essex Academy Trust,multi-academy trust,,company:07527304,4569,company:07527304,SOUTH EAST ESSEX ACADEMY TRUST
+595,De Aston School Academy Trust,single-academy trust,,,,company:07533362,DE ASTON SCHOOL ACADEMY TRUST
+596,Bradworthy Primary Academy,single-academy trust,,,,company:07530497,BRADWORTHY PRIMARY ACADEMY
+597,Teignmouth Learning Trust,multi-academy trust,,company:07519888,4915,company:07519888,TEIGNMOUTH LEARNING TRUST
+598,Templer Academy Schools Trust,multi-academy trust,,company:07518252,4920,company:07518252,TEMPLER ACADEMY SCHOOLS TRUST
+599,Devonport High School for Boys Academy Trust,single-academy trust,,,,company:07523546,DEVONPORT HIGH SCHOOL FOR BOYS ACADEMY TRUST
+600,Red Kite Learning Trust,multi-academy trust,,company:07523507,15727,company:07523507,RED KITE LEARNING TRUST
+601,Sale Grammar School,single-academy trust,,,,company:07538380,SALE GRAMMAR SCHOOL
+602,Amherst School (Academy) Trust,multi-academy trust,,company:07517121,2133,company:07517121,AMHERST SCHOOL (ACADEMY) TRUST
+603,Bishop Wordsworth's Church of England Grammar School for Boys,single-academy trust,,,,company:07525856,BISHOP WORDSWORTH'S CHURCH OF ENGLAND GRAMMAR SCHOOL FOR BOYS
+604,Sir Roger Manwood's School,single-academy trust,,,,company:07539918,SIR ROGER MANWOOD'S SCHOOL
+605,The North Huddersfield Trust,trust,,,,company:07654346,THE NORTH HUDDERSFIELD TRUST
+606,"Ecclesbourne School, The",single-academy trust,,,,company:07524069,THE ECCLESBOURNE SCHOOL
+607,Torquay Girls' Grammar School,single-academy trust,,,,company:07494620,TORQUAY GIRLS' GRAMMAR SCHOOL
+608,West Norfolk Academies Trust,multi-academy trust,,company:07546118,5275,company:07546118,WEST NORFOLK ACADEMIES TRUST
+609,Newport Girls' High School Academy Trust,single-academy trust,,,,company:07521640,NEWPORT GIRLS' HIGH SCHOOL ACADEMY TRUST
+610,Apollo Learning Trust,multi-academy trust,,company:07553596,4308,company:07553596,APOLLO LEARNING TRUST
+611,Mottram St. Andrew Primary Academy,single-academy trust,,,,company:07548791,MOTTRAM ST. ANDREW PRIMARY ACADEMY
+612,Haydon School,single-academy trust,,,,company:07557791,HAYDON SCHOOL
+613,Beechen Cliff School,single-academy trust,,,,company:07551986,BEECHEN CLIFF SCHOOL
+614,Langley Grammar School,single-academy trust,,,,company:07536795,LANGLEY GRAMMAR SCHOOL
+615,Cranford Community College,single-academy trust,,,,company:07559818,CRANFORD COMMUNITY COLLEGE
+616,Bodriggy Academy,single-academy trust,,,,company:07548794,BODRIGGY ACADEMY
+617,The CSIA Trust,multi-academy trust,,company:07551989,15757,company:07551989,THE CSIA TRUST
+618,Hurworth School Limited,single-academy trust,,,,company:07533271,HURWORTH SCHOOL LIMITED
+619,The Queen Katherine School Multi Academy Trust,multi-academy trust,,company:07472799,5011,company:07472799,THE QUEEN KATHERINE SCHOOL MULTI ACADEMY TRUST
+620,Cirencester Deer Park School,single-academy trust,,,,company:07524811,CIRENCESTER DEER PARK SCHOOL
+621,"Robinswood Academy Trust, The",multi-academy trust,,company:07530418,4380,company:07530418,THE ROBINSWOOD ACADEMY TRUST
+622,Sunbury Manor School,single-academy trust,,,,company:07545019,SUNBURY MANOR SCHOOL
+623,Rutland And District Schools' Federation,multi-academy trust,,company:07552631,2584,company:07552631,RUTLAND AND DISTRICT SCHOOLS' FEDERATION
+624,Weydon School,single-academy trust,,,,company:07552535,WEYDON SCHOOL
+625,Ashperton Primary Academy Trust,single-academy trust,,,,company:07551088,ASHPERTON PRIMARY ACADEMY TRUST
+626,GLF Schools,multi-academy trust,,company:07551959,3190,company:07551959,GLF SCHOOLS
+627,Leo Academy Trust,multi-academy trust,,company:07543202,15878,company:07543202,LEO ACADEMY TRUST
+628,"Academy of Lincoln Trust, The",multi-academy trust,,company:07557670,2059,company:07557670,THE ACADEMY OF LINCOLN TRUST
+629,Trinitas Academy Trust,multi-academy trust,,company:07554121,5108,company:07554121,TRINITAS ACADEMY TRUST
+630,Eaton Bray Academy,single-academy trust,,,,company:07556185,EATON BRAY ACADEMY
+631,Education for the 21st Century,multi-academy trust,,company:07559170,3015,company:07559170,EDUCATION FOR THE 21ST CENTURY
+632,Sandye Place Academy,single-academy trust,,,,company:07563116,SANDYE PLACE ACADEMY
+633,Hartwell Primary School,single-academy trust,,,,company:07566298,HARTWELL PRIMARY SCHOOL
+634,"Bishop's Blue Coat Church of England High School, The",single-academy trust,,,,company:07570395,THE BISHOPS' BLUE COAT CHURCH OF ENGLAND HIGH SCHOOL
+635,"Hope Learning Trust, York",multi-academy trust,,company:07559537,5632,company:07559537,"HOPE LEARNING TRUST, YORK"
+636,Charles Darwin Academy Trust,multi-academy trust,,company:07554396,2611,company:07554396,CHARLES DARWIN ACADEMY TRUST
+637,Whitehill Community Academy Multi-Academy Trust,multi-academy trust,,company:07559439,5324,company:07559439,WHITEHILL COMMUNITY ACADEMY MULTI-ACADEMY TRUST
+638,Brookfield School Academy Trust,single-academy trust,,,,company:07563387,BROOKFIELD SCHOOL ACADEMY TRUST
+639,Belgrave St. Bartholomew's Academy,single-academy trust,,,,company:07552598,BELGRAVE ST. BARTHOLOMEW'S ACADEMY
+640,Alban Church of England Academy Trust,single-academy trust,,,,company:07563436,ALBAN CHURCH OF ENGLAND ACADEMY TRUST
+641,Newstead Wood School,single-academy trust,,,,company:07557883,NEWSTEAD WOOD SCHOOL
+642,Goldington Academy Trust,single-academy trust,,,,company:07557785,GOLDINGTON ACADEMY TRUST
+643,"Delamere Church of England Primary Academy, The",single-academy trust,,,,company:07533308,THE DELAMERE CHURCH OF ENGLAND PRIMARY ACADEMY
+644,Dame Alice Owen's School,single-academy trust,,,,company:07559285,DAME ALICE OWEN'S SCHOOL
+645,Ridgeway School,single-academy trust,,,,company:07691947,THE RIDGEWAY SCHOOL SIXTH FORM COLLEGE
+646,Hele's Trust,single-academy trust,,,,company:07561217,HELE'S TRUST
+647,Coombe Dean School Academy Trust,single-academy trust,,,,company:07561268,COOMBE DEAN SCHOOL ACADEMY TRUST
+648,Redborne Upper School and Community College,single-academy trust,,,,company:07566436,REDBORNE UPPER SCHOOL AND COMMUNITY COLLEGE
+649,Woodland Middle School Academy,single-academy trust,,,,company:07566455,WOODLAND MIDDLE SCHOOL ACADEMY
+650,South Dartmoor Academy,multi-academy trust,,company:07561204,4567,company:07561204,SOUTH DARTMOOR ACADEMY
+651,"Pegasus Academy Trust, The",multi-academy trust,,company:07542114,4168,company:07542114,THE PEGASUS ACADEMY TRUST
+652,Penair School,single-academy trust,,,,company:07557657,PENAIR SCHOOL
+653,Plymstock School,single-academy trust,,,,company:07557886,PLYMSTOCK SCHOOL
+654,Queen Elizabeth's Grammar School Trust Faversham,multi-academy trust,,company:07558466,4280,company:07558466,QUEEN ELIZABETH'S GRAMMAR SCHOOL TRUST FAVERSHAM
+655,Coastal Academies Trust,multi-academy trust,,company:07552665,2731,company:07552665,COASTAL ACADEMIES TRUST
+656,"Roseland Multi Academy Trust, The",multi-academy trust,,company:07557817,16049,company:07557817,THE ROSELAND MULTI ACADEMY TRUST
+657,Peninsula Learning Trust,multi-academy trust,,company:07565242,5479,company:07565242,PENINSULA LEARNING TRUST
+658,Corfe Hills School Academy Trust,single-academy trust,,,,company:07536911,CORFE HILLS SCHOOL ACADEMY TRUST
+659,Saltash Multi Academy Regional Trust,multi-academy trust,,company:07542166,4449,company:07542166,SALTASH MULTI ACADEMY REGIONAL TRUST
+660,"Brittons Academy Trust, The",single-academy trust,,,,company:07566198,THE BRITTONS ACADEMY TRUST
+661,"KJS Academy Trust, The",multi-academy trust,,company:07559293,3661,company:07559293,THE KJS ACADEMY TRUST
+662,"Crypt School, The",single-academy trust,,,,company:07489196,THE CRYPT SCHOOL
+663,Benfleet Schools Trust,multi-academy trust,,company:07561574,15726,company:07561574,BENFLEET SCHOOLS TRUST
+664,Cambridge Meridian Academies Trust,multi-academy trust,,company:07552498,2526,company:07552498,CAMBRIDGE MERIDIAN ACADEMIES TRUST
+665,Valley Invicta Academies Trust,multi-academy trust,,company:07559256,5178,company:07559256,VALLEY INVICTA ACADEMIES TRUST
+666,Towers School Academy Trust,single-academy trust,,,,company:07552058,TOWERS SCHOOL ACADEMY TRUST
+667,"Langley Park School for Boys Academy Trust, The",single-academy trust,,,,company:07553717,THE LANGLEY PARK SCHOOL FOR BOYS ACADEMY TRUST
+668,Ashlawn School Academy Trust,single-academy trust,,,,company:07515832,ASHLAWN SCHOOL ACADEMY TRUST
+669,Devonport High School for Girls,single-academy trust,,,,company:07556657,DEVONPORT HIGH SCHOOL FOR GIRLS
+670,Bartley Green School,single-academy trust,,,,company:07523506,BARTLEY GREEN SCHOOL
+671,Kings Norton Girls' School,single-academy trust,,,,company:07563329,KINGS NORTON GIRLS' SCHOOL
+672,John Port School,single-academy trust,,,,company:07564777,JOHN PORT SCHOOL
+673,Lordswood Academies Trust,multi-academy trust,,company:07567230,3788,company:07567230,LORDSWOOD ACADEMIES TRUST
+674,Fairfield High School for Girls,single-academy trust,,,,company:07511610,FAIRFIELD HIGH SCHOOL FOR GIRLS
+675,Rugby High School Academy Trust,single-academy trust,,,,company:07521636,RUGBY HIGH SCHOOL ACADEMY TRUST
+676,Callington Community College,single-academy trust,,,,company:07559238,CALLINGTON COMMUNITY COLLEGE
+677,Venture Multi Academy Trust,single-academy trust,,,,company:07535379,VENTURE MULTI ACADEMY TRUST
+678,"Coopers' Company and Coborn School, The",single-academy trust,,,,company:07547060,THE COOPERS' COMPANY AND COBORN SCHOOL
+679,Weare Academy First School,single-academy trust,,,,company:07557900,WEARE ACADEMY FIRST SCHOOL
+680,St Margaret's Academy,single-academy trust,,,,company:07566505,ST MARGARET'S ACADEMY
+681,The Tenax Schools Trust,multi-academy trust,,company:07542155,15903,company:07542155,THE TENAX SCHOOLS TRUST
+682,Brighouse High School Academy Trust,single-academy trust,,,,company:07566986,BRIGHOUSE HIGH SCHOOL ACADEMY TRUST
+683,William de Ferrers School,single-academy trust,,,,company:07552735,WILLIAM DE FERRERS SCHOOL
+684,Rickmansworth School,single-academy trust,,,,company:07563361,RICKMANSWORTH SCHOOL
+685,The Hoddesdon School Trust,single-academy trust,,,,company:07555066,THE HODDESDON SCHOOL TRUST
+686,"Knights Templar School, The",single-academy trust,,,,company:07552786,THE KNIGHTS TEMPLAR SCHOOL
+687,Sandringham School Academy Trust,single-academy trust,,,,company:07523557,SANDRINGHAM SCHOOL ACADEMY TRUST
+688,Staploe Education Trust,multi-academy trust,,company:07534901,4824,company:07534901,STAPLOE EDUCATION TRUST
+689,"Corsham School Academy Group, The",multi-academy trust,,company:07550425,2791,company:07550425,THE CORSHAM SCHOOL ACADEMY GROUP
+690,Exmouth Community College,single-academy trust,,,,company:07554085,EXMOUTH COMMUNITY COLLEGE
+691,Airedale Academies Trust,multi-academy trust,,company:07556117,2083,company:07556117,AIREDALE ACADEMIES TRUST
+692,Pool Academy,single-academy trust,,,,company:07525178,POOL ACADEMY
+693,"Tiffin Girls' School, The",single-academy trust,,,,company:07538459,THE TIFFIN GIRLS' SCHOOL
+694,Wood Green Academy,single-academy trust,,,,company:07538389,WOOD GREEN ACADEMY
+695,Pathfinder Multi Acdemy Trust,multi-academy trust,,company:07559610,16162,company:07559610,PATHFINDER MULTI ACADEMY TRUST
+696,Windsor Academy Trust,multi-academy trust,,company:07523436,5361,company:07523436,WINDSOR ACADEMY TRUST
+697,Ryders Hayes Academy Trust,single-academy trust,,,,company:07501579,RYDERS HAYES ACADEMY TRUST
+698,Shire Oak Academy Trust,single-academy trust,,,,company:07544974,SHIRE OAK ACADEMY TRUST
+699,Wilson's School,single-academy trust,,,,company:07536970,WILSON'S SCHOOL
+700,Alcester Grammar School,single-academy trust,,,,company:07485466,ALCESTER GRAMMAR SCHOOL
+701,Chosen Hill School,single-academy trust,,,,company:07550474,CHOSEN HILL SCHOOL
+702,Diverse Academies Trust,multi-academy trust,,company:07664012,2936,company:07664012,DIVERSE ACADEMIES TRUST
+703,Davenant Foundation School,single-academy trust,,,,company:07540256,DAVENANT FOUNDATION SCHOOL
+704,Inspiring Schools Partnership,multi-academy trust,,company:07557634,16114,company:07557634,INSPIRING SCHOOLS PARTNERSHIP
+705,Carlton Le Willows Academy,single-academy trust,,,,company:07539214,GREATER NOTTINGHAM EDUCATION TRUST
+706,East Midlands Education Trust,multi-academy trust,,company:07530373,2987,company:07530373,EAST MIDLANDS EDUCATION TRUST
+707,Uppingham Community College,single-academy trust,,,,company:07556159,UPPINGHAM COMMUNITY COLLEGE
+708,Corsham Primary School,single-academy trust,,,,company:07557894,CORSHAM PRIMARY SCHOOL
+709,Swakeleys School for Girls,single-academy trust,,,,company:07570315,SWAKELEYS SCHOOL FOR GIRLS
+710,Sheldon School,single-academy trust,,,,company:07556236,SHELDON SCHOOL
+711,Castleford Academy Trust,multi-academy trust,,company:07547039,2572,company:07547039,CASTLEFORD ACADEMY TRUST
+712,West Park School,single-academy trust,,,,company:07560177,WEST PARK SCHOOL
+713,Parkside Federation Academies,multi-academy trust,,company:07557831,4151,company:07557831,PARKSIDE FEDERATION ACADEMIES
+714,Maiden Erlegh Trust,multi-academy trust,,company:07548754,15762,company:07548754,MAIDEN ERLEGH TRUST
+715,Clyst Vale Academy Trust,single-academy trust,,,,company:07564519,CLYST VALE ACADEMY TRUST
+716,Kingsmead Academy,single-academy trust,,,,company:07547023,KINGSMEAD ACADEMY
+717,"Mountbatten School, The",single-academy trust,,,,company:07560175,THE MOUNTBATTEN SCHOOL
+718,Freemantle Church of England Community Academy,single-academy trust,,,,company:07561488,FREEMANTLE CHURCH OF ENGLAND COMMUNITY ACADEMY
+719,"King Edward VI Grammar School, Chelmsford",single-academy trust,,,,company:07563345,"KING EDWARD VI GRAMMAR SCHOOL, CHELMSFORD"
+720,Bohunt Education Trust,multi-academy trust,,company:07535642,2368,company:07535642,BOHUNT EDUCATION TRUST
+721,Hayes School (Bromley),single-academy trust,,,,company:07563213,HAYES SCHOOL (BROMLEY)
+722,Christleton High School,single-academy trust,,,,company:07523884,CHRISTLETON LEARNING TRUST
+723,QE Academy Trust,single-academy trust,,,,company:07562194,QE ACADEMY TRUST
+724,Kennet School Academies Trust,multi-academy trust,,company:07543874,3590,company:07543874,KENNET SCHOOL ACADEMIES TRUST
+725,Hayes School,single-academy trust,,,,company:07548734,HAYES SCHOOL
+726,Twynham Learning,multi-academy trust,,company:07565088,5480,company:07565088,TWYNHAM LEARNING
+727,The Gryphon Trust,multi-academy trust,,company:07546874,2161,company:07546874,THE GRYPHON TRUST
+728,Alderman Jacobs School,single-academy trust,,,,company:07531756,ALDERMAN JACOBS SCHOOL
+729,Wildern School,single-academy trust,,,,company:07554117,WILDERN SCHOOL
+730,Congleton Multi-Academy Trust,multi-academy trust,,company:07538467,2766,company:07538467,CONGLETON MULTI-ACADEMY TRUST
+731,Claremont High School Academy Trust,single-academy trust,,,,company:07557868,CLAREMONT HIGH SCHOOL ACADEMY TRUST
+732,Ringwood School,multi-academy trust,,company:07552519,4365,company:07552519,RINGWOOD SCHOOL
+733,East Barnet School,single-academy trust,,,,company:07552702,EAST BARNET SCHOOL
+734,Shiphay Learning Academy,single-academy trust,,,,company:07566835,SHIPHAY LEARNING ACADEMY
+735,Queens Park Academy,single-academy trust,,,,company:07566528,QUEENS PARK ACADEMY
+736,Yesoiday Hatorah School,single-academy trust,,,,company:07573614,YESOIDAY HATORAH SCHOOL
+737,"Williamson Trust, The",multi-academy trust,,company:07569727,5348,company:07569727,THE WILLIAMSON TRUST
+738,Loxford School Trust Limited,multi-academy trust,,company:08743560,3797,company:08743560,LOXFORD SCHOOL TRUST LIMITED
+739,Northern Star Academies Trust,multi-academy trust,,company:07553531,5667,company:07553531,NORTHERN STAR ACADEMIES TRUST
+740,Dulwich Hamlet Educational Trust,multi-academy trust,,company:07531811,15761,company:07531811,DULWICH HAMLET EDUCATIONAL TRUST
+741,"High School for Girls, Gloucester",single-academy trust,,,,company:07538730,"HIGH SCHOOL FOR GIRLS, GLOUCESTER"
+742,The Education Alliance,multi-academy trust,,company:07542211,3511,company:07542211,THE EDUCATION ALLIANCE
+743,Lipson Co-operative Academy Trust,single-academy trust,,,,company:07561306,LIPSON CO-OPERATIVE ACADEMY TRUST
+744,Brampton Manor Trust,multi-academy trust,,company:07540236,2413,company:07540236,BRAMPTON MANOR TRUST
+745,Magna Learning Trust,multi-academy trust,,company:07491215,3735,company:07491215,MAGNA LEARNING TRUST
+746,Kirkbie Kendal School Academy Trust,single-academy trust,,,,company:07543834,KIRKBIE KENDAL SCHOOL ACADEMY TRUST
+747,"Hayfield School, The",single-academy trust,,,,company:07547393,THE HAYFIELD SCHOOL
+748,"King's School Ottery St Mary, The",single-academy trust,,,,company:07560660,THE KING'S SCHOOL OTTERY ST MARY
+749,"Mirfield Free Grammar and Sixth Form Multi-Academy Trust, The",multi-academy trust,,company:07521584,3924,company:07521584,THE MIRFIELD FREE GRAMMAR AND SIXTH FORM MULTI-ACADEMY TRUST
+750,Bottisham Multi Academy Trust,multi-academy trust,,company:07564749,16031,company:07564749,ANGLIAN LEARNING
+751,"College Academies Trust, The",multi-academy trust,,company:07272906,2743,company:07272906,THE COLLEGE ACADEMIES TRUST
+752,"Hermitage Academy Trust, The",single-academy trust,,,,company:07559614,THE HERMITAGE ACADEMY TRUST
+753,Bullers Wood School,single-academy trust,,,,company:07588418,BULLERS WOOD SCHOOL
+754,QED Academy Trust,multi-academy trust,,company:07493622,4269,company:07493622,QED ACADEMY TRUST
+755,Lowbrook Academy Trust,single-academy trust,,,,company:07533254,LOWBROOK ACADEMY TRUST
+756,Bedfordshire East Multi-Academy Trust,multi-academy trust,,company:07546141,2275,company:07546141,BEDFORDSHIRE SCHOOLS TRUST LIMITED
+757,Step Academy Trust,multi-academy trust,,company:07612865,4836,company:07612865,STEP ACADEMY TRUST
+758,Thornden School,single-academy trust,,,,company:07562918,THORNDEN SCHOOL
+759,"Long Eaton School Academy Trust, The",single-academy trust,,,,company:07532146,THE LONG EATON SCHOOL ACADEMY TRUST
+760,Hodgson Academy,single-academy trust,,,,company:07604183,HODGSON ACADEMY
+761,Aston Community Education Trust,multi-academy trust,,company:07577113,2195,company:07577113,ASTON COMMUNITY EDUCATION TRUST
+762,"Burgate School and Sixth Form, The",single-academy trust,,,,company:07596997,THE BURGATE SCHOOL AND SIXTH FORM
+763,Backwell School,single-academy trust,,,,company:07545681,BACKWELL SCHOOL
+764,Wycombe High School Academies Trust,multi-academy trust,,company:07597324,5421,company:07597324,WYCOMBE HIGH SCHOOL ACADEMIES TRUST
+765,"Fernwood Academy Trust, The",single-academy trust,,,,company:07597390,THE FERNWOOD ACADEMY TRUST
+766,Cheltenham Bournside School and Sixth Form Centre,single-academy trust,,,,company:07524244,CHELTENHAM BOURNSIDE SCHOOL AND SIXTH FORM CENTRE
+767,Chalfont Saint Peter Church of England Academy,single-academy trust,,,,company:07586346,CHALFONT SAINT PETER CHURCH OF ENGLAND ACADEMY
+768,Oakwood Park Grammar School,multi-academy trust,,company:07584611,4074,company:07584611,OAKWOOD PARK GRAMMAR SCHOOL
+769,Evolution Schools Learning Trust,multi-academy trust,,company:07596422,3063,company:07596422,EVOLUTION SCHOOLS LEARNING TRUST
+770,Honywood Community Science School,multi-academy trust,,company:07592309,3477,company:07592309,HONYWOOD COMMUNITY SCIENCE SCHOOL
+771,Shenley Brook End School,single-academy trust,,,,company:07595434,SHENLEY BROOK END SCHOOL
+772,Ripley St Thomas Church of England Academy,single-academy trust,,,,company:07588464,RIPLEY ST THOMAS CHURCH OF ENGLAND ACADEMY
+773,Queen Elizabeth Grammar School Penrith,single-academy trust,,,,company:07584063,QUEEN ELIZABETH GRAMMAR SCHOOL PENRITH
+774,Park House School Newbury,single-academy trust,,,,company:07606250,PARK HOUSE SCHOOL NEWBURY
+775,Buttsbury Junior School,single-academy trust,,,,company:07601846,BUTTSBURY JUNIOR SCHOOL
+776,St.Edward's College Edmund Rice Academy Trust,single-academy trust,,,,company:07597686,ST.EDWARD'S COLLEGE EDMUND RICE ACADEMY TRUST
+777,South Craven Academy Trust,single-academy trust,,,,company:07591948,SOUTH CRAVEN ACADEMY TRUST
+778,Wood End Academy,single-academy trust,,,,company:07601680,WOOD END ACADEMY
+779,Lancaster Royal Grammar School,single-academy trust,,,,company:07469330,LANCASTER ROYAL GRAMMAR SCHOOL
+780,New College Durham Academies Trust,multi-academy trust,,company:07195175,3975,company:07195175,NEW COLLEGE DURHAM ACADEMIES TRUST
+781,"West London Free School Academy Trust, The",multi-academy trust,,company:07493696,5271,company:07493696,THE WEST LONDON FREE SCHOOL ACADEMY TRUST
+782,Overton Grange School,single-academy trust,,,,company:07627110,OVERTON GRANGE SCHOOL
+783,Stour Valley Educational Trust Limited,single-academy trust,,,,company:07226557,STOUR VALLEY EDUCATIONAL TRUST LIMITED
+784,West Hatch High School Academy Trust,single-academy trust,,,,company:07628943,WEST HATCH HIGH SCHOOL ACADEMY TRUST
+785,"Herefordshire Marches Federation of Academies, The",multi-academy trust,,company:07578861,3396,company:07578861,THE HEREFORDSHIRE MARCHES FEDERATION OF ACADEMIES
+786,Atlantic Centre of Excellence Multi Academy Trust,multi-academy trust,,company:08782544,2199,company:08782544,ATLANTIC CENTRE OF EXCELLENCE MULTI ACADEMY TRUST
+787,Violet Way Trust,multi-academy trust,,company:07606026,5188,company:07606026,VIOLET WAY TRUST
+788,Highcliffe School,multi-academy trust,,company:07631213,3410,company:07631213,HIGHCLIFFE SCHOOL
+789,Winchcombe School,single-academy trust,,,,company:07606409,WINCHCOMBE SCHOOL
+790,Linslade Academy Trust,single-academy trust,,,,company:07621395,LINSLADE ACADEMY TRUST
+791,Ribston Hall High School Academy Trust,single-academy trust,,,,company:07625308,RIBSTON HALL HIGH SCHOOL ACADEMY TRUST
+792,Uxbridge High School Academy Trust,single-academy trust,,,,company:07623418,UXBRIDGE HIGH SCHOOL ACADEMY TRUST
+793,Synaptic Trust,multi-academy trust,,company:07588104,4892,company:07588104,SYNAPTIC TRUST
+794,"King James I Academy, Bishop Auckland Limited",single-academy trust,,,,company:07638979,"KING JAMES I ACADEMY, BISHOP AUCKLAND LIMITED"
+795,John Hampden Grammar School,single-academy trust,,,,company:07638999,JOHN HAMPDEN GRAMMAR SCHOOL
+796,Cleeve School,single-academy trust,,,,company:07633215,CLEEVE SCHOOL
+797,Queen Mary's Grammar School (Walsall),single-academy trust,,,,company:07611347,QUEEN MARY'S GRAMMAR SCHOOL (WALSALL)
+798,West Somerset Academy Trust,multi-academy trust,,company:07630164,16116,company:07630164,WEST SOMERSET ACADEMIES TRUST
+799,Saffron Academy Trust,multi-academy trust,,company:07618351,4437,company:07618351,SAFFRON ACADEMY TRUST
+800,Queen Mary's High School (Walsall),single-academy trust,,,,company:07611345,QUEEN MARY'S HIGH SCHOOL (WALSALL)
+801,Sutton Coldfield Grammar School for Girls Academy Trust,single-academy trust,,,,company:07543893,SUTTON COLDFIELD GRAMMAR SCHOOL FOR GIRLS ACADEMY TRUST
+802,"Heath Family (North West), The",multi-academy trust,,company:07614421,3372,company:07614421,THE HEATH FAMILY (NORTH WEST)
+803,St. Anselm's College Edmund Rice Academy Trust,single-academy trust,,,,company:07638417,ST. ANSELM'S COLLEGE EDMUND RICE ACADEMY TRUST
+804,Sir William Borlase's Grammar School,single-academy trust,,,,company:07625556,SIR WILLIAM BORLASE'S GRAMMAR SCHOOL
+805,Thomas Mills High School,single-academy trust,,,,company:07605059,THOMAS MILLS HIGH SCHOOL
+806,"Kings of Wessex Academy Trust, The",single-academy trust,,,,company:07348580,WESSEX LEARNING TRUST
+807,Eaglesfield Paddle CE Primary Academy,single-academy trust,,,,company:07635527,EAGLESFIELD PADDLE CE PRIMARY ACADEMY
+808,Cheam Academies Network,multi-academy trust,,company:07588097,15881,company:07588097,CHEAM ACADEMIES NETWORK
+809,Studley High School,single-academy trust,,,,company:07610791,STUDLEY HIGH SCHOOL
+810,Sutton Grammar School Trust,single-academy trust,,,,company:07633715,SUTTON GRAMMAR SCHOOL TRUST
+811,"North Halifax Grammar School Academy Trust, The",single-academy trust,,,,company:07628903,THE NORTH HALIFAX GRAMMAR SCHOOL ACADEMY TRUST
+812,Nonsuch and Wallington Education Trust,multi-academy trust,,company:07627961,15882,company:07627961,NONSUCH AND WALLINGTON EDUCATION TRUST
+813,Fosse Way Academy Ltd,single-academy trust,,,,company:07534695,FOSSE WAY ACADEMY LTD
+814,Bridgwater College Trust,multi-academy trust,,company:08098956,2434,company:08098956,BRIDGWATER COLLEGE TRUST
+815,Olney Infant Academy,single-academy trust,,,,company:07622171,OLNEY INFANT ACADEMY
+816,Tower Road Academy (Primary),single-academy trust,,,,company:07629129,TOWER ROAD ACADEMY (PRIMARY)
+817,Westbourne Academy Trust,multi-academy trust,,company:07626526,16140,company:07626526,WESTBOURNE ACADEMY TRUST
+818,"Carshalton Girls Educational Trust, The",single-academy trust,,,,company:07635770,THE CARSHALTON GIRLS EDUCATIONAL TRUST
+819,WCGS Academy Trust,multi-academy trust,,company:07627302,15902,company:07627302,WCGS ACADEMY TRUST
+820,Carshalton Boys Sports College,single-academy trust,,,,company:07635432,CARSHALTON BOYS SPORTS COLLEGE
+821,Greenshaw Learning Trust,multi-academy trust,,company:07633694,5452,company:07633694,GREENSHAW LEARNING TRUST
+822,John Masefield High School and Sixth Form Centre,single-academy trust,,,,company:07631985,JOHN MASEFIELD HIGH SCHOOL AND SIXTH FORM CENTRE
+823,St Luke's Church Of England School,single-academy trust,,,,company:07451568,ST LUKE'S CHURCH OF ENGLAND SCHOOL
+824,Eden Primary Trust,single-academy trust,,,,company:07313138,EDEN PRIMARY TRUST
+825,"Free School Norwich, The",single-academy trust,,,,company:07408229,THE FREE SCHOOL NORWICH
+826,Russell Education Trust,multi-academy trust,,company:07452885,4421,company:07452885,RUSSELL EDUCATION TRUST
+827,Copleston High School,single-academy trust,,,,company:07656715,COPLESTON HIGH SCHOOL
+828,Collingwood College,single-academy trust,,,,company:07657277,COLLINGWOOD COLLEGE
+829,Arnold Academy,single-academy trust,,,,company:07670723,ARNOLD ACADEMY
+830,Elmlea Junior School,single-academy trust,,,,company:07626956,ELMLEA JUNIOR SCHOOL
+831,Trewirgie Junior School,single-academy trust,,,,company:07652476,TREWIRGIE JUNIOR SCHOOL
+832,"Howard Partnership Trust, The",multi-academy trust,,company:07597068,3493,company:07597068,THE HOWARD PARTNERSHIP TRUST
+833,Farlingaye High School,single-academy trust,,,,company:07667407,FARLINGAYE HIGH SCHOOL
+834,Reid Street Primary School,single-academy trust,,,,company:07658688,REID STREET PRIMARY SCHOOL
+835,Hummersknott Academy Trust,multi-academy trust,,company:07664322,3507,company:07664322,HUMMERSKNOTT ACADEMY TRUST
+836,Ansford Academy Trust,single-academy trust,,,,company:07657806,ANSFORD ACADEMY TRUST
+837,Whitley Academy,single-academy trust,,,,company:07657794,WHITLEY ACADEMY
+838,Wedmore First School Academy And Nursery,single-academy trust,,,,company:07664284,WEDMORE FIRST SCHOOL ACADEMY AND NURSERY
+839,Milton Keynes Education Trust,multi-academy trust,,company:07663689,3918,company:07663689,MILTON KEYNES EDUCATION TRUST
+840,"Hazeley Academy, The",single-academy trust,,,,company:07611275,THE HAZELEY ACADEMY
+841,Sir Henry Floyd Grammar School Academy Trust,single-academy trust,,,,company:07657307,INSIGNIS ACADEMY TRUST
+842,Aylesbury High School,single-academy trust,,,,company:07633357,AYLESBURY HIGH SCHOOL
+843,Brookside Community Primary School Academy Trust,single-academy trust,,,,company:07641618,BROOKSIDE COMMUNITY PRIMARY SCHOOL ACADEMY TRUST
+844,Pewsey Vale School,single-academy trust,,,,company:07662809,PEWSEY VALE SCHOOL
+845,Poole Grammar School,single-academy trust,,,,company:07666111,POOLE GRAMMAR SCHOOL
+846,Bishop Fox's School,single-academy trust,,,,company:07660968,BISHOP FOX'S SCHOOL
+847,Penryn College,single-academy trust,,,,company:07654298,PENRYN COLLEGE
+848,Oxley Park Academy Trust,single-academy trust,,,,company:07660971,OXLEY PARK ACADEMY TRUST
+849,"Stanford & Corringham Schools Trust, The",multi-academy trust,,company:07660783,4819,company:07660783,THE STANFORD & CORRINGHAM SCHOOLS TRUST
+850,Moulsham Infant School,single-academy trust,,,,company:07610916,MOULSHAM INFANT SCHOOL
+851,Gordano School,single-academy trust,,,,company:07481956,GORDANO SCHOOL COMMUNITY TRUST
+852,Aspire Academies Trust,multi-academy trust,,company:08187216,2189,company:08187216,ASPIRE ACADEMIES TRUST
+853,"Highcrest Academy, The",single-academy trust,,,,company:07633379,THE HIGHCREST ACADEMY
+854,Cliffe Woods Primary School,single-academy trust,,,,company:07659069,CLIFFE WOODS PRIMARY SCHOOL
+855,Highworth Warneford School,single-academy trust,,,,company:07660247,HIGHWORTH WARNEFORD SCHOOL
+856,"Billericay School, The",single-academy trust,,,,company:07666213,THE BILLERICAY SCHOOL
+857,Moulsham High School,single-academy trust,,,,company:07663795,MOULSHAM HIGH SCHOOL
+858,RMET,multi-academy trust,,company:07654628,16030,company:07654628,RMET
+859,"Southwater Junior Academy, The",single-academy trust,,,,company:07540802,THE SOUTHWATER JUNIOR ACADEMY
+860,"Southwater Infant Academy, The",single-academy trust,,,,company:07540811,THE SOUTHWATER INFANT ACADEMY
+861,"Primary Academies Trust, The",multi-academy trust,,company:07821367,4243,company:07821367,THE PRIMARY ACADEMIES TRUST
+862,"King Edmund School, The",single-academy trust,,,,company:07633375,THE KING EDMUND SCHOOL
+863,North Kesteven School,single-academy trust,,,,company:07657605,NORTH KESTEVEN SCHOOL
+864,Mounts Bay Academy,single-academy trust,,,,company:07657923,MOUNTS BAY ACADEMY
+865,Stroud High School,single-academy trust,,,,company:07657741,STROUD HIGH SCHOOL
+866,Brentwood Academies Trust,multi-academy trust,,company:07638800,2424,company:07638800,BRENTWOOD ACADEMIES TRUST
+867,"Prospect School, Reading",single-academy trust,,,,company:07660159,"PROSPECT SCHOOL, READING"
+868,Queens' School (Bushey),single-academy trust,,,,company:07650609,QUEENS' SCHOOL (BUSHEY)
+869,Torch Academy Gateway Trust,multi-academy trust,,company:07635510,5084,company:07635510,TORCH ACADEMY GATEWAY TRUST
+870,St Hilary School,single-academy trust,,,,company:07655662,ST HILARY SCHOOL
+871,"Holt School, The",single-academy trust,,,,company:07661205,THE HOLT SCHOOL
+872,Trewirgie Infants School,single-academy trust,,,,company:07652964,TREWIRGIE INFANTS SCHOOL
+873,Equitas Academies Trust,multi-academy trust,,company:07662289,3047,company:07662289,EQUITAS ACADEMIES TRUST
+874,Chestnut Grove Academy,single-academy trust,,,,company:07655651,CHESTNUT GROVE ACADEMY
+875,Aylesbury Grammar School,single-academy trust,,,,company:07538386,AYLESBURY GRAMMAR SCHOOL
+876,Matrix Academy Trust,multi-academy trust,,company:07654219,3878,company:07654219,MATRIX ACADEMY TRUST
+877,Erasmus Darwin Academy,single-academy trust,,,,company:07669035,ERASMUS DARWIN ACADEMY
+878,Cambridgeshire Educational Trust,multi-academy trust,,company:07665396,16249,company:07665396,CAMBRIDGESHIRE EDUCATIONAL TRUST
+879,South Farnham Educational Trust,multi-academy trust,,company:07652902,5481,company:07652902,SOUTH FARNHAM EDUCATIONAL TRUST
+880,St Bede Church of England Primary Academy,single-academy trust,,,,company:07628909,ST BEDE CHURCH OF ENGLAND PRIMARY ACADEMY
+881,Christopher Whitehead Language College,single-academy trust,,,,company:07634426,CHRISTOPHER WHITEHEAD LANGUAGE COLLEGE
+882,"Piggott Church of England School, The",single-academy trust,,,,company:07682284,THE PIGGOTT CHURCH OF ENGLAND SCHOOL
+883,Coast Academies,multi-academy trust,,company:07668923,2729,company:07668923,COAST ACADEMIES
+884,St Michael's Church Of England Academy Trust,single-academy trust,,,,company:07654237,ST MICHAEL'S CHURCH OF ENGLAND ACADEMY TRUST
+885,Preston School Academy Trust,single-academy trust,,,,company:07657910,PRESTON SCHOOL ACADEMY TRUST
+886,"Oldershaw Academy, The",single-academy trust,,,,company:07652792,THE OLDERSHAW ACADEMY
+887,Rossett School,single-academy trust,,,,company:07664288,ROSSETT SCHOOL
+888,"Chantry School, The",single-academy trust,,,,company:07657852,THE CHANTRY SCHOOL
+889,Haybridge High School,single-academy trust,,,,company:07652306,HAYBRIDGE HIGH SCHOOL
+890,Parmiter's School,single-academy trust,,,,company:07662765,PARMITER'S SCHOOL
+891,St Wilfrid's Church of England Academy,single-academy trust,,,,company:07671404,ST WILFRID'S CHURCH OF ENGLAND ACADEMY
+892,Danes Educational Trust,multi-academy trust,,company:07671949,16254,company:07671949,DANES EDUCATIONAL TRUST
+893,Keswick School,single-academy trust,,,,company:07664297,KESWICK SCHOOL
+894,Great Baddow High School,single-academy trust,,,,company:07662023,GREAT BADDOW HIGH SCHOOL
+895,Ilkley Grammar School,single-academy trust,,,,company:07663864,ILKLEY GRAMMAR SCHOOL
+896,Guildford Education Partnership,multi-academy trust,,company:07649091,3272,company:07649091,GUILDFORD EDUCATION PARTNERSHIP
+897,Myton School Trust,single-academy trust,,,,company:07669416,MYTON SCHOOL TRUST
+898,Fairfax Multi Academy Trust,multi-academy trust,,company:07661164,3076,company:07661164,FAIRFAX MULTI ACADEMY TRUST
+899,Heart of England School,single-academy trust,,,,company:07654164,HEART OF ENGLAND SCHOOL
+900,Tiffin School,single-academy trust,,,,company:07547311,TIFFIN SCHOOL
+901,Royal Wootton Bassett Academy,single-academy trust,,,,company:07569743,ROYAL WOOTTON BASSETT ACADEMY
+902,Honiton Community College Academy Trust,single-academy trust,,,,company:07665387,HONITON COMMUNITY COLLEGE ACADEMY TRUST
+903,Crispin School Academy Trust,single-academy trust,,,,company:07669314,CRISPIN SCHOOL ACADEMY TRUST
+904,Glenthorne High School,single-academy trust,,,,company:07635098,GLENTHORNE HIGH SCHOOL
+905,Warren Road Primary School,single-academy trust,,,,company:07645774,WARREN ROAD PRIMARY SCHOOL
+906,"Castle Partnership Trust, The",multi-academy trust,,company:07657731,2564,company:07657731,THE CASTLE PARTNERSHIP TRUST
+907,Haygrove School,single-academy trust,,,,company:07665225,THE HAYGROVE ACADEMY TRUST
+908,Hadleigh High School,single-academy trust,,,,company:07657751,HADLEIGH HIGH SCHOOL
+909,"Spring Partnership Trust, The",multi-academy trust,,company:07656245,3496,company:07656245,THE SPRING PARTNERSHIP TRUST
+910,"Cottingham Trust, The",single-academy trust,,,,company:07553984,THE COTTINGHAM TRUST
+911,Yavneh College Academy Trust,single-academy trust,,,,company:07643712,YAVNEH COLLEGE ACADEMY TRUST
+912,Woodrush High School An Academy For Students Aged 11-18 Ltd,single-academy trust,,,,company:07677510,WOODRUSH HIGH SCHOOL AN ACADEMY FOR STUDENTS AGED 11-18 LTD
+913,Pershore High School,single-academy trust,,,,company:07665364,PERSHORE HIGH SCHOOL
+914,"Redstart Learning Partnership, The",multi-academy trust,,company:07649832,5598,company:07649832,THE REDSTART LEARNING PARTNERSHIP
+915,Droitwich Spa High School and Sixth Form Centre,single-academy trust,,,,company:07666185,DROITWICH SPA HIGH SCHOOL AND SIXTH FORM CENTRE
+916,Avanti Schools Trust,multi-academy trust,,company:07506598,2209,company:07506598,AVANTI SCHOOLS TRUST
+917,"Woodland Academy Trust, The",multi-academy trust,,company:07694050,5396,company:07694050,THE WOODLAND ACADEMY TRUST
+918,Black Country UTC,single-academy trust,,,,company:07556132,BLACK COUNTRY UTC
+919,Etz Chaim Jewish Primary School Trust,single-academy trust,,,,company:07471707,ETZ CHAIM JEWISH PRIMARY SCHOOL TRUST
+920,Schools Development Partnership,trust,,,,company:07246113,THE CO-OPERATIVE SCHOOL DEVELOPMENT PARTNERSHIP LIMITED
+921,Birmingham Ormiston Academy,single-academy trust,,,,company:06832416,BIRMINGHAM ORMISTON ACADEMY
+922,Langley Hall Primary Academy Trust,single-academy trust,,,,company:07463031,LANGLEY HALL PRIMARY ACADEMY TRUST
+923,Bridge Multi-academy Trust,multi-academy trust,,company:07736425,2430,company:07736425,BRIDGE MULTI-ACADEMY TRUST
+924,Caistor Yarborough Academy Limited,single-academy trust,,,,company:07680513,CAISTOR YARBOROUGH ACADEMY LIMITED
+925,"Cheadle Academy, The",single-academy trust,,,,company:07694080,THE CHEADLE ACADEMY
+926,Chipping Campden School,single-academy trust,,,,company:07680770,CHIPPING CAMPDEN SCHOOL
+927,"Key Educational Trust, The",multi-academy trust,,company:07702211,16091,company:07702211,THE KEY EDUCATIONAL TRUST
+928,Feversham Education Trust,multi-academy trust,,company:07697587,16050,company:07697587,FEVERSHAM EDUCATION TRUST
+929,Finham Park Multi-Academy Trust,multi-academy trust,,company:07700317,15766,company:07700317,FINHAM PARK MULTI-ACADEMY TRUST
+930,Great Marlow School,single-academy trust,,,,company:07690054,GREAT MARLOW SCHOOL
+931,Flixton Girls' School Academy Trust,single-academy trust,,,,company:07691820,FLIXTON GIRLS' SCHOOL ACADEMY TRUST
+932,Hayesfield Girls' School,single-academy trust,,,,company:07671637,HAYESFIELD GIRLS' SCHOOL
+933,Holy Cross Catholic Primary Academy,single-academy trust,,,,company:07696114,HOLY CROSS CATHOLIC PRIMARY ACADEMY
+934,John Spendluffe Technology College,single-academy trust,,,,company:07683660,JOHN SPENDLUFFE TECHNOLOGY COLLEGE
+935,Kesgrave High School,single-academy trust,,,,company:07681739,KESGRAVE HIGH SCHOOL
+936,Oakfield School Academy Trust,single-academy trust,,,,company:07694044,OAKFIELD SCHOOL ACADEMY TRUST
+937,Park View Academy,single-academy trust,,,,company:07709270,PARK VIEW ACADEMY
+938,Queen Elizabeth's Grammar School Ashbourne Academy,single-academy trust,,,,company:07698914,QUEEN ELIZABETH'S GRAMMAR SCHOOL ASHBOURNE ACADEMY
+939,Roundwood Park School Academy Trust,single-academy trust,,,,company:07695458,ROUNDWOOD PARK SCHOOL ACADEMY TRUST
+940,Signhills Academy Limited,single-academy trust,,,,company:07660690,SIGNHILLS ACADEMY LIMITED
+941,Southfield School,single-academy trust,,,,company:07694399,SOUTHFIELD SCHOOL
+942,St Helen's Catholic Junior School Academy,single-academy trust,,,,company:07695916,ST HELEN'S CATHOLIC JUNIOR SCHOOL ACADEMY
+943,Stratford School Academy,single-academy trust,,,,company:07710532,STRATFORD SCHOOL ACADEMY
+944,Marches Academy Trust,multi-academy trust,,company:07680422,3855,company:07680422,MARCHES ACADEMY TRUST
+945,St Joseph's Catholic College,single-academy trust,,,,company:07696999,ST JOSEPH'S CATHOLIC COLLEGE
+946,Holy Cross Catholic Primary School,single-academy trust,,,,company:07696905,HOLY CROSS CATHOLIC PRIMARY SCHOOL
+947,St Peter's Catholic High School & Sixth Form Centre,single-academy trust,,,,company:07696728,ST PETER'S CATHOLIC HIGH SCHOOL & SIXTH FORM CENTRE
+948,Suckley School,single-academy trust,,,,company:07697002,SUCKLEY SCHOOL
+949,Mercian Educational Trust,multi-academy trust,,company:07698974,15935,company:07698974,MERCIAN EDUCATIONAL TRUST
+950,Sir William Romney's School,single-academy trust,,,,company:07694641,SIR WILLIAM ROMNEY'S SCHOOL
+951,"Arthur Terry Learning Partnership, The",multi-academy trust,,company:07730920,2166,company:07730920,THE ARTHUR TERRY LEARNING PARTNERSHIP
+952,"Swinton High School Academy Trust, The",single-academy trust,,,,company:07633705,THE SWINTON HIGH SCHOOL ACADEMY TRUST
+953,"Federation of Abbey Schools Academy Trust, The",multi-academy trust,,company:07699775,3090,company:07699775,THE FEDERATION OF ABBEY SCHOOLS ACADEMY TRUST
+954,Bury St Edmunds Academy Trust,multi-academy trust,,company:07697600,2508,company:07697600,BURY ST EDMUNDS ACADEMY TRUST
+955,Henley-in-Arden School,single-academy trust,,,,company:07660995,HENLEY-IN-ARDEN SCHOOL
+956,"St Neots Learning Partnership, The",multi-academy trust,,company:07703784,4771,company:07703784,THE ST NEOTS LEARNING PARTNERSHIP
+957,Alderbrook School,single-academy trust,,,,company:07687619,ALDERBROOK SCHOOL
+958,Beverley Grammar School,single-academy trust,,,,company:07688240,BEVERLEY GRAMMAR SCHOOL
+959,Bournemouth School for Girls,single-academy trust,,,,company:07703931,BOURNEMOUTH SCHOOL FOR GIRLS
+960,Bowland High Academy Trust,single-academy trust,,,,company:07678864,ACHIEVEMENT THROUGH COLLABORATION TRUST
+961,Bungay High School,single-academy trust,,,,company:07698578,BUNGAY HIGH SCHOOL
+962,Charlton Kings Infants' School,single-academy trust,,,,company:07689749,CHARLTON KINGS INFANTS' SCHOOL
+963,Churchill Academy,single-academy trust,,,,company:07687722,CHURCHILL ACADEMY
+964,Crofton Academy,single-academy trust,,,,company:07646836,CROFTON ACADEMY
+965,Freman College,single-academy trust,,,,company:07686458,FREMAN COLLEGE
+966,Graveney Trust,multi-academy trust,,company:07687897,3220,company:07687897,GRAVENEY TRUST
+967,Langley Park Academies,multi-academy trust,,company:07697400,5633,company:07697400,LANGLEY PARK ACADEMIES
+968,Langley School,single-academy trust,,,,company:07693853,LANGLEY SCHOOL
+969,Lode Heath School,single-academy trust,,,,company:07687663,LODE HEATH SCHOOL
+970,Aspirations Academies Trust,multi-academy trust,,company:07867577,2186,company:07867577,ASPIRATIONS ACADEMIES TRUST
+971,"Learning Alliance Academy Trust, The",multi-academy trust,,company:07703829,3711,company:07703829,THE LEARNING ALLIANCE ACADEMY TRUST
+972,Minsthorpe Academy Trust,single-academy trust,,,,company:07635467,MINSTHORPE ACADEMY TRUST
+973,Newport Community School Primary Academy,single-academy trust,,,,company:07700494,NEWPORT COMMUNITY SCHOOL PRIMARY ACADEMY
+974,North Essex Multi-Academy Trust,multi-academy trust,,company:07687474,4018,company:07687474,NORTH ESSEX MULTI-ACADEMY TRUST
+975,"Raleigh School, The",single-academy trust,,,,company:07686515,THE RALEIGH SCHOOL
+976,Canary Wharf College Ltd,multi-academy trust,,company:07413883,2535,company:07413883,CANARY WHARF COLLEGE LTD
+977,Rodborough,single-academy trust,,,,company:07694358,RODBOROUGH
+978,West Hill School,single-academy trust,,,,company:07697027,WEST HILL SCHOOL
+979,BRandH Academy Limited,multi-academy trust,,company:07698718,2415,company:07698718,BRANDH ACADEMY LIMITED
+980,Chulmleigh Academy Trust,multi-academy trust,,company:07697698,2685,company:07697698,CHULMLEIGH ACADEMY TRUST
+981,Hadleigh Infants and Nursery School (Academy),single-academy trust,,,,company:07698504,HADLEIGH INFANTS AND NURSERY SCHOOL (ACADEMY)
+982,Nower Hill High School,single-academy trust,,,,company:07690023,NOWER HILL HIGH SCHOOL
+983,South Benfleet Primary School,single-academy trust,,,,company:07684902,SOUTH BENFLEET PRIMARY SCHOOL
+984,South Essex Academy Trust,multi-academy trust,,company:07681226,5303,company:07681226,SOUTH ESSEX ACADEMY TRUST
+985,"St Mary's Catholic Primary School, Churchdown",single-academy trust,,,,company:07696498,"ST MARY'S CATHOLIC PRIMARY SCHOOL, CHURCHDOWN"
+986,Darrick Wood Infant School,single-academy trust,,,,company:07698658,DARRICK WOOD INFANT SCHOOL
+987,Katharine Lady Berkeley's School,single-academy trust,,,,company:07696921,KATHARINE LADY BERKELEY'S SCHOOL
+988,Holyhead School,single-academy trust,,,,company:07698296,HOLYHEAD SCHOOL
+989,"Pioneer Academy, The",multi-academy trust,,company:07691324,4209,company:07691324,THE PIONEER ACADEMY
+990,Abbey Multi Academy Trust,multi-academy trust,,company:07705552,2046,company:07705552,ABBEY MULTI ACADEMY TRUST
+991,Jefferys Education Trust,multi-academy trust,,company:07690473,3552,company:07690473,JEFFERYS EDUCATION TRUST
+992,Verulam School,single-academy trust,,,,company:07690125,VERULAM SCHOOL
+993,"Hathershaw College, The",single-academy trust,,,,company:07687135,THE HATHERSHAW COLLEGE
+994,"Campion School, The",single-academy trust,,,,company:07693827,THE CAMPION SCHOOL
+995,West Park Academy,single-academy trust,,,,company:07659444,WEST PARK ACADEMY
+996,King Edward VI Aston School,single-academy trust,,,,company:07656224,KING EDWARD VI ASTON SCHOOL
+997,King Edward VI Camp Hill School for Girls,single-academy trust,,,,company:07656265,KING EDWARD VI CAMP HILL SCHOOL FOR GIRLS
+998,King Edward VI Camp Hill School for Boys,single-academy trust,,,,company:07656262,KING EDWARD VI CAMP HILL SCHOOL FOR BOYS
+999,King Edward VI Five Ways School,single-academy trust,,,,company:07676490,KING EDWARD VI FIVE WAYS SCHOOL
+1000,King Edward VI Handsworth School,single-academy trust,,,,company:07656363,KING EDWARD VI HANDSWORTH SCHOOL
+1001,Mayflower High School,single-academy trust,,,,company:07692668,MAYFLOWER HIGH SCHOOL
+1002,Montsaye Community Learning Partnership,multi-academy trust,,company:07670511,3931,company:07670511,MONTSAYE COMMUNITY LEARNING PARTNERSHIP
+1003,Nunnery Wood High School,single-academy trust,,,,company:07694547,NUNNERY WOOD HIGH SCHOOL
+1004,Ousedale School,single-academy trust,,,,company:07647327,OUSEDALE SCHOOL
+1005,Plantsbrook Learning Trust,multi-academy trust,,company:07655702,4210,company:07655702,PLANTSBROOK LEARNING TRUST
+1006,Runwell Community Primary School Academy Trust,single-academy trust,,,,company:07673903,RUNWELL COMMUNITY PRIMARY SCHOOL ACADEMY TRUST
+1007,Sir John Leman High School,single-academy trust,,,,company:07682294,SIR JOHN LEMAN HIGH SCHOOL
+1008,Our Lady of Fatima Catholic Multi Academy Trust,multi-academy trust,,company:07696069,4114,company:07696069,OUR LADY OF FATIMA CATHOLIC MULTI ACADEMY TRUST
+1009,St. Laurence School Academy Trust,single-academy trust,,,,company:07698410,ST. LAURENCE SCHOOL ACADEMY TRUST
+1010,St. Mark's West Essex Catholic School,single-academy trust,,,,company:07694563,ST. MARK'S WEST ESSEX CATHOLIC SCHOOL
+1011,Thomas Keble School,single-academy trust,,,,company:07698037,THOMAS KEBLE SCHOOL
+1012,Tolworth Girls' School And Sixth Form,single-academy trust,,,,company:07700838,TOLWORTH GIRLS' SCHOOL AND SIXTH FORM
+1013,Inspiring Futures Through Learning,multi-academy trust,,company:07698904,16141,company:07698904,INSPIRING FUTURES THROUGH LEARNING
+1014,Westbury-on-Trym Church of England Academy,single-academy trust,,,,company:07669263,WESTBURY-ON-TRYM CHURCH OF ENGLAND ACADEMY
+1015,Portslade Aldridge Community Academy Trust,single-academy trust,,,,company:07672441,PORTSLADE ALDRIDGE COMMUNITY ACADEMY TRUST
+1016,"Macclesfield Academy, The",single-academy trust,,,,company:07597883,THE MACCLESFIELD ACADEMY
+1017,South Orpington Learning Alliance Multi-Academy Trust,multi-academy trust,,company:07943613,16095,company:07943613,SOUTH ORPINGTON LEARNING ALLIANCE MULTI-ACADEMY TRUST
+1018,Pickhurst Infant School,single-academy trust,,,,company:07698731,PICKHURST INFANT SCHOOL
+1019,Chancery Education Trust,multi-academy trust,,company:07671255,16092,company:07671255,CHANCERY EDUCATION TRUST
+1020,Kingstone Academy Trust,multi-academy trust,,company:07681857,3651,company:07681857,KINGSTONE ACADEMY TRUST
+1021,Holy Rood Catholic Primary School,single-academy trust,,,,company:07697045,HOLY ROOD CATHOLIC PRIMARY SCHOOL
+1022,Park High School,single-academy trust,,,,company:07689613,PARK HIGH SCHOOL
+1023,"Rosedale Hewens Academy Trust, The",multi-academy trust,,company:07683702,4397,company:07683702,THE ROSEDALE HEWENS ACADEMY TRUST
+1024,Stanchester Community School Academy,single-academy trust,,,,company:07677142,STANCHESTER COMMUNITY SCHOOL ACADEMY
+1025,St. Thomas More Catholic Primary School,single-academy trust,,,,company:07696148,ST. THOMAS MORE CATHOLIC PRIMARY SCHOOL
+1026,Bishop Stopford School,single-academy trust,,,,company:07698789,BISHOP STOPFORD SCHOOL
+1027,Campion School & Language College,single-academy trust,,,,company:07697798,CAMPION SCHOOL & LANGUAGE COLLEGE
+1028,"Palmer Catholic Academy, The",single-academy trust,,,,company:07696155,THE PALMER CATHOLIC ACADEMY
+1029,Caroline Chisholm School,single-academy trust,,,,company:07638756,CAROLINE CHISHOLM SCHOOL
+1030,Chauncy School,single-academy trust,,,,company:07694228,CHAUNCY SCHOOL
+1031,Chesham Grammar School Academy Trust,multi-academy trust,,company:07697482,15764,company:07697482,CHESHAM GRAMMAR SCHOOL ACADEMY TRUST
+1032,Diss High School,single-academy trust,,,,company:07692440,DISS HIGH SCHOOL
+1033,"Dunraven Educational Trust, The",single-academy trust,,,,company:07700362,THE DUNRAVEN EDUCATIONAL TRUST
+1034,Enfield Grammar School,single-academy trust,,,,company:07697044,ENFIELD GRAMMAR SCHOOL
+1035,Farmor's School,single-academy trust,,,,company:07707979,FARMOR'S SCHOOL
+1036,Gravesend Grammar School Academies Trust,multi-academy trust,,company:07685923,3222,company:07685923,GRAVESEND GRAMMAR SCHOOL ACADEMIES TRUST
+1037,Creative Education Trust,multi-academy trust,,company:07617529,2816,company:07617529,CREATIVE EDUCATION TRUST
+1038,Hanley Castle High School,single-academy trust,,,,company:07690414,HANLEY CASTLE HIGH SCHOOL
+1039,Highnam C of E Primary Academy,single-academy trust,,,,company:07701920,HIGHNAM C OF E PRIMARY ACADEMY
+1040,Hillview School for Girls Academy Trust,single-academy trust,,,,company:07698506,HILLVIEW SCHOOL FOR GIRLS ACADEMY TRUST
+1041,Kirkby Stephen Grammar School,single-academy trust,,,,company:07715613,KIRKBY STEPHEN GRAMMAR SCHOOL
+1042,Lee Chapel Academy Trust,multi-academy trust,,company:07673871,3718,company:07673871,LEE CHAPEL ACADEMY TRUST
+1043,Longdean School,single-academy trust,,,,company:07695624,LONGDEAN SCHOOL
+1044,Lostock Hall Academy Trust,single-academy trust,,,,company:07657427,LOSTOCK HALL ACADEMY TRUST
+1045,Central Academy Trust,multi-academy trust,,company:07685645,2592,company:07685645,CENTRAL ACADEMY TRUST
+1046,Lutterworth High School Academy Trust,single-academy trust,,,,company:07687235,LUTTERWORTH HIGH SCHOOL ACADEMY TRUST
+1047,Unity Schools Trust,multi-academy trust,,company:07692130,15904,company:07692130,UNITY SCHOOLS TRUST
+1048,Maiden Beech Academy Trust,single-academy trust,,,,company:07706667,MAIDEN BEECH ACADEMY TRUST
+1049,Manor High School,single-academy trust,,,,company:07695364,MANOR HIGH SCHOOL
+1050,Longfield Academy Trust,multi-academy trust,,company:07700556,3782,company:07700556,LONGFIELD ACADEMY TRUST
+1051,Cotswold Beacon Academy Trust,single-academy trust,,,,company:07692339,COTSWOLD BEACON ACADEMY TRUST
+1052,Newton Abbot Academy Trust,single-academy trust,,,,company:07717015,NEWTON ABBOT ACADEMY TRUST
+1053,Noadswood School,single-academy trust,,,,company:07693860,NOADSWOOD SCHOOL
+1054,North Town Academy Trust,single-academy trust,,,,company:07697356,NORTH TOWN ACADEMY TRUST
+1055,Parbold Douglas Church of England Academy,single-academy trust,,,,company:07713512,PARBOLD DOUGLAS CHURCH OF ENGLAND ACADEMY
+1056,Perins School,single-academy trust,,,,company:07699705,PERINS SCHOOL
+1057,Priestlands School,single-academy trust,,,,company:07695684,PRIESTLANDS SCHOOL
+1058,Prenton High School for Girls,single-academy trust,,,,company:07672980,PRENTON HIGH SCHOOL FOR GIRLS
+1059,Queen Elizabeth's Girls' School (Barnet),single-academy trust,,,,company:07698875,QUEEN ELIZABETH'S GIRLS' SCHOOL (BARNET)
+1060,Redmarley C of E Primary Academy,single-academy trust,,,,company:07705259,REDMARLEY C OF E PRIMARY ACADEMY
+1061,Cranmer Education Trust,multi-academy trust,,company:07687709,5666,company:07687709,CRANMER EDUCATION TRUST
+1062,Sir Robert Pattinson Academy,single-academy trust,,,,company:07690250,SIR ROBERT PATTINSON ACADEMY
+1063,Yorkshire Causeway Schools Trust,multi-academy trust,,company:07663935,5599,company:07663935,YORKSHIRE CAUSEWAY SCHOOLS TRUST
+1064,Vale Academy Trust,multi-academy trust,,company:07674473,5176,company:07674473,VALE ACADEMY TRUST
+1065,St Edward's Church of England School and Sixth Form College,single-academy trust,,,,company:07709271,ST EDWARD'S CHURCH OF ENGLAND SCHOOL AND SIXTH FORM COLLEGE
+1066,"St Mary's Catholic Primary School (Academy Trust), Swindon",single-academy trust,,,,company:07697658,"ST MARY'S CATHOLIC PRIMARY SCHOOL (ACADEMY TRUST), SWINDON"
+1067,Jerry Clay Academy,single-academy trust,,,,company:07688230,JERRY CLAY ACADEMY
+1068,Staunton and Corse C of E Academy,single-academy trust,,,,company:07701954,STAUNTON AND CORSE C OF E ACADEMY
+1069,Swanland Education Trust,multi-academy trust,,company:07679051,4888,company:07679051,SWANLAND EDUCATION TRUST
+1070,"Abbey School (Faversham), The",single-academy trust,,,,company:07697086,THE ABBEY SCHOOL (FAVERSHAM)
+1071,Deanery Church of England Primary School,single-academy trust,,,,company:07667168,DEANERY CHURCH OF ENGLAND PRIMARY SCHOOL
+1072,The Rivers Multi Academy Trust,multi-academy trust,,company:07697367,15905,company:07697367,RIVERS MULTI ACADEMY TRUST
+1073,"London Oratory School, The",single-academy trust,,,,company:07700776,THE LONDON ORATORY SCHOOL
+1074,"Two Counties Trust, The",multi-academy trust,,company:07972029,16093,company:07972029,THE TWO COUNTIES TRUST
+1075,"National Church of England Academy Trust, The",single-academy trust,,,,company:07708713,THE NATIONAL CHURCH OF ENGLAND ACADEMY TRUST
+1076,"Robert Smyth Academy, The",single-academy trust,,,,company:07692325,THE ROBERT SMYTH ACADEMY
+1077,"Stourport High School & Vith Form Centre, The",single-academy trust,,,,company:07633402,SEVERN ACADEMIES EDUCATIONAL TRUST
+1078,The Thomas Hardye Multi Academy Trust,multi-academy trust,,company:07677838,16028,company:07677838,THE THOMAS HARDYE MULTI ACADEMY TRUST
+1079,Staffordshire University Academies Trust,multi-academy trust,,company:07704020,4813,company:07704020,STAFFORDSHIRE UNIVERSITY ACADEMIES TRUST
+1080,Woodlands Academy,single-academy trust,,,,company:07693574,WOODLANDS ACADEMY
+1081,"King's School, The",single-academy trust,,,,company:07706900,THE KING'S SCHOOL
+1082,Trinity High School and Sixth Form Centre,single-academy trust,,,,company:07704968,TRINITY HIGH SCHOOL AND SIXTH FORM CENTRE
+1083,Rookery School,single-academy trust,,,,company:07685796,ROOKERY SCHOOL
+1084,Vandyke Upper School,single-academy trust,,,,company:07700206,VANDYKE UPPER SCHOOL
+1085,Welland Park Community College Academy Trust,single-academy trust,,,,company:07675238,WELLAND PARK COMMUNITY COLLEGE ACADEMY TRUST
+1086,Wirral Grammar School for Girls,single-academy trust,,,,company:07695736,WIRRAL GRAMMAR SCHOOL FOR GIRLS
+1087,Alcester Academy,single-academy trust,,,,company:07700251,ALCESTER ACADEMY
+1088,Churchdown Village Infant School,single-academy trust,,,,company:07698978,CHURCHDOWN VILLAGE INFANT SCHOOL
+1089,Avishayes Primary School and Early Years Centre,single-academy trust,,,,company:07695401,AVISHAYES PRIMARY SCHOOL AND EARLY YEARS CENTRE
+1090,Tatworth Primary School,single-academy trust,,,,company:07700773,TATWORTH PRIMARY SCHOOL
+1091,Harrow High School,single-academy trust,,,,company:07695709,HARROW HIGH SCHOOL
+1092,The Bentley Wood Trust,multi-academy trust,,company:07693936,4935,company:07693936,THE BENTLEY WOOD TRUST
+1093,"UCL Academy, The",single-academy trust,,,,company:07024902,THE UCL ACADEMY
+1094,St Matthias Church of England Primary Academy,single-academy trust,,,,company:07704001,ST MATTHIAS CHURCH OF ENGLAND PRIMARY ACADEMY
+1095,Dyson Perrins Church of England Academy,single-academy trust,,,,company:07703941,DYSON PERRINS CHURCH OF ENGLAND ACADEMY
+1096,"Albany School, The",single-academy trust,,,,company:07689986,THE ALBANY SCHOOL
+1097,"Commonweal School, The",single-academy trust,,,,company:07682819,THE COMMONWEAL SCHOOL
+1098,Lethbridge Primary School,single-academy trust,,,,company:07685652,LETHBRIDGE PRIMARY SCHOOL
+1099,Whitstone School Academy Trust,single-academy trust,,,,company:07706741,WHITSTONE SCHOOL ACADEMY TRUST
+1100,Buckler's Mead School,single-academy trust,,,,company:07697504,BUCKLER'S MEAD SCHOOL
+1101,Gloucestershire Learning Alliance,multi-academy trust,,company:07690119,3188,company:07690119,GLOUCESTERSHIRE LEARNING ALLIANCE
+1102,Empower Learning Academy Trust,multi-academy trust,,company:07702119,16251,company:07702119,EMPOWER LEARNING ACADEMY TRUST
+1103,Rooks Heath College,single-academy trust,,,,company:07687178,ROOKS HEATH COLLEGE
+1104,Canons High School,multi-academy trust,,company:07694362,16255,company:07694362,CANONS HIGH SCHOOL
+1105,Millfield Community Academy Trust,multi-academy trust,,company:07705438,16029,company:07705438,MILLFIELD COMMUNITY ACADEMY TRUST
+1106,Westfield Academy Trust,single-academy trust,,,,company:07664348,WESTFIELD ACADEMY TRUST
+1107,Hatch End High School,single-academy trust,,,,company:07690395,HATCH END HIGH SCHOOL
+1108,Dallam School,single-academy trust,,,,company:07646748,DALLAM SCHOOL
+1109,Tor Bridge Academy Trust,single-academy trust,,,,company:07584372,TOR BRIDGE ACADEMY TRUST
+1110,Gotherington Primary School,single-academy trust,,,,company:07649769,GOTHERINGTON PRIMARY SCHOOL
+1111,Holbrook Academy,single-academy trust,,,,company:07654882,HOLBROOK ACADEMY
+1112,Tile Hill Wood School and Language College,single-academy trust,,,,company:07654273,TILE HILL WOOD SCHOOL AND LANGUAGE COLLEGE
+1113,Abraham Guest Academy Trust,single-academy trust,,,,company:07820566,ABRAHAM GUEST ACADEMY TRUST
+1114,Sussex Learning Trust,multi-academy trust,,company:07705100,5214,company:07705100,SUSSEX LEARNING TRUST
+1115,Waycroft Multi Academy Trust,multi-academy trust,,company:07683980,5600,company:07683980,WAYCROFT MULTI ACADEMY TRUST
+1116,The Robert Carre Trust,multi-academy trust,,company:07671174,15883,company:07671174,THE ROBERT CARRE TRUST
+1117,South West Essex Community Education Trust Limited,multi-academy trust,,company:07693309,5634,company:07693309,SOUTH WEST ESSEX COMMUNITY EDUCATION TRUST LIMITED
+1118,"Chalfonts Community College, The",single-academy trust,,,,company:07693365,THE CHALFONTS COMMUNITY COLLEGE
+1119,Balgowan Primary School,single-academy trust,,,,company:07672683,BALGOWAN PRIMARY SCHOOL
+1120,Cirencester Kingshill School,single-academy trust,,,,company:07686390,CIRENCESTER KINGSHILL SCHOOL
+1121,East Bergholt High School,single-academy trust,,,,company:07682993,EAST BERGHOLT HIGH SCHOOL
+1122,Dr Challoner's High School,single-academy trust,,,,company:07694530,DR CHALLONER'S HIGH SCHOOL
+1123,Robus Multi Academy Trust,multi-academy trust,,company:07681811,4382,company:07681811,ROBUS MULTI ACADEMY TRUST
+1124,Drayton Manor High School Academy Trust,single-academy trust,,,,company:07698859,DRAYTON MANOR HIGH SCHOOL ACADEMY TRUST
+1125,Falmouth School,single-academy trust,,,,company:07695977,FALMOUTH SCHOOL
+1126,Mount Grace School,single-academy trust,,,,company:07695796,MOUNT GRACE SCHOOL
+1127,"Westwood School (Coventry), The",single-academy trust,,,,company:07700728,THE WESTWOOD ACADEMY (COVENTRY)
+1128,Great Berry Primary School,single-academy trust,,,,company:07692638,GREAT BERRY PRIMARY SCHOOL
+1129,Wilmington Grammar School for Boys,single-academy trust,,,,company:07682311,WILMINGTON GRAMMAR SCHOOL FOR BOYS
+1130,GTS Academy Trust,single-academy trust,,,,company:07698197,GTS ACADEMY TRUST
+1131,Hounsdown School,single-academy trust,,,,company:07687770,HOUNSDOWN SCHOOL
+1132,Acorn Education Trust,multi-academy trust,,company:07654902,2070,company:07654902,ACORN EDUCATION TRUST
+1133,Light Hall School,single-academy trust,,,,company:07687583,LIGHT HALL SCHOOL
+1134,Ringmer Community College Academy Trust,single-academy trust,,,,company:07678672,RINGMER COMMUNITY COLLEGE ACADEMY TRUST
+1135,Sacred Heart of Mary Girls' School,single-academy trust,,,,company:07693743,SACRED HEART OF MARY GIRLS' SCHOOL
+1136,Staindrop School,single-academy trust,,,,company:07695172,STAINDROP SCHOOL
+1137,Stratford Girls' Grammar School,single-academy trust,,,,company:07646003,STRATFORD GIRLS' GRAMMAR SCHOOL
+1138,Stratford-upon-Avon School,single-academy trust,,,,company:07690776,STRATFORD-UPON-AVON SCHOOL
+1139,Thamesmead School,single-academy trust,,,,company:07686145,THAMESMEAD SCHOOL
+1140,"Romsey School, The",single-academy trust,,,,company:07697070,THE ROMSEY SCHOOL
+1141,"Sandon School Academy Trust, The",single-academy trust,,,,company:07697483,THE SANDON SCHOOL ACADEMY TRUST
+1142,Thurstable School Sports College and Sixth Form Centre,single-academy trust,,,,company:07694325,THURSTABLE SCHOOL SPORTS COLLEGE AND SIXTH FORM CENTRE
+1143,Valley Primary School,single-academy trust,,,,company:07695505,VALLEY PRIMARY SCHOOL
+1144,West Kirby Grammar School,single-academy trust,,,,company:07697158,WEST KIRBY GRAMMAR SCHOOL
+1145,Biggin Hill Primary School,single-academy trust,,,,company:07682300,BIGGIN HILL PRIMARY SCHOOL
+1146,Hilltop Junior School,single-academy trust,,,,company:07711826,HILLTOP JUNIOR SCHOOL
+1147,"Robert Drake Primary School, The",single-academy trust,,,,company:07686371,THE ROBERT DRAKE PRIMARY SCHOOL
+1148,Jotmans Hall Primary School,single-academy trust,,,,company:07687947,JOTMANS HALL PRIMARY SCHOOL
+1149,St Peter's School Huntingdon,single-academy trust,,,,company:07702046,ST PETER'S SCHOOL HUNTINGDON
+1150,Alameda Middle School,single-academy trust,,,,company:07681848,ALAMEDA MIDDLE SCHOOL
+1151,Wilmington Grammar School for Girls,single-academy trust,,,,company:07682332,WILMINGTON GRAMMAR SCHOOL FOR GIRLS
+1152,Appleby Grammar School,single-academy trust,,,,company:07698461,APPLEBY GRAMMAR SCHOOL
+1153,William Howard Trust,multi-academy trust,,company:07698631,15765,company:07698631,WILLIAM HOWARD TRUST
+1154,Caldew School,single-academy trust,,,,company:07680823,CALDEW SCHOOL
+1155,Sir William Ramsay School Academy Trust,single-academy trust,,,,company:07697618,SIR WILLIAM RAMSAY SCHOOL ACADEMY TRUST
+1156,Sir Robert Geffery's School,single-academy trust,,,,company:07700611,SIR ROBERT GEFFERY'S SCHOOL
+1157,Archbishop Benson Church of England Primary School,single-academy trust,,,,company:07705878,ARCHBISHOP BENSON CHURCH OF ENGLAND PRIMARY SCHOOL
+1158,Baylis Court Trust,multi-academy trust,,company:07662414,15858,company:07662414,BAYLIS COURT TRUST
+1159,Chelmer Valley High School,single-academy trust,,,,company:07696117,CHELMER VALLEY HIGH SCHOOL
+1160,John Colet School,single-academy trust,,,,company:07633408,JOHN COLET SCHOOL
+1161,Houghton Kepier Sports College Academy Trust,single-academy trust,,,,company:07693870,HOUGHTON KEPIER SPORTS COLLEGE ACADEMY TRUST
+1162,Hazelwick School,single-academy trust,,,,company:07686578,HAZELWICK SCHOOL
+1163,"Lydiard Park Academy, The",single-academy trust,,,,company:07694023,THE PARK ACADEMIES TRUST
+1164,Kingsdown School,single-academy trust,,,,company:07697067,KINGSDOWN SCHOOL
+1165,Charlton Kings Junior School,single-academy trust,,,,company:07691867,CHARLTON KINGS JUNIOR SCHOOL
+1166,Ranelagh Church of England School,single-academy trust,,,,company:07698406,RANELAGH CHURCH OF ENGLAND SCHOOL
+1167,Settlebeck School Academy Trust,single-academy trust,,,,company:07693715,SETTLEBECK SCHOOL ACADEMY TRUST
+1168,"Sir John Lawes Academies Trust, The",multi-academy trust,,company:07697132,4533,company:07697132,SIR JOHN LAWES ACADEMIES TRUST
+1169,"Blue Coat Church of England Academy, The",single-academy trust,,,,company:07594562,THE BLUE COAT CHURCH OF ENGLAND ACADEMY LIMITED
+1170,"Chiltern Hills Academy, The",single-academy trust,,,,company:07718351,THE CHILTERN HILLS ACADEMY
+1171,"Lincolnshire Educational Trust Limited, The",multi-academy trust,,company:07647805,3749,company:07647805,THE LINCOLNSHIRE EDUCATIONAL TRUST LIMITED
+1172,"Eastwood Academy Trust, The",single-academy trust,,,,company:07700909,THE EASTWOOD ACADEMY TRUST
+1173,"Blue School, The",single-academy trust,,,,company:07706776,THE BLUE SCHOOL
+1174,Montacute School,single-academy trust,,,,company:07724780,MONTACUTE SCHOOL
+1175,"Slough and East Berkshire C of E Multi Academy Trust, The",multi-academy trust,,company:07723151,4553,company:07723151,THE SLOUGH AND EAST BERKSHIRE C OF E MULTI ACADEMY TRUST
+1176,Hitchin Girls' School,single-academy trust,,,,company:07697117,HITCHIN GIRLS' SCHOOL
+1177,Bright Futures Educational Trust,multi-academy trust,,company:07695771,2437,company:07695771,BRIGHT FUTURES EDUCATIONAL TRUST
+1178,Greenfield & Pulloxhill Academy,multi-academy trust,,company:07719857,3245,company:07719857,GREENFIELD & PULLOXHILL ACADEMY
+1179,"Catholic Academy Trust in Southampton, The",multi-academy trust,,company:07714121,2582,company:07714121,THE CATHOLIC ACADEMY TRUST IN SOUTHAMPTON
+1180,Crompton House Church of England School,single-academy trust,,,,company:07713345,CROMPTON HOUSE CHURCH OF ENGLAND SCHOOL
+1181,Corpus Christi Catholic Primary School,single-academy trust,,,,company:07712850,CORPUS CHRISTI CATHOLIC PRIMARY SCHOOL
+1182,Bishop Rawstorne Church of England Academy Trust,single-academy trust,,,,company:07672781,BISHOP RAWSTORNE CHURCH OF ENGLAND ACADEMY TRUST
+1183,Birkdale High School,single-academy trust,,,,company:07695504,BIRKDALE HIGH SCHOOL
+1184,Severn Vale School,single-academy trust,,,,company:07705465,SEVERN VALE SCHOOL
+1185,Richard Challoner School,single-academy trust,,,,company:07718002,RICHARD CHALLONER SCHOOL
+1186,Priory Community School,single-academy trust,,,,company:07732889,PRIORY COMMUNITY SCHOOL ENTERPRISES LIMITED
+1187,"Grammar School of King Edward VI at Stratford-upon-Avon, The",single-academy trust,,,,company:07696173,THE GRAMMAR SCHOOL OF KING EDWARD VI AT STRATFORD-UPON-AVON
+1188,Independent Jewish Day School,single-academy trust,,,,company:07718480,INDEPENDENT JEWISH DAY SCHOOL
+1189,Learning Academy Partnership (South West),multi-academy trust,,company:07713540,3710,company:07713540,LEARNING ACADEMY PARTNERSHIP (SOUTH WEST)
+1190,St Ivo School,single-academy trust,,,,company:07703797,ST IVO SCHOOL
+1191,"Hessle Academy Community Trust, The",multi-academy trust,,company:07665828,3403,company:07665828,THE HESSLE ACADEMY COMMUNITY TRUST
+1192,"Athelstan Trust, The",multi-academy trust,,company:07699625,5494,company:07699625,THE ATHELSTAN TRUST
+1193,"King David High School, The",single-academy trust,,,,company:07716057,THE KING DAVID HIGH SCHOOL
+1194,St. Thomas More High School,single-academy trust,,,,company:07696989,ST. THOMAS MORE HIGH SCHOOL
+1195,St Mary's Church of England Junior School,single-academy trust,,,,company:07716911,ST MARY'S CHURCH OF ENGLAND JUNIOR SCHOOL
+1196,St Bernard's High School,single-academy trust,,,,company:07697023,ST BERNARD'S HIGH SCHOOL
+1197,Sexey's School,single-academy trust,,,,company:07698729,SEXEY'S SCHOOL
+1198,Woolmer Hill School,single-academy trust,,,,company:07692394,WOOLMER HILL SCHOOL
+1199,Testwood Sports College,single-academy trust,,,,company:07703800,TESTWOOD SPORTS COLLEGE
+1200,"Stephenson Studio School Trust, The",single-academy trust,,,,company:07662709,THE STEPHENSON STUDIO SCHOOL TRUST
+1201,Rainbow Schools Trust,single-academy trust,,,,company:07471734,RAINBOW SCHOOLS TRUST
+1202,Auckley School,single-academy trust,,,,company:07705402,AUCKLEY SCHOOL
+1203,"Corbet School, The",single-academy trust,,,,company:07721594,THE CORBET SCHOOL
+1204,Beech Hill School,single-academy trust,,,,company:07733196,BEECH HILL SCHOOL
+1205,Cartmel Priory Church of England School Academy Trust,single-academy trust,,,,company:07740632,CARTMEL PRIORY CHURCH OF ENGLAND SCHOOL ACADEMY TRUST
+1206,St Albans Girls' School,single-academy trust,,,,company:07719076,ST ALBANS GIRLS' SCHOOL
+1207,Casterton Business and Enterprise College Academy Trust,single-academy trust,,,,company:07718680,CASTERTON COLLEGE RUTLAND
+1208,Scout Road Academy,single-academy trust,,,,company:07717189,SCOUT ROAD ACADEMY
+1209,Garstang Community Academy Trust,single-academy trust,,,,company:07706760,GARSTANG COMMUNITY ACADEMY TRUST
+1210,Amersham School,single-academy trust,,,,company:07662135,AMERSHAM SCHOOL
+1211,Royal Latin School. The,single-academy trust,,,,company:07686209,THE ROYAL LATIN SCHOOL
+1212,"Catholic Academy Trust in Havant, The",multi-academy trust,,company:07721932,2580,company:07721932,THE CATHOLIC ACADEMY TRUST IN HAVANT
+1213,Hillcrest School and Sixth Form Centre,single-academy trust,,,,company:07744525,HILLCREST SCHOOL AND SIXTH FORM CENTRE
+1214,Salterlee Academy Trust Limited,single-academy trust,,,,company:07712946,SALTERLEE ACADEMY TRUST LIMITED
+1215,Great Smeaton Academy Primary School,single-academy trust,,,,company:07730938,GREAT SMEATON ACADEMY PRIMARY SCHOOL
+1216,St Peter's Catholic Voluntary Academy Trust,multi-academy trust,,company:07739194,4787,company:07739194,ST PETER'S CATHOLIC VOLUNTARY ACADEMY TRUST
+1217,Hope Valley College,single-academy trust,,,,company:07697177,HOPE VALLEY COLLEGE
+1218,Summercroft Primary School,single-academy trust,,,,company:07715667,SUMMERCROFT PRIMARY SCHOOL
+1219,SHARE Multi Academy Trust,multi-academy trust,,company:07729878,5635,company:07729878,SHARE MULTI ACADEMY TRUST
+1220,"St Marylebone Church of England School, The",single-academy trust,,,,company:07719620,THE ST MARYLEBONE CHURCH OF ENGLAND SCHOOL
+1221,Northgate School Arts College,single-academy trust,,,,company:07734360,NORTHGATE SCHOOL ARTS COLLEGE
+1222,Waddesdon Church of England School,single-academy trust,,,,company:07743646,WADDESDON CHURCH OF ENGLAND SCHOOL
+1223,Biddulph High School,single-academy trust,,,,company:07680339,BIDDULPH HIGH SCHOOL
+1224,Wallingford Schools Academy Trust,multi-academy trust,,company:07727786,5203,company:07727786,WALLINGFORD SCHOOLS ACADEMY TRUST
+1225,Brooke Hill Academy Trust Limited,multi-academy trust,,company:07693338,16033,company:07693338,BROOKE HILL ACADEMY TRUST LIMITED
+1226,Whickham School and Sports College,single-academy trust,,,,company:07729766,WHICKHAM SCHOOL AND SPORTS COLLEGE
+1227,Whitefield School,single-academy trust,,,,company:07697281,WHITEFIELD SCHOOL
+1228,Norbridge Academy Trust,single-academy trust,,,,company:07668839,VENTURE ACADEMY TRUST PARTNERSHIP
+1229,Cambridge Park Academy Limited,single-academy trust,,,,company:07714867,CAMBRIDGE PARK ACADEMY LIMITED
+1230,Hassenbrook Academy Trust,single-academy trust,,,,company:07712779,HASSENBROOK ACADEMY TRUST
+1231,Eastrop Infant School,single-academy trust,,,,company:07728828,EASTROP INFANT SCHOOL
+1232,Limehurst Academy,single-academy trust,,,,company:07671440,LIMEHURST ACADEMY
+1233,Hurstmere School,single-academy trust,,,,company:07654127,HURSTMERE SCHOOL
+1234,"Trinity School, A Church of England Academy",single-academy trust,,,,company:07697485,"TRINITY SCHOOL, A CHURCH OF ENGLAND ACADEMY"
+1235,Schoolsworks Academy Trust,multi-academy trust,,company:07962974,4477,company:07962974,SCHOOLSWORKS ACADEMY TRUST
+1236,"Saint Joseph's Catholic Primary School, Devizes",single-academy trust,,,,company:07734205,"SAINT JOSEPH'S CATHOLIC PRIMARY SCHOOL, DEVIZES"
+1237,Princes Risborough School,single-academy trust,,,,company:07712579,PRINCES RISBOROUGH SCHOOL
+1238,St Dominic's Catholic Primary School,single-academy trust,,,,company:07727826,ST DOMINIC'S CATHOLIC PRIMARY SCHOOL
+1239,"Totteridge Academy, The",single-academy trust,,,,company:07695342,THE TOTTERIDGE ACADEMY
+1240,Saint Augustine's Catholic College,single-academy trust,,,,company:07736524,SAINT AUGUSTINE'S CATHOLIC COLLEGE
+1241,"Abbey College, Ramsey",single-academy trust,,,,company:07740516,"ABBEY COLLEGE, RAMSEY"
+1242,Wyedean School and Sixth Form Centre,single-academy trust,,,,company:07735863,WYEDEAN SCHOOL AND SIXTH FORM CENTRE
+1243,Leodis Academies Trust,multi-academy trust,,company:07720181,16046,company:07720181,LEODIS ACADEMIES TRUST
+1244,Cannock Chase High School,single-academy trust,,,,company:07727974,CANNOCK CHASE HIGH SCHOOL
+1245,Mill Hill County High School,single-academy trust,,,,company:07713287,MILL HILL COUNTY HIGH SCHOOL
+1246,Dene Magna School,single-academy trust,,,,company:07695544,DENE MAGNA SCHOOL
+1247,Christ's College Finchley,single-academy trust,,,,company:07714167,CHRIST'S COLLEGE FINCHLEY
+1248,Chatham Grammar School for Girls,single-academy trust,,,,company:07710807,CHATHAM GRAMMAR SCHOOL FOR GIRLS
+1249,"Holly Hall Academy, The",single-academy trust,,,,company:07673775,THE HOLLY HALL ACADEMY
+1250,Burnley Road Academy,single-academy trust,,,,company:07733200,BURNLEY ROAD ACADEMY
+1251,Bolton Brow Primary Academy,single-academy trust,,,,company:07731186,BOLTON BROW PRIMARY ACADEMY
+1252,"New North Academy, The",single-academy trust,,,,company:07732879,THE NEW NORTH ACADEMY
+1253,Humberston Park Special School,single-academy trust,,,,company:07685660,HUMBERSTON PARK SPECIAL SCHOOL
+1254,"Kents Hill Infant Academy Trust, The",single-academy trust,,,,company:07705363,THE KENTS HILL INFANT ACADEMY TRUST
+1255,Redden Court School,single-academy trust,,,,company:07689980,REDDEN COURT SCHOOL
+1256,Sheldwich Primary School,single-academy trust,,,,company:07725629,SHELDWICH PRIMARY SCHOOL
+1257,Old Earth School,single-academy trust,,,,company:07726649,OLD EARTH SCHOOL
+1258,Castle Hall Academy Trust,single-academy trust,,,,company:07726907,CASTLE HALL ACADEMY TRUST
+1259,Woodbrook Vale School,single-academy trust,,,,company:07671486,WOODBROOK VALE SCHOOL
+1260,"Catholic Academy Trust in South Hampshire, The",multi-academy trust,,company:07723349,2581,company:07723349,THE CATHOLIC ACADEMY TRUST IN SOUTH HAMPSHIRE
+1261,Bishop Ramsey Church Of England Academies Trust,multi-academy trust,,company:07724916,16256,company:07724916,BISHOP RAMSEY CHURCH OF ENGLAND ACADEMIES TRUST
+1262,Churchfields Academy,single-academy trust,,,,company:07728940,CHURCHFIELDS ACADEMY
+1263,South Nottingham Catholic Academy Trust,multi-academy trust,,company:07743523,4581,company:07743523,SOUTH NOTTINGHAM CATHOLIC ACADEMY TRUST
+1264,Rosary Catholic Primary School,single-academy trust,,,,company:07709421,ROSARY CATHOLIC PRIMARY SCHOOL
+1265,Holy Trinity Church of England Primary Academy,single-academy trust,,,,company:07743627,HOLY TRINITY CHURCH OF ENGLAND PRIMARY ACADEMY
+1266,Emerson Park Academy,single-academy trust,,,,company:07726858,EMERSON PARK ACADEMY
+1267,"Ursuline Academy Ilford, The",single-academy trust,,,,company:07737159,THE URSULINE ACADEMY ILFORD
+1268,St Mary's Church of England Academy Trust,single-academy trust,,,,company:07733363,ST MARY'S CHURCH OF ENGLAND ACADEMY TRUST
+1269,Lees Brook Community School,single-academy trust,,,,company:07731277,LEES BROOK COMMUNITY SCHOOL
+1270,Accrington St Christopher's Church of England High School,single-academy trust,,,,company:07728029,ACCRINGTON ST CHRISTOPHER'S CHURCH OF ENGLAND HIGH SCHOOL
+1271,"Catholic Academy Trust in Aldershot, The",multi-academy trust,,company:07728054,4717,company:07728054,THE CATHOLIC ACADEMY TRUST IN ALDERSHOT
+1272,Chislehurst and Sidcup Grammar School,single-academy trust,,,,company:07654130,CHISLEHURST AND SIDCUP GRAMMAR SCHOOL
+1273,Batley Multi Academy Trust,multi-academy trust,,company:07732537,15729,company:07732537,BATLEY MULTI ACADEMY TRUST
+1274,Saint Edmund's Catholic Academy,single-academy trust,,,,company:07733864,SAINT EDMUND'S CATHOLIC ACADEMY
+1275,"Philip Morant School and College Academy Trust, The",multi-academy trust,,company:07803969,16252,company:07803969,THE PHILIP MORANT SCHOOL AND COLLEGE ACADEMY TRUST
+1276,Field Court Junior School,single-academy trust,,,,company:07728265,FIELD COURT JUNIOR SCHOOL
+1277,Priory School,single-academy trust,,,,,
+1278,"Cottenham Academy, The",multi-academy trust,,company:07740815,2798,company:07740815,THE COTTENHAM ACADEMY
+1279,"Avenue School Special Needs Academy Trust, The",single-academy trust,,,,company:07706726,THE AVENUE SCHOOL SPECIAL NEEDS ACADEMY TRUST
+1280,Formby High School,single-academy trust,,,,company:07724342,FORMBY HIGH SCHOOL
+1281,Enmore Church of England Primary School,single-academy trust,,,,company:07736180,ENMORE CHURCH OF ENGLAND PRIMARY SCHOOL
+1282,Rooks Nest Academy,single-academy trust,,,,company:07645519,ROOKS NEST ACADEMY
+1283,Cotham School,single-academy trust,,,,company:07732888,COTHAM SCHOOL
+1284,REAch2 Academy Trust,multi-academy trust,,company:08452281,4320,company:08452281,REACH2 ACADEMY TRUST
+1285,Clapton Girls' Academy Trust,single-academy trust,,,,company:07698419,CLAPTON GIRLS' ACADEMY TRUST
+1286,L.E.A.D. Multi-Academy Trust,multi-academy trust,,company:08296921,3670,company:08296921,L.E.A.D. MULTI-ACADEMY TRUST
+1287,Rastrick High School Academy Trust,single-academy trust,,,,company:07737429,RASTRICK HIGH SCHOOL ACADEMY TRUST
+1288,The Passmores Co-operative Learning Community,multi-academy trust,,company:07736246,4157,company:07736246,THE PASSMORES CO-OPERATIVE LEARNING COMMUNITY
+1289,Lincoln Christ's Hospital School,single-academy trust,,,,company:07732027,LINCOLN CHRIST'S HOSPITAL SCHOOL
+1290,Fred Longworth High School,single-academy trust,,,,company:07733109,LATERAL ACADEMY TRUST
+1291,Holmes Chapel Comprehensive School & Sixth Form College,single-academy trust,,,,company:07711928,HOLMES CHAPEL COMPREHENSIVE SCHOOL & SIXTH FORM COLLEGE
+1292,Lacey Green Primary Academy,single-academy trust,,,,company:07710870,LACEY GREEN PRIMARY ACADEMY
+1293,Westgate Academy Ltd,single-academy trust,,,,company:07669751,WESTGATE ACADEMY LTD
+1294,Bournemouth School,single-academy trust,,,,company:07745881,BOURNEMOUTH SCHOOL
+1295,Stockland (C of E) Primary Academy Trust Limited,single-academy trust,,,,company:07717215,STOCKLAND (C OF E) PRIMARY ACADEMY TRUST LIMITED
+1296,St Clere's Co-operative Academy Trust,multi-academy trust,,company:07703865,4662,company:07703865,ST CLERE’S CO-OPERATIVE ACADEMY TRUST
+1297,Cramlington Learning Village,single-academy trust,,,,company:07730940,CRAMLINGTON LEARNING VILLAGE
+1298,Brockhill Park Performing Arts College,single-academy trust,,,,company:07715043,BROCKHILL PARK PERFORMING ARTS COLLEGE
+1299,"Ashley School Academy Trust, The",single-academy trust,,,,company:07729412,THE ASHLEY SCHOOL ACADEMY TRUST
+1300,Southfield Junior School,single-academy trust,,,,company:07739514,SOUTHFIELD JUNIOR SCHOOL
+1301,Wymondham High Academy Trust,single-academy trust,,,,company:07725111,WYMONDHAM HIGH ACADEMY TRUST
+1302,Cedars Upper School,single-academy trust,,,,company:07720110,CEDARS UPPER SCHOOL
+1303,Wearmouth Learning Trust,multi-academy trust,,company:08767870,5238,company:08767870,WEARMOUTH LEARNING TRUST
+1304,St Bartholomew's School,single-academy trust,,,,company:07721470,ST BARTHOLOMEW'S SCHOOL
+1305,Ludgvan School,single-academy trust,,,,company:07716479,LUDGVAN SCHOOL
+1306,"Village Academy, The",multi-academy trust,,company:07738386,5186,company:07738386,THE VILLAGE ACADEMY
+1307,St Ives Infant School,single-academy trust,,,,company:07713374,ST IVES INFANT SCHOOL
+1308,St John's Special School and College,single-academy trust,,,,company:07750051,ST JOHN'S SPECIAL SCHOOL AND COLLEGE
+1309,"Springfields Academy, The",single-academy trust,,,,company:07736212,THE SPRINGFIELDS ACADEMY
+1310,Bamford Academy,single-academy trust,,,,company:07721109,BAMFORD ACADEMY
+1311,Corelli College Co-operative Academy Trust,single-academy trust,,,,company:07698469,CORELLI COLLEGE CO-OPERATIVE ACADEMY TRUST
+1312,Barton Court Grammar School Academy,single-academy trust,,,,company:07711925,BARTON COURT GRAMMAR SCHOOL ACADEMY
+1313,Hinchingbrooke School,single-academy trust,,,,company:07732319,HINCHINGBROOKE SCHOOL
+1314,Wirral Grammar School for Boys,single-academy trust,,,,company:07734231,WIRRAL GRAMMAR SCHOOL FOR BOYS
+1315,"Diocese of Gloucester Academies Trust, The",multi-academy trust,,company:08149299,2907,company:08149299,THE DIOCESE OF GLOUCESTER ACADEMIES TRUST
+1316,Pencalenick,single-academy trust,,,,company:07724160,SPECIAL PARTNERSHIP TRUST
+1317,Southwark Primary Academy Trust,multi-academy trust,,company:07726568,4601,company:07726568,SOUTHWARK PRIMARY ACADEMY TRUST
+1318,Homewood School & Sixth Form Centre,single-academy trust,,,,company:07736448,HOMEWOOD SCHOOL & SIXTH FORM CENTRE
+1319,Hadleigh Junior School Academy Trust,single-academy trust,,,,company:07719938,HADLEIGH JUNIOR SCHOOL ACADEMY TRUST
+1320,Batley Academy Trust,single-academy trust,,,,company:07509409,BATLEY ACADEMY TRUST
+1321,"Priors School, The",single-academy trust,,,,company:03143086,THE PRIORS SCHOOL
+1322,Sandbach School,single-academy trust,,,,company:06486255,SANDBACH SCHOOL
+1323,Nishkam School Trust,multi-academy trust,,company:07522245,4005,company:07522245,NISHKAM SCHOOL TRUST
+1324,The Partnership Trust,multi-academy trust,,company:07728112,3126,company:07728112,THE PARTNERSHIP TRUST
+1325,Maharishi School Trust Ltd,single-academy trust,,,,company:01902341,MAHARISHI SCHOOL TRUST LTD
+1326,Wandle Valley School,single-academy trust,,,,company:07736095,WANDLE VALLEY SCHOOL
+1327,Belthorn Academy Primary School,single-academy trust,,,,company:07756219,BELTHORN ACADEMY PRIMARY SCHOOL
+1328,Broughton Academy,single-academy trust,,,,company:07754698,BROUGHTON ACADEMY
+1329,Chesterfield High School,single-academy trust,,,,company:07761675,CHESTERFIELD HIGH SCHOOL
+1330,Colchester County High School for Girls,single-academy trust,,,,company:07755713,COLCHESTER COUNTY HIGH SCHOOL FOR GIRLS
+1331,Great Chesterford Church of England Academy Trust,single-academy trust,,,,company:07769026,GREAT CHESTERFORD CHURCH OF ENGLAND ACADEMY TRUST
+1332,Harrowbarrow School,single-academy trust,,,,company:07770592,HARROWBARROW SCHOOL
+1333,Henleaze Junior School,single-academy trust,,,,company:07763421,HENLEAZE JUNIOR SCHOOL
+1334,Lindley Junior School,single-academy trust,,,,company:07727564,LINDLEY JUNIOR SCHOOL
+1335,Maghull High School,single-academy trust,,,,company:07767222,MAGHULL HIGH SCHOOL
+1336,"Brooksbank School Sports College, The",single-academy trust,,,,company:07762548,THE BROOKSBANK SCHOOL SPORTS COLLEGE
+1337,Wootton Academy Trust,multi-academy trust,,company:07740758,5411,company:07740758,WOOTTON ACADEMY TRUST
+1338,Wellsway Multi Academy Trust,multi-academy trust,,company:07746787,5253,company:07746787,WELLSWAY MULTI ACADEMY TRUST
+1339,Alexandra Park School,single-academy trust,,,,company:07708890,NEW RIVER TRUST
+1340,Goffs School,single-academy trust,,,,company:07759302,GOFFS SCHOOL
+1341,Lydiate Learning Trust,multi-academy trust,,company:07732559,3810,company:07732559,LYDIATE LEARNING TRUST
+1342,Amery Hill School Academy Trust,single-academy trust,,,,company:07760509,AMERY HILL SCHOOL ACADEMY TRUST
+1343,Trent Academies Group,multi-academy trust,,company:08128513,5454,company:08128513,TRENT ACADEMIES GROUP
+1344,Burton Morewood Church of England Primary School,single-academy trust,,,,company:07788628,BURTON MOREWOOD CHURCH OF ENGLAND PRIMARY SCHOOL
+1345,Cams Hill School,single-academy trust,,,,company:07751232,CAMS HILL SCHOOL
+1346,Hasmonean High School,single-academy trust,,,,company:07706488,HASMONEAN HIGH SCHOOL
+1347,Kibworth High School A Community Technology College,single-academy trust,,,,company:07761713,KIBWORTH HIGH SCHOOL A COMMUNITY TECHNOLOGY COLLEGE
+1348,Mellor Primary School,single-academy trust,,,,company:07737398,MELLOR PRIMARY SCHOOL
+1349,Pennine Way Junior Academy,single-academy trust,,,,company:07772327,PENNINE WAY JUNIOR ACADEMY
+1350,Stisted Church of England Primary Academy Trust,single-academy trust,,,,company:07769085,STISTED CHURCH OF ENGLAND PRIMARY ACADEMY TRUST
+1351,"St John's (CE) Primary Academy Trust, Clifton",single-academy trust,,,,company:07745167,"ST JOHN'S (CE) PRIMARY ACADEMY TRUST, CLIFTON"
+1352,Twyford Church of England Academies Trust,multi-academy trust,,company:07648968,5132,company:07648968,TWYFORD CHURCH OF ENGLAND ACADEMIES TRUST
+1353,Witchford Village College,single-academy trust,,,,company:07772516,WITCHFORD VILLAGE COLLEGE
+1354,Dragonfly Education Trust,multi-academy trust,,company:07728482,5601,company:07728482,DRAGONFLY EDUCATION TRUST
+1355,Stewards Academy Trust,single-academy trust,,,,company:07770970,STEWARDS ACADEMY TRUST
+1356,"Weston Road Academy, The",single-academy trust,,,,company:07778406,THE WESTON ROAD ACADEMY
+1357,Seax Trust,multi-academy trust,,company:07747149,5636,company:07747149,SEAX TRUST
+1358,Eversholt Academy Trust,single-academy trust,,,,company:07697481,EVERSHOLT ACADEMY TRUST
+1359,Broadoak Primary School,single-academy trust,,,,company:07717482,BROADOAK PRIMARY SCHOOL
+1360,Highams Park Academy Trust,single-academy trust,,,,company:07738801,HIGHAMS PARK ACADEMY TRUST
+1361,Belleville Primary School,single-academy trust,,,,company:07768645,BELLEVILLE PRIMARY SCHOOL
+1362,Burnham Grammar School,single-academy trust,,,,company:07769232,BURNHAM GRAMMAR SCHOOL
+1363,"William Alvey School Trust, The",single-academy trust,,,,company:07737302,THE WILLIAM ALVEY SCHOOL TRUST
+1364,William Tyndale Primary School,single-academy trust,,,,company:07774109,WILLIAM TYNDALE PRIMARY SCHOOL
+1365,South Lincolnshire Academies Trust,multi-academy trust,,company:07559187,16247,company:07559187,SOUTH LINCOLNSHIRE ACADEMIES TRUST
+1366,The Surbiton Education Health Trust,trust,,,,company:08187058,SURBITON EDUCATION HEALTH TRUST
+1367,Bourne Education Trust,multi-academy trust,,company:07768726,2386,company:07768726,BOURNE EDUCATION TRUST
+1368,Berwick Academy,single-academy trust,,,,company:07807248,BERWICK ACADEMY
+1369,Bourne Westfield Primary Academy,single-academy trust,,,,company:07788995,BOURNE WESTFIELD PRIMARY ACADEMY
+1370,Cheetham Church of England Community Academy,single-academy trust,,,,company:07811354,CHEETHAM CHURCH OF ENGLAND COMMUNITY ACADEMY
+1371,Dearham Primary School,single-academy trust,,,,company:07796829,BE THE CHANGE MULTI ACADEMY TRUST
+1372,"Academy @ Ridgewood Trust, The",single-academy trust,,,,company:07795736,THE ACADEMY @ RIDGEWOOD TRUST
+1373,Greenbank High School,single-academy trust,,,,company:07790934,GREENBANK HIGH SCHOOL
+1374,Dove House School Academy Trust,single-academy trust,,,,company:07738845,DOVE HOUSE SCHOOL ACADEMY TRUST
+1375,"Tyrrells Primary School, The",single-academy trust,,,,company:07799872,THE TYRRELLS PRIMARY SCHOOL
+1376,Lady Hawkins School,single-academy trust,,,,company:07722445,LADY HAWKINS’ SCHOOL
+1377,Aletheia Anglican Academies Trust,multi-academy trust,,company:07801612,2100,company:07801612,ALETHEIA ANGLICAN ACADEMIES TRUST
+1378,St Leonard's CE Primary Academy,single-academy trust,,,,company:07807811,ST LEONARD'S CE PRIMARY ACADEMY
+1379,Lisle Marsden Church of England Primary Academy,single-academy trust,,,,company:07808707,LISLE MARSDEN CHURCH OF ENGLAND PRIMARY ACADEMY
+1380,Range High School,single-academy trust,,,,company:07770687,RANGE HIGH SCHOOL
+1381,Manor Learning Trust,multi-academy trust,,company:07816548,3847,company:07816548,MANOR LEARNING TRUST
+1382,Moulton School and Science College,single-academy trust,,,,company:07807158,MOULTON SCHOOL AND SCIENCE COLLEGE
+1383,St John's Church of England Primary School Maidstone,single-academy trust,,,,company:07807291,ST JOHN'S CHURCH OF ENGLAND PRIMARY SCHOOL MAIDSTONE
+1384,Nansloe Academy,single-academy trust,,,,company:07808705,NANSLOE ACADEMY
+1385,Mowbray Education Trust Limited,multi-academy trust,,company:07796947,3952,company:07796947,MOWBRAY EDUCATION TRUST LIMITED
+1386,Tudor Park Education Trust,multi-academy trust,,company:07798639,16052,company:07798639,TUDOR PARK EDUCATION TRUST
+1387,Colebrook Infant Academy,single-academy trust,,,,company:07808765,COLEBROOK INFANT ACADEMY
+1388,North Norfolk Academy Trust,multi-academy trust,,company:07800153,4024,company:07800153,NORTH NORFOLK ACADEMY TRUST
+1389,Carmel Education Trust,multi-academy trust,,company:07808732,2548,company:07808732,CARMEL EDUCATION TRUST
+1390,Brockhampton Academy Trust,single-academy trust,,,,company:07817746,BROCKHAMPTON ACADEMY TRUST
+1391,"Chase School, The",single-academy trust,,,,company:07800306,THE CHASE SCHOOL
+1392,Bourn Church of England Primary Academy,single-academy trust,,,,company:07807218,BOURN CHURCH OF ENGLAND PRIMARY ACADEMY
+1393,St Bede's Catholic College,single-academy trust,,,,company:07798550,ST BEDE'S CATHOLIC COLLEGE
+1394,Walderslade Girls' School,single-academy trust,,,,company:07800431,WALDERSLADE GIRLS' SCHOOL
+1395,Kents Hill Junior School,single-academy trust,,,,company:07804282,KENTS HILL JUNIOR SCHOOL
+1396,Bishopshalt School,single-academy trust,,,,company:07799811,BISHOPSHALT SCHOOL
+1397,Churchdown School,single-academy trust,,,,company:07773693,CHURCHDOWN SCHOOL
+1398,Vyners Learning Trust,multi-academy trust,,company:07796938,5482,company:07796938,VYNERS LEARNING TRUST
+1399,Brooklands Academy Trust,single-academy trust,,,,company:07798183,BROOKLANDS ACADEMY TRUST
+1400,Birchwood High School,single-academy trust,,,,company:07791971,BIRCHWOOD HIGH SCHOOL
+1401,Buckden Church of England Primary School Company,single-academy trust,,,,company:07708603,BUCKDEN CHURCH OF ENGLAND PRIMARY ACADEMY
+1402,Rawlins Academy,single-academy trust,,,,company:07652661,RAWLINS ACADEMY
+1403,Clayton-Le-Moors All Saints' Church Of England Primary School,single-academy trust,,,,company:07770605,CLAYTON-LE-MOORS ALL SAINTS' CHURCH OF ENGLAND PRIMARY SCHOOL
+1404,"First Federation Trust, The",multi-academy trust,,company:07819870,3104,company:07819870,THE FIRST FEDERATION TRUST
+1405,Inspire Partnership Multi Academy Trust,multi-academy trust,,company:07805262,16179,company:07805262,GAWTHORPE COMMUNITY ACADEMY TRUST
+1406,Hendon School,single-academy trust,,,,company:07803827,HENDON SCHOOL
+1407,Quintin Kynaston Trust,single-academy trust,,,,company:07802563,QUINTIN KYNASTON TRUST
+1408,"John Bentley School, The",single-academy trust,,,,company:07807398,THE JOHN BENTLEY SCHOOL
+1409,"Willows School Academy Trust, The",single-academy trust,,,,company:07785550,THE WILLOWS SCHOOL ACADEMY TRUST
+1410,Castle Carrock School,single-academy trust,,,,company:07729759,CASTLE CARROCK SCHOOL
+1411,"Royston Schools Academy Trust, The",multi-academy trust,,company:07695881,4410,company:07695881,THE ROYSTON SCHOOLS ACADEMY TRUST
+1412,Joydens Wood Infant School,single-academy trust,,,,company:07804043,JOYDENS WOOD INFANT SCHOOL
+1413,Joydens Wood Junior School,single-academy trust,,,,company:07803743,JOYDENS WOOD JUNIOR SCHOOL
+1414,Wilmington Primary School,single-academy trust,,,,company:07800252,WILMINGTON PRIMARY SCHOOL
+1415,"Great Schools Trust, The",multi-academy trust,,company:07641004,15758,company:07641004,THE GREAT SCHOOLS TRUST
+1416,"Hollyfield School, The",single-academy trust,,,,company:07794825,THE HOLLYFIELD SCHOOL
+1417,Icknield High School,single-academy trust,,,,company:07831395,ICKNIELD HIGH SCHOOL
+1418,"Malcolm Sargent Primary School, The",single-academy trust,,,,company:07838151,THE MALCOLM SARGENT PRIMARY SCHOOL
+1419,St Catherine's Catholic School,single-academy trust,,,,company:07694573,ST CATHERINE'S CATHOLIC SCHOOL
+1420,Sir William Burrough Primary School,single-academy trust,,,,company:07797058,SIR WILLIAM BURROUGH PRIMARY SCHOOL
+1421,Crofton Schools Academy Trust,multi-academy trust,,company:07824714,2824,company:07824714,CROFTON SCHOOLS ACADEMY TRUST
+1422,"Dorcan Academy, The",single-academy trust,,,,company:07831414,THE DORCAN ACADEMY
+1423,Kingsbury High School,single-academy trust,,,,company:07819872,KINGSBURY HIGH SCHOOL
+1424,Arnside National Church of England School,single-academy trust,,,,company:07840925,ARNSIDE NATIONAL CHURCH OF ENGLAND SCHOOL
+1425,Bilton School,single-academy trust,,,,company:07845283,BILTON SCHOOL
+1426,Beacon Multi-Academy Trust Limited,multi-academy trust,,company:07835788,2265,company:07835788,BEACON MULTI-ACADEMY TRUST LIMITED
+1427,Bransgore Church of England Primary School,single-academy trust,,,,company:07803789,BRANSGORE CHURCH OF ENGLAND PRIMARY SCHOOL
+1428,Burnt Mill Academy Trust,multi-academy trust,,company:07843166,2497,company:07843166,BURNT MILL ACADEMY TRUST
+1429,Cox Green School,single-academy trust,,,,company:07831255,COX GREEN SCHOOL
+1430,"Excel Academy Partnership, The",multi-academy trust,,company:07837770,3066,company:07837770,THE EXCEL ACADEMY PARTNERSHIP
+1431,"Coppice Primary School, The",single-academy trust,,,,company:07845627,THE COPPICE PRIMARY SCHOOL
+1432,Hutton All Saints' Church of England Primary Trust,single-academy trust,,,,company:07848566,HUTTON ALL SAINTS' CHURCH OF ENGLAND PRIMARY TRUST
+1433,Brighter Futures Academy Trust,multi-academy trust,,company:08175471,2442,company:08175471,BRIGHTER FUTURES ACADEMY TRUST
+1434,Oldbury Academy,single-academy trust,,,,company:07672607,OLDBURY ACADEMY
+1435,"St John's Catholic School and Sixth Form College, A Catholic Academy (Bishop Auckland)",single-academy trust,,,,company:07835950,"ST JOHN'S CATHOLIC SCHOOL AND SIXTH FORM COLLEGE, A CATHOLIC ACADEMY (BISHOP AUCKLAND)"
+1436,QEHC Academy Trust,single-academy trust,,,,company:07840838,QEHC ACADEMY TRUST
+1437,Otley Prince Henry's Academy Trust,single-academy trust,,,,company:07831080,OTLEY PRINCE HENRY'S ACADEMY TRUST
+1438,"High Arcal School Academy Trust, The",single-academy trust,,,,company:07817806,THE HIGH ARCAL SCHOOL ACADEMY TRUST
+1439,"Streetly Academy, The",single-academy trust,,,,company:07841414,THE STREETLY ACADEMY
+1440,Sacred Heart Catholic High School,single-academy trust,,,,company:07841435,SACRED HEART CATHOLIC HIGH SCHOOL
+1441,Herschel Grammar School,single-academy trust,,,,company:07899845,THE SCHELWOOD TRUST
+1442,Anglo European Academy Trust,single-academy trust,,,,company:07846848,ANGLO EUROPEAN ACADEMY TRUST
+1443,Chiddingstone Church of England School,single-academy trust,,,,company:07800664,CHIDDINGSTONE CHURCH OF ENGLAND SCHOOL
+1444,Featherstone High School,single-academy trust,,,,company:07800029,GRAND UNION MULTI ACADEMY TRUST
+1445,Central Learning Partnership Trust,multi-academy trust,,company:07827368,2594,company:07827368,CENTRAL LEARNING PARTNERSHIP TRUST
+1446,Holmer Church of England Academy,single-academy trust,,,,company:07850551,HOLMER CHURCH OF ENGLAND ACADEMY
+1447,Honiton Littletown Primary Academy Trust,single-academy trust,,,,company:07851471,HONITON LITTLETOWN PRIMARY ACADEMY TRUST
+1448,Shoeburyness High School,single-academy trust,,,,company:07825856,SOUTHEND EAST COMMUNITY ACADEMY TRUST
+1449,St Thomas More Roman Catholic Academy,single-academy trust,,,,company:07844795,ST THOMAS MORE ROMAN CATHOLIC ACADEMY
+1450,Rosebery School,multi-academy trust,,company:07818029,4395,company:07818029,ROSEBERY SCHOOL
+1451,South Ossett Infants' Academy Trust,single-academy trust,,,,company:07851205,SOUTH OSSETT INFANTS' ACADEMY TRUST
+1452,Cranbrook School Academy Trust,single-academy trust,,,,company:07794423,CRANBROOK SCHOOL ACADEMY TRUST
+1453,Furze Platt Senior School,single-academy trust,,,,company:07834715,FURZE PLATT SENIOR SCHOOL
+1454,Selwood Academy,single-academy trust,,,,company:07814065,SELWOOD ACADEMY
+1455,Isle Education Trust,multi-academy trust,,company:07814150,3543,company:07814150,ISLE EDUCATION TRUST
+1456,HEARTS Academy Trust,multi-academy trust,,company:07851097,3370,company:07851097,HEARTS ACADEMY TRUST
+1457,Woodside High School,single-academy trust,,,,company:07831292,WOODSIDE HIGH SCHOOL
+1458,"Three Rivers Learning Trust Limited, The",multi-academy trust,,company:07838203,5063,company:07838203,THE THREE RIVERS LEARNING TRUST LIMITED
+1459,Tewkesbury School,single-academy trust,,,,company:07840060,TEWKESBURY SCHOOL
+1460,"Olympus Academy Trust, The",multi-academy trust,,company:07844791,4095,company:07844791,THE OLYMPUS ACADEMY TRUST
+1461,Norbury Manor Business and Enterprise College for Girls,single-academy trust,,,,company:07843573,NORBURY MANOR BUSINESS AND ENTERPRISE COLLEGE FOR GIRLS
+1462,Bay Education Trust,multi-academy trust,,company:09299975,2255,company:09299975,BAY EDUCATION TRUST
+1463,"Firs Lower School, The",single-academy trust,,,,company:07851337,THE FIRS LOWER SCHOOL
+1464,Bishop's Hatfield Girls' School,single-academy trust,,,,company:07831507,BISHOP'S HATFIELD GIRLS' SCHOOL
+1465,"Axholme Academy, The",single-academy trust,,,,company:07840804,THE AXHOLME ACADEMY
+1466,Waltham Leas Primary Academy Limited,single-academy trust,,,,company:07772345,WALTHAM LEAS PRIMARY ACADEMY LIMITED
+1467,New Waltham Primary Academy Limited,single-academy trust,,,,company:07835845,NEW WALTHAM PRIMARY ACADEMY LIMITED
+1468,West Town Lane Academy,single-academy trust,,,,company:07848632,WEST TOWN LANE ACADEMY
+1469,The Evolve Trust,multi-academy trust,,company:07827747,4965,company:07827747,THE EVOLVE TRUST
+1470,"Cathedral Church of England Academy Trust (Wakefield), The",single-academy trust,,,,company:07846823,THE CATHEDRAL CHURCH OF ENGLAND ACADEMY TRUST (WAKEFIELD)
+1471,Conisbrough Ivanhoe Primary Academy,single-academy trust,,,,company:07825848,CONISBROUGH IVANHOE PRIMARY ACADEMY
+1472,Campion Academy Trust,single-academy trust,,,,company:07848338,CAMPION ACADEMY TRUST
+1473,Higham Lane School,single-academy trust,,,,company:07849858,HIGHAM LANE SCHOOL
+1474,Tarleton Academy,single-academy trust,,,,company:07848372,ENDEAVOUR LEARNING TRUST
+1475,Townley Grammar School,single-academy trust,,,,company:07844587,TOWNLEY GRAMMAR SCHOOL
+1476,Aylesford School and Sixth Form College,single-academy trust,,,,company:07848367,AYLESFORD SCHOOL AND SIXTH FORM COLLEGE
+1477,Shirley High School,single-academy trust,,,,company:07837778,SHIRLEY HIGH SCHOOL
+1478,"Kingswinford School and Science College, The",single-academy trust,,,,company:07844874,THE KINGSWINFORD SCHOOL AND SCIENCE COLLEGE
+1479,"Gerrards Cross Church of England School, The",single-academy trust,,,,company:07847454,THE GERRARDS CROSS CHURCH OF ENGLAND SCHOOL
+1480,Horsforth School,single-academy trust,,,,company:07849654,HORSFORTH SCHOOL
+1481,Denefield School,single-academy trust,,,,company:07852122,DENEFIELD SCHOOL
+1482,Hadrian Academy Trust,single-academy trust,,,,company:07824369,HADRIAN ACADEMY TRUST
+1483,Scartho Junior Academy Limited,single-academy trust,,,,company:07805677,SCARTHO JUNIOR ACADEMY LIMITED
+1484,Datchet St Mary's Church of England Primary Academy,single-academy trust,,,,company:07851937,DATCHET ST MARY'S CHURCH OF ENGLAND PRIMARY ACADEMY
+1485,Green spring Education Trust,multi-academy trust,,company:07856680,2299,company:07856680,GREEN SPRING EDUCATION TRUST
+1486,Plume School,single-academy trust,,,,company:07849731,PLUME SCHOOL
+1487,Bay House School,single-academy trust,,,,company:07834711,BAY HOUSE SCHOOL
+1488,Onslow St Audrey's Academy Trust,single-academy trust,,,,company:07817708,ONSLOW ST AUDREY'S ACADEMY TRUST
+1489,Bourne Grammar School,single-academy trust,,,,company:07850292,BOURNE GRAMMAR SCHOOL
+1490,St. John's Primary Academy Bracebridge Heath Ltd,single-academy trust,,,,company:07777372,ST. JOHN'S PRIMARY ACADEMY BRACEBRIDGE HEATH LTD
+1491,Park Hall Junior Academy,single-academy trust,,,,company:07848445,PARK HALL JUNIOR ACADEMY
+1492,Bluecoat Academies Trust,multi-academy trust,,company:07875164,2363,company:07875164,BLUECOAT ACADEMIES TRUST
+1493,Humphrey Perkins School,single-academy trust,,,,company:07819429,HUMPHREY PERKINS SCHOOL
+1494,Borden Grammar School Trust,single-academy trust,,,,company:07827591,BORDEN GRAMMAR SCHOOL TRUST
+1495,Trinity Church of England High School,single-academy trust,,,,company:07878966,TRINITY CHURCH OF ENGLAND HIGH SCHOOL
+1496,East Ravendale Church of England Primary School Academy,single-academy trust,,,,company:07809637,EAST RAVENDALE CHURCH OF ENGLAND PRIMARY SCHOOL ACADEMY
+1497,"Earls High School, The",single-academy trust,,,,company:07865663,THE EARLS HIGH SCHOOL
+1498,New Dawn Trust,multi-academy trust,,company:07842369,3977,company:07842369,NEW DAWN TRUST
+1499,Colchester Royal Grammar School,single-academy trust,,,,company:07769103,COLCHESTER ROYAL GRAMMAR SCHOOL
+1500,Weatherhead High School,single-academy trust,,,,company:07847190,WEATHERHEAD HIGH SCHOOL
+1501,Lickhill Primary School,single-academy trust,,,,company:07806338,LICKHILL PRIMARY SCHOOL
+1502,Impington Village College,single-academy trust,,,,company:07899393,IMPINGTON VILLAGE COLLEGE
+1503,St Edmund's School,single-academy trust,,,,company:07865850,ST EDMUND'S SCHOOL
+1504,Martin High School,single-academy trust,,,,company:07877078,MARTIN HIGH SCHOOL
+1505,Joseph Leckie Academy Trust,single-academy trust,,,,company:07892678,JOSEPH LECKIE ACADEMY TRUST
+1506,Benedict Biscop Church of England Academy,single-academy trust,,,,company:07909140,NORTHERN LIGHTS LEARNING TRUST
+1507,Huntcliff Academy Trust,single-academy trust,,,,company:07897108,HUNTCLIFF ACADEMY TRUST
+1508,"Maplesden Noakes School, The",single-academy trust,,,,company:07898331,THE MAPLESDEN NOAKES SCHOOL
+1509,"Mayfield Grammar School, Gravesend",single-academy trust,,,,company:07900248,"MAYFIELD GRAMMAR SCHOOL, GRAVESEND"
+1510,Wentworth Primary School,single-academy trust,,,,company:07899198,WENTWORTH PRIMARY SCHOOL
+1511,"Folkestone School for Girls Academy Trust, The",multi-academy trust,,company:07882159,3115,company:07882159,THE FOLKESTONE SCHOOL FOR GIRLS ACADEMY TRUST
+1512,Thomas Wolsey School,single-academy trust,,,,company:07849180,THOMAS WOLSEY SCHOOL
+1513,Looe Community Academy Trust,single-academy trust,,,,company:07909371,LOOE COMMUNITY ACADEMY TRUST
+1514,Broadoak Mathematics and Computing College,single-academy trust,,,,company:07872725,BROADOAK MATHEMATICS AND COMPUTING COLLEGE
+1515,Hall Cross Academy Trust,single-academy trust + umbrella trust,,,,company:07902880,HALL CROSS ACADEMY TRUST
+1516,The Consortium of Community Trusts,single-academy trust + umbrella trust,yes,,,company:07885568,YORKSHIRE EDUCATION TRUST
+1517,"Laurus Trust, The",multi-academy trust,,company:07907463,2627,company:07907463,THE LAURUS TRUST
+1518,"Barnhill Partnership Trust, The",multi-academy trust,,company:07719016,2237,company:07719016,THE BARNHILL PARTNERSHIP TRUST
+1519,Wellspring Academy Trust,multi-academy trust,,company:08120960,5252,company:08120960,WELLSPRING ACADEMY TRUST
+1520,Stanborough School,single-academy trust,,,,company:07900439,STANBOROUGH SCHOOL
+1521,"Coombe Secondary Schools Academy Trust, The",multi-academy trust,,company:07905433,2776,company:07905433,THE COOMBE SECONDARY SCHOOLS ACADEMY TRUST
+1522,St Alban's Catholic High School,single-academy trust,,,,company:07902662,ST ALBAN'S CATHOLIC HIGH SCHOOL
+1523,Goldsworth Trust,multi-academy trust,,company:07887259,3200,company:07887259,GOLDSWORTH TRUST
+1524,St Thomas More Partnership of Schools,multi-academy trust,,company:07900532,4797,company:07900532,ST THOMAS MORE PARTNERSHIP OF SCHOOLS
+1525,The Trinity Catholic Multi Academy Trust,multi-academy trust,,company:07890590,16035,company:07890590,THE TRINITY CATHOLIC MULTI ACADEMY TRUST
+1526,Cranfield Church of England Academy,single-academy trust,,,,company:07897243,CRANFIELD CHURCH OF ENGLAND ACADEMY
+1527,Gretton Primary School,single-academy trust,,,,company:07836684,GRETTON PRIMARY SCHOOL
+1528,Hinchley Wood School,single-academy trust,,,,company:07886416,HINCHLEY WOOD SCHOOL
+1529,St Agatha's Catholic Primary School,single-academy trust,,,,company:07907633,ST AGATHA'S CATHOLIC PRIMARY SCHOOL
+1530,Quarrydale Academy,single-academy trust,,,,company:07891230,QUARRYDALE ACADEMY
+1531,Hall Green Secondary School,single-academy trust,,,,company:07892732,HALL GREEN SECONDARY SCHOOL
+1532,Great Corby School,single-academy trust,,,,company:07727695,GREAT CORBY SCHOOL
+1533,Bushey St James Trust,multi-academy trust,,company:07895684,2510,company:07895684,BUSHEY ST JAMES TRUST
+1534,St Barnabas C of E Primary Academy Trust,single-academy trust,,,,company:07982966,ST BARNABAS C OF E PRIMARY ACADEMY TRUST
+1535,Salendine Nook Academy Trust,single-academy trust,,,,company:07883174,SALENDINE NOOK ACADEMY TRUST
+1536,St Mary's Academy Trust,multi-academy trust,,company:07917752,4742,company:07917752,ST MARY'S ACADEMY TRUST
+1537,Graveney Primary School,multi-academy trust,,company:07847021,3219,company:07847021,GRAVENEY PRIMARY SCHOOL
+1538,"Boswells Academy Trust, The",multi-academy trust,,company:07907388,2377,company:07907388,THE BOSWELLS ACADEMY TRUST
+1539,Kingsley Special Academy Trust,single-academy trust,,,,company:07834300,KINGSLEY SPECIAL ACADEMY TRUST
+1540,St Christopher's C of E (Primary) Multi Academy Trust,multi-academy trust,,company:08538844,4656,company:08538844,ST CHRISTOPHER'S C OF E (PRIMARY) MULTI ACADEMY TRUST
+1541,Shenfield High School,single-academy trust,,,,company:07898905,SHENFIELD HIGH SCHOOL
+1542,Chenderit School Academy Trust,single-academy trust,,,,company:07900254,CHENDERIT SCHOOL ACADEMY TRUST
+1543,Stratton Education Trust,multi-academy trust,,company:07798627,4863,company:07798627,STRATTON EDUCATION TRUST
+1544,Clevedon Learning Trust,multi-academy trust,,company:07872799,5453,company:07872799,CLEVEDON LEARNING TRUST
+1545,Reddish Vale Academy Trust,single-academy trust,,,,company:07890769,REDDISH VALE ACADEMY TRUST
+1546,"Diocese of Westminster Academy Trust, The",multi-academy trust,,company:07944160,2928,company:07944160,THE DIOCESE OF WESTMINSTER ACADEMY TRUST
+1547,Weatherfield Academy,single-academy trust,,,,company:07939260,WEATHERFIELD ACADEMY
+1548,Redhill Academy,single-academy trust,,,,company:07901900,REDHILL ACADEMY
+1549,Joseph Swan Academy,single-academy trust,,,,company:07950949,JOSEPH SWAN ACADEMY
+1550,Hungerhill Academy Trust,single-academy trust,,,,company:07939747,HUNGERHILL ACADEMY TRUST
+1551,St Cuthbert's Catholic High School,single-academy trust,,,,company:07918561,ST CUTHBERT'S CATHOLIC HIGH SCHOOL
+1552,Stradbroke High School,single-academy trust,,,,company:07921744,STRADBROKE HIGH SCHOOL
+1553,Cavendish Learning Trust,multi-academy trust,,company:07935515,16139,company:07935515,CAVENDISH LEARNING TRUST
+1554,Parkside Academy,single-academy trust,,,,company:07928558,PARKSIDE ACADEMY
+1555,Fulbrook Academy,single-academy trust,,,,company:07695419,FULBROOK ACADEMY
+1556,Forest Way School,single-academy trust,,,,company:07931627,FOREST WAY SCHOOL
+1557,Blenheim High School,single-academy trust,,,,company:07944253,BLENHEIM HIGH SCHOOL
+1558,Chiswick School,single-academy trust,,,,company:07954211,CHISWICK SCHOOL
+1559,Saint Robert Lawrence Catholic Academy Trust,multi-academy trust,,company:07937154,4442,company:07937154,SAINT ROBERT LAWRENCE CATHOLIC ACADEMY TRUST
+1560,Allestree Woodlands School,single-academy trust,,,,company:07951293,ALLESTREE WOODLANDS SCHOOL
+1561,Hatton Academies Trust,multi-academy trust,,company:07949111,3345,company:07949111,HATTON ACADEMIES TRUST
+1562,St John the Baptist Catholic Multi Academy Trust,multi-academy trust,,company:07913261,16094,company:07913261,ST JOHN THE BAPTIST CATHOLIC MULTI ACADEMY TRUST
+1563,"All Saints Catholic Academy Trust, The",multi-academy trust,,company:07943555,2111,company:07943555,ALL SAINTS CATHOLIC ACADEMY TRUST
+1564,Nethergate School,single-academy trust,,,,company:07914400,NETHERGATE SCHOOL
+1565,"Liverpool Blue Coat School, The",single-academy trust,,,,company:07950827,THE LIVERPOOL BLUE COAT SCHOOL
+1566,Southborough High School,single-academy trust,,,,company:07776910,SOUTHBOROUGH HIGH SCHOOL
+1567,Woodland View Primary School,single-academy trust,,,,company:07943378,WOODLAND VIEW PRIMARY SCHOOL
+1568,Eynsham Partnership Academy,multi-academy trust,,company:07939655,3072,company:07939655,EYNSHAM PARTNERSHIP ACADEMY
+1569,Abingdon Learning Trust,multi-academy trust,,company:07931886,4417,company:07931886,ABINGDON LEARNING TRUST
+1570,Gillotts School,single-academy trust,,,,company:07954417,GILLOTTS SCHOOL
+1571,Hazel Grove High School,single-academy trust,,,,company:07947961,HAZEL GROVE HIGH SCHOOL
+1572,St Bede's Inter Church School,single-academy trust,,,,company:07941524,ST BEDE'S INTER CHURCH SCHOOL
+1573,"Gilberd School, The",multi-academy trust + umbrella trust,,company:07933810,3173,company:07933810,THE GILBERD SCHOOL
+1574,North East Essex Education Partnership,multi-academy trust + umbrella trust,yes,,,company:07947381,NORTH EAST ESSEX EDUCATION PARTNERSHIP
+1575,"Stanway Federation, The",multi-academy trust + umbrella trust,,company:07887953,4822,company:07887953,THE STANWAY FEDERATION
+1576,Gumley House Convent School FCJ,single-academy trust,,,,company:07950851,GUMLEY HOUSE CONVENT SCHOOL FCJ
+1577,Upton Hall School FCJ,single-academy trust,,,,company:07952451,UPTON HALL SCHOOL FCJ
+1578,South Wigston High School,single-academy trust,,,,company:07937317,SOUTH WIGSTON HIGH SCHOOL
+1579,Glen Hills Primary School,single-academy trust,,,,company:07941899,SYMPHONY LEARNING TRUST
+1580,Fairfield Community Primary School,single-academy trust,,,,company:07937266,FAIRFIELD COMMUNITY PRIMARY SCHOOL
+1581,Alfriston School,single-academy trust,,,,company:07916763,ALFRISTON SCHOOL
+1582,Sacred Heart High School Hammersmith,single-academy trust,,,,company:07941140,SACRED HEART HIGH SCHOOL HAMMERSMITH
+1583,Chipping Norton School Academy Trust,multi-academy trust,,company:07929429,2665,company:07929429,CHIPPING NORTON SCHOOL ACADEMY TRUST
+1584,"Bourton Meadow Education Trust, The",multi-academy trust,,company:07867334,5483,company:07867334,THE BOURTON MEADOW EDUCATION TRUST
+1585,Isleworth and Syon School for Boys,single-academy trust,,,,company:07962216,ISLEWORTH AND SYON SCHOOL FOR BOYS
+1586,Harlington Upper School,single-academy trust,,,,company:07668955,HARLINGTON UPPER SCHOOL
+1587,Lord Lawson of Beamish Academy,single-academy trust,,,,company:07908404,LORD LAWSON OF BEAMISH ACADEMY
+1588,Applecroft School,single-academy trust,,,,company:07917745,APPLECROFT SCHOOL
+1589,St Helena School,single-academy trust + umbrella trust,,,,company:07912930,ST HELENA SCHOOL
+1590,Manningtree High School,single-academy trust + umbrella trust,,,,company:07883446,MANNINGTREE HIGH SCHOOL
+1591,Harwich and Dovercourt High School,single-academy trust + umbrella trust,,,,company:07881889,HARWICH AND DOVERCOURT HIGH SCHOOL
+1592,Biggleswade Academy Trust,multi-academy trust,,company:07928028,2311,company:07928028,LIFE ACADEMIES TRUST
+1593,Norfolk Academies,multi-academy trust,,company:07946986,4011,company:07946986,NORFOLK ACADEMIES
+1594,St. James' R.C. Primary School,single-academy trust,,,,company:07976516,ST. JAMES’ R.C. PRIMARY SCHOOL
+1595,St James the Great R.C. Primary and Nursery School,single-academy trust,,,,company:07937939,ST. JAMES THE GREAT R.C. PRIMARY AND NURSERY SCHOOL
+1596,Redditch West School Trust,multi-academy trust,,company:07967402,4336,company:07967402,REDDITCH WEST SCHOOL TRUST
+1597,Hampton Primary School Academy,single-academy trust,,,,company:07966182,HAMPTON PRIMARY SCHOOL ACADEMY
+1598,Stramongate School,single-academy trust,,,,company:07992440,STRAMONGATE SCHOOL
+1599,Hamilton Academy,single-academy trust,,,,company:07984125,HAMILTON ACADEMY
+1600,Blackfen School for Girls,single-academy trust,,,,company:07974098,BLACKFEN SCHOOL FOR GIRLS
+1601,St Martin-in-the-Fields High School for Girls,single-academy trust,,,,company:07984073,ST MARTIN-IN-THE-FIELDS HIGH SCHOOL FOR GIRLS
+1602,Horbury Bridge St Johns Academy Trust,single-academy trust,,,,company:07966187,HORBURY BRIDGE ST JOHNS ACADEMY TRUST
+1603,Redmoor Academy,single-academy trust,,,,company:07992372,REDMOOR ACADEMY
+1604,Bosworth Academy,single-academy trust,,,,company:07992438,BOSWORTH ACADEMY
+1605,River Learning Trust,multi-academy trust,,company:07966500,2644,company:07966500,RIVER LEARNING TRUST
+1606,Moulsham Junior School,single-academy trust,,,,company:07973327,MOULSHAM JUNIOR SCHOOL
+1607,Mesty Croft Academy,single-academy trust,,,,company:07987596,MESTY CROFT ACADEMY
+1608,Aldridge School A Science College,single-academy trust,,,,company:07983995,ALDRIDGE SCHOOL A SCIENCE COLLEGE
+1609,"Helena Romanes School, The",single-academy trust,,,,company:07984843,THE HELENA ROMANES SCHOOL
+1610,"Langtree School Academy Trust Company, The",multi-academy trust,,company:07980335,3694,company:07980335,THE LANGTREE SCHOOL ACADEMY TRUST COMPANY
+1611,Aurum Academies Trust,multi-academy trust,,company:07971651,5637,company:07971651,AURUM ACADEMIES TRUST
+1612,Equate Education Trust,single-academy trust,,,,company:07971665,EQUATE EDUCATION TRUST
+1613,Chepping View Primary Academy,single-academy trust,,,,company:07977442,CHEPPING VIEW PRIMARY ACADEMY
+1614,Beacon Community College Academy Trust,multi-academy trust,,company:07959980,2259,company:07959980,BEACON COMMUNITY COLLEGE ACADEMY TRUST
+1615,Wreake Valley Academy Trust,single-academy trust,,,,company:07988521,WREAKE VALLEY ACADEMY TRUST
+1616,Wigston Academies Trust,multi-academy trust,,company:07975551,5638,company:07975551,WIGSTON ACADEMIES TRUST
+1617,Presdales School Academy Trust,single-academy trust,,,,company:07990029,PRESDALES SCHOOL ACADEMY TRUST
+1618,Leverton Church of England Academy,single-academy trust,,,,company:07998451,LEVERTON CHURCH OF ENGLAND ACADEMY
+1619,Bradshaw Primary School (with Academy Status),single-academy trust,,,,company:07988495,BRADSHAW PRIMARY SCHOOL (WITH ACADEMY STATUS)
+1620,Bishop Vesey's Grammar School,single-academy trust,,,,company:07986921,BISHOP VESEY'S GRAMMAR SCHOOL
+1621,Henry Hinde School,single-academy trust,,,,company:07988497,HENRY HINDE SCHOOL
+1622,Harwood Meadows Community Primary School,single-academy trust,,,,company:07986090,HARWOOD MEADOWS COMMUNITY PRIMARY SCHOOL
+1623,Faringdon Academy of Schools,multi-academy trust,,company:07977368,3083,company:07977368,FARINGDON ACADEMY OF SCHOOLS
+1624,"Enquire Learning Trust, The",multi-academy trust,,company:08056907,3042,company:08056907,THE ENQUIRE LEARNING TRUST
+1625,Woolgrove School Special Needs Academy,single-academy trust,,,,company:07988540,WOOLGROVE SCHOOL SPECIAL NEEDS ACADEMY
+1626,St George's Church of England Academy,multi-academy trust,,company:07984221,16034,company:07984221,ST GEORGE'S CHURCH OF ENGLAND ACADEMY
+1627,Knutsford Multi Academy Trust,multi-academy trust,,company:07984413,3667,company:07984413,KNUTSFORD MULTI ACADEMY TRUST
+1628,Gilbert Inglefield Academy Trust,single-academy trust,,,,company:07883254,GILBERT INGLEFIELD ACADEMY TRUST
+1629,Seven Fields Primary School,single-academy trust,,,,company:07977150,SEVEN FIELDS PRIMARY SCHOOL
+1630,Eagley Infant School,single-academy trust,,,,company:07986805,EAGLEY INFANT SCHOOL
+1631,The Westgate School,multi-academy trust,,company:09583593,15747,company:09583593,THE WESTGATE SCHOOL
+1632,"Cippenham Schools' Trust, The",multi-academy trust,,company:07988376,2697,company:07988376,THE CIPPENHAM SCHOOLS' TRUST
+1633,"Northern Lincolnshire Catholic Academy Trust, The",multi-academy trust,,company:07973953,4039,company:07973953,THE NORTHERN LINCOLNSHIRE CATHOLIC ACADEMY TRUST
+1634,"Norton Knatchbull School, THe",single-academy trust,,,,company:07992899,THE NORTON KNATCHBULL SCHOOL
+1635,"John of Gaunt School, The",single-academy trust,,,,company:07990655,THE JOHN OF GAUNT SCHOOL
+1636,St Christophers Academy (Dunstable),single-academy trust,,,,company:07890613,ST CHRISTOPHERS ACADEMY (DUNSTABLE)
+1637,"St Mary's Church of England Academy, Stotfold",single-academy trust,,,,company:07999942,"ST MARY'S CHURCH OF ENGLAND ACADEMY, STOTFOLD"
+1638,Coundon Court,single-academy trust,,,,company:07994219,COUNDON COURT
+1639,Wadebridge School,single-academy trust,,,,company:07999988,WADEBRIDGE SCHOOL
+1640,Monkton Junior School,single-academy trust,,,,company:07984453,MONKTON JUNIOR SCHOOL
+1641,Webheath First School Academy,single-academy trust,,,,company:07959096,WEBHEATH ACADEMY PRIMARY SCHOOL
+1642,Henlow Church of England Academy,single-academy trust,,,,company:07996350,HENLOW CHURCH OF ENGLAND ACADEMY
+1643,Learning Pathways Academy,multi-academy trust,,company:07984238,3715,company:07984238,LEARNING PATHWAYS ACADEMY
+1644,Godmanchester Community Education Trust,single-academy trust,,,,company:07923329,GODMANCHESTER COMMUNITY EDUCATION TRUST
+1645,Huxlow Science College,single-academy trust,,,,company:07982740,HUXLOW SCIENCE COLLEGE
+1646,King Charles I School,single-academy trust,,,,company:07969062,KING CHARLES I SCHOOL
+1647,Victoria Academies Trust,multi-academy trust,,company:07887796,5183,company:07887796,VICTORIA ACADEMIES TRUST
+1648,Luddenham School,single-academy trust,,,,company:07974434,LUDDENHAM SCHOOL
+1649,Lugwardine Primary Academy Trust,single-academy trust,,,,company:07988355,LUGWARDINE PRIMARY ACADEMY TRUST
+1650,Tyldesley Primary School,single-academy trust,,,,company:07943227,LEADING LEARNERS MULTI ACADEMY TRUST
+1651,St Paul's Church of England Primary School,single-academy trust,,,,company:07994514,ST PAUL'S CHURCH OF ENGLAND PRIMARY SCHOOL
+1652,"Cowplain School, The",single-academy trust,,,,company:07954363,THE COWPLAIN SCHOOL
+1653,The Wensum Trust,multi-academy trust,,company:07982312,16054,company:07982312,THE WENSUM TRUST
+1654,"Epiphany School, The",multi-academy trust,,company:07991877,3044,company:07991877,THE EPIPHANY SCHOOL
+1655,Braunton School and Community College Academy Trust,single-academy trust,,,,company:07989226,BRAUNTON SCHOOL AND COMMUNITY COLLEGE ACADEMY TRUST
+1656,"Marlborough Science Academy, The",single-academy trust,,,,company:08003969,THE MARLBOROUGH SCIENCE ACADEMY LIMITED
+1657,Bursley Multi Academy Trust,multi-academy trust,,company:07972070,15767,company:07972070,BURSLEY MULTI ACADEMY TRUST
+1658,"St Christopher School Academy Trust, The",single-academy trust,,,,company:07973980,THE ST CHRISTOPHER SCHOOL ACADEMY TRUST
+1659,"Greenacre Academy Trust, The",multi-academy trust,,company:07965316,3243,company:07965316,THE GREENACRE ACADEMY TRUST
+1660,"Henrietta Barnett School, The",single-academy trust,,,,company:07992842,THE HENRIETTA BARNETT SCHOOL
+1661,Aspire Learning Trust (Whittlesey),multi-academy trust,,company:08006711,4530,company:08006711,ASPIRE LEARNING TRUST (WHITTLESEY)
+1662,St. Anthony's Girls' Catholic Academy,single-academy trust,,,,company:07968898,ST. ANTHONY'S GIRLS' CATHOLIC ACADEMY
+1663,Stretton Sugwas Church of England Academy,single-academy trust,,,,company:07718539,STRETTON SUGWAS CHURCH OF ENGLAND ACADEMY
+1664,Waynflete Infants' School,single-academy trust,,,,company:07998122,WAYNFLETE INFANTS' SCHOOL
+1665,Long Bennington Church of England Academy,single-academy trust,,,,company:07994012,LONG BENNINGTON CHURCH OF ENGLAND ACADEMY
+1666,Holmer Green Senior School,single-academy trust,,,,company:07827237,HOLMER GREEN SENIOR SCHOOL
+1667,The Core Educational Trust,multi-academy trust,,company:07949154,4145,company:07949154,THE CORE EDUCATION TRUST
+1668,Signhills Infant Academy,single-academy trust,,,,company:07930349,SIGNHILLS INFANT ACADEMY
+1669,Daubeney Academy,single-academy trust,,,,company:07978124,DAUBENEY ACADEMY
+1670,Tapton School Academy Trust,multi-academy trust,,company:07697171,4899,company:07697171,TAPTON SCHOOL ACADEMY TRUST
+1671,Easington Academy,single-academy trust,,,,company:07990434,EASINGTON ACADEMY
+1672,"Elizabethan Academy Trust, The",single-academy trust,,,,company:07964360,THE ELIZABETHAN ACADEMY TRUST
+1673,Meadowdale Academy,single-academy trust,,,,company:07987239,MEADOWDALE ACADEMY
+1674,"Roundhill Academy, The",single-academy trust,,,,company:07976179,THE ROUNDHILL ACADEMY
+1675,Corpus Christi Catholic Academy Trust,multi-academy trust,,company:07976019,2788,company:07976019,CORPUS CHRISTI CATHOLIC ACADEMY TRUST
+1676,"Sigma Trust, The",multi-academy trust + umbrella trust,,company:07926573,16257,company:07926573,THE SIGMA TRUST
+1677,St Hybald's Academy Trust,multi-academy trust,,company:08003909,4697,company:08003909,ST HYBALD'S ACADEMY TRUST
+1678,Bradford Diocesan Academies Trust,multi-academy trust,,company:08258994,2408,company:08258994,BRADFORD DIOCESAN ACADEMIES TRUST
+1679,"Education Village Academy Trust, The",multi-academy trust,,company:07748248,3018,company:07748248,THE EDUCATION VILLAGE ACADEMY TRUST
+1680,Ash Field Academy Trust,single-academy trust,,,,company:07988444,ASH FIELD ACADEMY TRUST
+1681,Southmoor Academy,multi-academy trust,,company:08021855,5712,company:08021855,SOUTHMOOR ACADEMY
+1682,Timberley Academy Trust,single-academy trust,,,,company:08025958,TIMBERLEY ACADEMY TRUST
+1683,Our Lady Immaculate Catholic Primary School,single-academy trust,,,,company:08020070,OUR LADY IMMACULATE CATHOLIC PRIMARY SCHOOL
+1684,Loreto College (St Albans),single-academy trust,,,,company:08028084,LORETO COLLEGE (ST ALBANS)
+1685,Bishop Perowne Church of England College,single-academy trust,,,,company:08024353,BISHOP PEROWNE CHURCH OF ENGLAND COLLEGE
+1686,"Market Bosworth School, The",single-academy trust,,,,company:08028789,THE MARKET BOSWORTH SCHOOL
+1687,Holy Trinity Church of England Academy,single-academy trust,,,,company:08045401,HOLY TRINITY CHURCH OF ENGLAND ACADEMY
+1688,"Rowan Learning Trust, The",multi-academy trust,,company:08010464,4405,company:08010464,THE ROWAN LEARNING TRUST
+1689,"Rodillian Multi Academy Trust, The",multi-academy trust,,company:07990619,4386,company:07990619,THE RODILLIAN MULTI ACADEMY TRUST
+1690,By Brook Valley Academy Trust,single-academy trust,,,,company:08020467,BY BROOK VALLEY ACADEMY TRUST
+1691,"Priory Academy Trust, The",multi-academy trust,,company:08032410,4250,company:08032410,THE PRIORY ACADEMY TRUST
+1692,Campsmount Community Academy Trust,single-academy trust,,,,company:07736364,CAMPSMOUNT COMMUNITY ACADEMY TRUST
+1693,Kenton Schools Academy Trust,multi-academy trust,,company:07964133,3598,company:07964133,KENTON SCHOOLS ACADEMY TRUST
+1694,St Nicolas' CE Combined School Taplow,single-academy trust,,,,company:08043695,ST NICOLAS' CE COMBINED SCHOOL TAPLOW
+1695,"Dean Trust, The",multi-academy trust,,company:08027943,2864,company:08027943,THE DEAN TRUST
+1696,REAch4 Academy Trust,multi-academy trust,,company:09791051,16104,company:09791051,REACH4 ACADEMY TRUST
+1697,St John's Church of England Academy,single-academy trust,,,,company:08026134,ST JOHN'S CHURCH OF ENGLAND ACADEMY
+1698,Firthmoor Primary School,single-academy trust,,,,company:08027879,FIRTHMOOR PRIMARY SCHOOL
+1699,"Oakwood Academy Schools Trust, The",multi-academy trust,,company:07982516,5711,company:07982516,THE OAKWOOD ACADEMY SCHOOLS TRUST
+1700,"Mead Academy Trust, The",multi-academy trust,,company:08024396,3884,company:08024396,THE MEAD ACADEMY TRUST
+1701,St. Ambrose College Edmund Rice Academy Trust,single-academy trust,,,,company:07827963,ST. AMBROSE COLLEGE EDMUND RICE ACADEMY TRUST
+1702,Robert May's School,single-academy trust,,,,company:07875747,ROBERT MAY'S SCHOOL
+1703,Perry Beeches The Academy Trust,multi-academy trust,,company:07749786,4185,company:07749786,PERRY BEECHES THE ACADEMY TRUST
+1704,Manor Leas Infant School,single-academy trust,,,,company:08041135,MANOR LEAS INFANT SCHOOL
+1705,"Lutterworth Academies Trust, The",multi-academy trust,,company:08038063,3806,company:08038063,THE LUTTERWORTH ACADEMIES TRUST
+1706,Grove Park Academies,multi-academy trust,,company:08059055,3265,company:08059055,GROVE PARK ACADEMIES
+1707,Eagley Junior School,single-academy trust,,,,company:07986218,EAGLEY JUNIOR SCHOOL
+1708,Woodnewton Academy Trust,multi-academy trust,,company:08034402,5402,company:08034402,WOODNEWTON ACADEMY TRUST
+1709,Stafford Leys Academy Trust,single-academy trust,,,,company:08054506,STAFFORD LEYS ACADEMY TRUST
+1710,Gartree High School,single-academy trust,,,,company:08023322,GARTREE HIGH SCHOOL
+1711,Dorothy Goodman School,single-academy trust,,,,company:08071851,DOROTHY GOODMAN SCHOOL
+1712,"Eden Academy, The",multi-academy trust,,company:08036395,3004,company:08036395,THE EDEN ACADEMY
+1713,Gilsland Church of England Primary School,single-academy trust,,,,company:08047328,GILSLAND CHURCH OF ENGLAND PRIMARY SCHOOL
+1714,"Castle Partnership Academy Trust, The",multi-academy trust,,company:08066451,2563,company:08066451,THE CASTLE PARTNERSHIP ACADEMY TRUST
+1715,Barnby Dun Primary Academy,single-academy trust,,,,company:08029445,BARNBY DUN PRIMARY ACADEMY
+1716,Primary Excellence - A Catholic Education Trust,multi-academy trust,,company:08068528,4244,company:08068528,PRIMARY EXCELLENCE - A CATHOLIC EDUCATION TRUST
+1717,St Osmund's CE Middle School,single-academy trust,,,,company:08066279,ST OSMUND'S CE MIDDLE SCHOOL
+1718,Marish Academy Trust,multi-academy trust,,company:08073873,3860,company:08073873,MARISH ACADEMY TRUST
+1719,The Dover Federation for the Arts,multi-academy trust,,company:08039629,4958,company:08039629,THE DOVER FEDERATION FOR THE ARTS
+1720,Avonbourne International Business and Enterprise Academy Trust,multi-academy trust,,company:08080096,2213,company:08080096,AVONBOURNE INTERNATIONAL BUSINESS AND ENTERPRISE ACADEMY TRUST
+1721,St Bede's Catholic Academy (Lanchester),single-academy trust,,,,company:08062065,ST BEDE'S CATHOLIC ACADEMY (LANCHESTER)
+1722,"Meadow Community Primary School Academy Trust, The",single-academy trust,,,,company:08049033,THE MEADOW COMMUNITY PRIMARY SCHOOL ACADEMY TRUST
+1723,Legra Academy Trust,multi-academy trust,,company:08066610,5639,company:08066610,LEGRA ACADEMY TRUST
+1724,Federation of Mowden Schools Academy Trust,multi-academy trust,,company:08027205,3091,company:08027205,FEDERATION OF MOWDEN SCHOOLS ACADEMY TRUST
+1725,Cromwell Community College,single-academy trust,,,,company:07994038,CROMWELL COMMUNITY COLLEGE
+1726,The Collegiate Trust,multi-academy trust,,company:08058921,15936,company:08058921,THE COLLEGIATE TRUST
+1727,Heathfield Academy Trust,multi-academy trust,,company:08027885,3375,company:08027885,HEATHFIELD ACADEMY TRUST
+1728,"Priory Academy, Dunstable",single-academy trust,,,,company:08002543,"PRIORY ACADEMY, DUNSTABLE"
+1729,Bellerive FCJ Catholic College,single-academy trust,,,,company:08028387,BELLERIVE FCJ CATHOLIC COLLEGE
+1730,Wyvern College Academy Trust,single-academy trust,,,,company:08021829,WYVERN COLLEGE ACADEMY TRUST
+1731,Dorchester Middle School,single-academy trust,,,,company:08059041,DORCHESTER MIDDLE SCHOOL
+1732,Woodcote High School,single-academy trust,,,,company:08053276,WOODCOTE HIGH SCHOOL
+1733,Woodford Valley Church of England Primary Academy,single-academy trust,,,,company:08056328,WOODFORD VALLEY CHURCH OF ENGLAND PRIMARY ACADEMY
+1734,Greenwood Tree Academy Trust,multi-academy trust,,company:08066324,5640,company:08066324,GREENWOOD TREE ACADEMY TRUST
+1735,Ryvers School,single-academy trust,,,,company:08060671,RYVERS SCHOOL
+1736,School 21,multi-academy trust,,company:07648389,4473,company:07648389,SCHOOL 21
+1737,Sandymoor Free School,single-academy trust,,,,company:07635438,SANDYMOOR FREE SCHOOL
+1738,Central Bedfordshire UTC Trust Limited,single-academy trust,,,,company:07651573,CENTRAL BEDFORDSHIRE UTC TRUST LIMITED
+1739,Hatfield Community Free School,single-academy trust,,,,company:07648654,HATFIELD COMMUNITY FREE SCHOOL
+1740,"Wapping and Shadwell Secondaery Education Trust, The",single-academy trust,,,,company:07412515,THE WAPPING AND SHADWELL SECONDARY EDUCATION TRUST
+1741,Bedminster Down School,single-academy trust,,,,company:07829616,BEDMINSTER DOWN SCHOOL
+1742,Fleetville Trust,multi-academy trust,,company:08028375,3107,company:08028375,SPIRAL PARTNERSHIP TRUST
+1743,Denton West End Primary School,single-academy trust,,,,company:07929335,DENTON WEST END PRIMARY SCHOOL
+1744,Woodfield Academy,single-academy trust,,,,company:08039319,WOODFIELD ACADEMY
+1745,Ardley Hill Academy,single-academy trust,,,,company:08006892,ARDLEY HILL ACADEMY
+1746,The Mill Academy,multi-academy trust,,company:08060721,15886,company:08060721,THE MILL ACADEMY
+1747,Kibblesworth Academy,single-academy trust,,,,company:08063683,KIBBLESWORTH ACADEMY
+1748,Eppleton Academy Primary School,single-academy trust,,,,company:08063334,EPPLETON ACADEMY PRIMARY SCHOOL
+1749,"Duston Education Trust, The",single-academy trust,,,,company:09299605,THE DUSTON EDUCATION TRUST
+1750,"Wroxham Foundation, The",single-academy trust,,,,company:08033193,THE WROXHAM FOUNDATION
+1751,Pursuing Educational Excellence Together,multi-academy trust,,company:08064698,4264,company:08064698,THE PRIORY SCHOOL TRUST
+1752,Henbury School,single-academy trust,,,,company:07838126,HENBURY SCHOOL
+1753,Dorrington Academy Trust,single-academy trust,,,,company:08049062,DORRINGTON ACADEMY TRUST
+1754,Tauheedul Education Trust,multi-academy trust,,company:07353849,4903,company:07353849,TAUHEEDUL EDUCATION TRUST
+1755,St Joseph's College DelaSalle,single-academy trust,,,,company:08061075,ST JOSEPH'S COLLEGE DELASALLE
+1756,Aston University Engineering Academy Birmingham,single-academy trust,,,,company:07166427,ASTON UNIVERSITY ENGINEERING ACADEMY BIRMINGHAM
+1757,"North Hertfordshire Studio School Trust, The",multi-academy trust,,company:07791933,4020,company:07791933,THE NORTH HERTFORDSHIRE STUDIO SCHOOL TRUST
+1758,Cobham Free School Trust,single-academy trust,,,,company:07643477,COBHAM FREE SCHOOL TRUST
+1759,"Bedford and Kempston Free School Limited, The",single-academy trust,,,,company:07337888,THE BEDFORD AND KEMPSTON FREE SCHOOL LIMITED
+1760,Alban City Free School Ltd,single-academy trust,,,,company:07644208,ALBAN CITY FREE SCHOOL LTD
+1761,Chapel Street Community Schools Trust,multi-academy trust,,company:07885963,2609,company:07885963,CHAPEL STREET COMMUNITY SCHOOLS TRUST
+1762,RET Becket Keys Church of England Free School Trust,single-academy trust,,,,company:08096798,RET BECKET KEYS CHURCH OF ENGLAND FREE SCHOOL TRUST
+1763,"Greenwich Free School Group, The",single-academy trust,,,,company:07638748,THE GREENWICH FREE SCHOOL GROUP
+1764,Sabres Educational Trust,single-academy trust,,,,company:07432586,SABRES EDUCATIONAL TRUST
+1765,Stephenson (MK) Trust,multi-academy trust,,company:07919427,4837,company:07919427,STEPHENSON (MK) TRUST
+1766,Cramlington Village Primary Ltd,single-academy trust,,,,company:07575016,CRAMLINGTON VILLAGE PRIMARY LTD
+1767,"Emmanuel School Trust, The",single-academy trust,,,,company:07640769,THE EMMANUEL SCHOOL TRUST
+1768,Bilingual Primary School Project Ltd,single-academy trust,,,,company:07413872,BILINGUAL PRIMARY SCHOOL PROJECT LTD
+1769,City Gateway 14-19 Provision,single-academy trust,,,,company:08111431,CITY GATEWAY 14-19 PROVISION
+1770,Southwark Free Schools Trust,single-academy trust,,,,company:07649385,SOUTHWARK FREE SCHOOLS TRUST
+1771,Stone Soup Learns,single-academy trust,,,,company:07217174,STONE SOUP LEARNS
+1772,Hackney UTC,single-academy trust,,,,company:07722672,HACKNEY UTC
+1773,Reach Academy,single-academy trust,,,,company:07634106,REACH ACADEMY
+1774,Barrow 1618 The School Co,single-academy trust,,,,company:07640198,BARROW 1618 THE SCHOOL CO
+1775,Europa School UK,single-academy trust,,,,company:07649335,EUROPA SCHOOL UK
+1776,Rimon Jewish Primary School,single-academy trust,,,,company:07643890,RIMON JEWISH PRIMARY SCHOOL
+1777,"Seckford Foundation Free Schools Trust, The",multi-academy trust,,company:08077362,4482,company:08077362,THE SECKFORD FOUNDATION FREE SCHOOLS TRUST
+1778,"Diamond Learning Partnership Trust, The",multi-academy trust,,company:08062508,2886,company:08062508,THE DIAMOND LEARNING PARTNERSHIP TRUST
+1779,Wilson Stuart School,single-academy trust,,,,company:07972037,WILSON STUART SCHOOL
+1780,"Harrowby/National Academies Trust, The",multi-academy trust,,company:08105941,3326,company:08105941,THE HARROWBY/NATIONAL ACADEMIES TRUST
+1781,Rauceby Church of England Primary School,single-academy trust,,,,company:08099606,RAUCEBY CHURCH OF ENGLAND PRIMARY SCHOOL
+1782,Riverside Primary Academy,single-academy trust,,,,company:08104080,RIVERSIDE PRIMARY ACADEMY
+1783,Beaumont School,single-academy trust,,,,company:08104190,BEAUMONT SCHOOL
+1784,"Costello School, The",single-academy trust,,,,company:08062622,THE COSTELLO SCHOOL
+1785,Burford School,single-academy trust,,,,company:08082185,BURFORD SCHOOL
+1786,Saint Dominic's Catholic Academy Trust,multi-academy trust,,company:08106388,4438,company:08106388,SAINT DOMINIC'S CATHOLIC ACADEMY TRUST
+1787,Crigglestone St James CE Primary Academy Trust,single-academy trust + umbrella trust,,,,company:08097265,CRIGGLESTONE ST JAMES CE PRIMARY ACADEMY TRUST
+1788,"Blessed Cyprian Tansi Catholic Academy Trust, The",multi-academy trust,,company:08090890,2354,company:08090890,THE BLESSED CYPRIAN TANSI CATHOLIC ACADEMY TRUST
+1789,Zest Academies Trust,multi-academy trust,,company:08087508,16160,company:08087508,ZEST ACADEMY TRUST
+1790,Newbridge High School Academy Trust,single-academy trust,,,,company:08100149,NEWBRIDGE HIGH SCHOOL ACADEMY TRUST
+1791,"Holy Trinity Primary School, A Church of England Academy",single-academy trust,,,,company:08105758,"HOLY TRINITY PRIMARY SCHOOL, A CHURCH OF ENGLAND ACADEMY"
+1792,Warren Farm Primary School,single-academy trust,,,,company:08055393,WARREN FARM PRIMARY SCHOOL
+1793,Interserve Academies Trust Limited,multi-academy trust,,company:09042916,3535,company:09042916,INTERSERVE ACADEMIES TRUST LIMITED
+1794,Elburton Primary School Academy,single-academy trust,,,,company:08084557,HORIZON MULTI ACADEMY TRUST
+1795,St Teresa's Catholic Primary School,single-academy trust,,,,company:08111345,ST TERESA'S CATHOLIC PRIMARY SCHOOL
+1796,Westminster City School,single-academy trust,,,,company:08100409,WESTMINSTER CITY SCHOOL
+1797,"Grey Coat Hospital, The",single-academy trust,,,,company:08099098,THE GREY COAT HOSPITAL
+1798,Consilium Academies,multi-academy trust + umbrella trust,,company:09495671,15728,company:09495671,CONSILIUM ACADEMIES
+1799,TEAM Multi-Academy Trust,multi-academy trust,,company:08110847,5641,company:08110847,TEAM MULTI-ACADEMY TRUST
+1800,Christ Church C of E Primary School,single-academy trust,,,,company:08082405,CHRIST CHURCH C OF E PRIMARY SCHOOL
+1801,Neston High School,single-academy trust,,,,company:08100578,NESTON HIGH SCHOOL
+1802,"Park Federation Academy Trust, The",multi-academy trust,,company:08146330,4134,company:08146330,THE PARK FEDERATION ACADEMY TRUST
+1803,Huncote Community Primary School Academy Trust,single-academy trust,,,,company:08076310,HUNCOTE COMMUNITY PRIMARY SCHOOL ACADEMY TRUST
+1804,Brookvale High School,single-academy trust,,,,company:08089397,BROOKVALE HIGH SCHOOL
+1805,Lincoln Anglican Academy Trust,multi-academy trust,,company:08737412,3746,company:08737412,LINCOLN ANGLICAN ACADEMY TRUST
+1806,"Silver Birch Academy, The",multi-academy trust,,company:08107310,4524,company:08107310,THE SILVER BIRCH ACADEMY
+1807,"Frances Bardsley Academy for Girls, The",single-academy trust,,,,company:08102628,LIFE EDUCATION TRUST
+1808,Peninsula Gateway Academy Trust,multi-academy trust,,company:08095169,4175,company:08095169,PENINSULA GATEWAY ACADEMY TRUST
+1809,St Bernard's Catholic High School,single-academy trust + umbrella trust,,,,company:08098352,ST BERNARD'S CATHOLIC HIGH SCHOOL
+1810,The Holy Spirit Umbrella Trust,single-academy trust + umbrella trust,yes,,,company:08096750,THE HOLY SPIRIT UMBRELLA TRUST
+1811,Hillcrest Early Years Academy Limited,single-academy trust,,,,company:07980317,HILLCREST EARLY YEARS ACADEMY LIMITED
+1812,Balmoral Learning Trust,multi-academy trust,,company:08083620,16051,company:08083620,BALMORAL LEARNING TRUST
+1813,St Cyprian's Greek Orthodox Primary Academy,single-academy trust,,,,company:08085808,ST CYPRIAN'S GREEK ORTHODOX PRIMARY ACADEMY
+1814,All Saints' Catholic High School,single-academy trust + umbrella trust,,,,company:08100620,ALL SAINTS' CATHOLIC HIGH SCHOOL
+1815,Hallam: De La Salle Academy Trust,single-academy trust + umbrella trust,yes,,,company:08101591,HALLAM: DE LA SALLE ACADEMY TRUST
+1816,St Barnabas Catholic Academy Trust,multi-academy trust,,company:08089246,4806,company:08089246,ST BARNABAS CATHOLIC ACADEMY TRUST
+1817,Altwood Church of England School,single-academy trust,,,,company:08107655,ALTWOOD CHURCH OF ENGLAND SCHOOL
+1818,Woodlands Academy of Learning,single-academy trust,,,,company:08077289,WOODLANDS ACADEMY OF LEARNING
+1819,John Cleveland College,single-academy trust,,,,company:08073889,JOHN CLEVELAND COLLEGE
+1820,Discovery Schools Academies Trust Ltd,multi-academy trust,,company:08104111,2932,company:08104111,DISCOVERY SCHOOLS ACADEMIES TRUST LTD
+1821,Meadowdale Primary Academy,single-academy trust,,,,company:08061303,MEADOWDALE PRIMARY ACADEMY
+1822,Ridgeway Primary Academy,single-academy trust,,,,company:08041206,RIDGEWAY PRIMARY ACADEMY
+1823,Ivanhoe College,single-academy trust,,,,company:08100518,IVANHOE COLLEGE
+1824,"Rural Enterprise Academy, The",single-academy trust,,,,company:07652211,THE RURAL ENTERPRISE ACADEMY
+1825,Tring School,single-academy trust,,,,company:08056991,TRING SCHOOL
+1826,Flying High Trust,multi-academy trust,,company:08076374,3111,company:08076374,FLYING HIGH TRUST
+1827,Hilbre High School Humanities College,single-academy trust,,,,company:08075363,HILBRE HIGH SCHOOL HUMANITIES COLLEGE
+1828,"St George's School, Harpenden Academy Trust",single-academy trust,,,,company:08092358,"ST GEORGE'S SCHOOL, HARPENDEN ACADEMY TRUST"
+1829,Great Bowden Academy Ltd,single-academy trust,,,,company:08095439,LEARN ACADEMIES TRUST
+1830,"St Mary's CE Academy, Cheshunt",single-academy trust,,,,company:07999861,"ST MARY'S CE ACADEMY, CHESHUNT"
+1831,Notre Dame High School,single-academy trust + umbrella trust,,,,company:08098354,NOTRE DAME HIGH SCHOOL
+1832,Our Lady's,single-academy trust + umbrella trust,yes,,,company:08096699,OUR LADY'S
+1833,"Griffin Schools Trust, The",multi-academy trust,,company:07893665,3262,company:07893665,THE GRIFFIN SCHOOLS TRUST
+1834,"Active Learning Trust Limited, The",multi-academy trust,,company:07903002,2075,company:07903002,THE ACTIVE LEARNING TRUST LIMITED
+1835,Everton in the Community Free School Trust,single-academy trust,,,,company:07664278,EVERTON IN THE COMMUNITY FREE SCHOOL TRUST
+1836,Lighthouse School,single-academy trust,,,,company:07591868,LIGHTHOUSE SCHOOL
+1837,Steiner Academy Frome,single-academy trust,,,,company:08102584,STEINER ACADEMY FROME
+1838,LeAF Academy,multi-academy trust,,company:08011930,3713,company:08011930,LEAF ACADEMY
+1839,Isle of Portland Aldridge Community Academy Trust,single-academy trust,,,,company:07927423,ISLE OF PORTLAND ALDRIDGE COMMUNITY ACADEMY TRUST
+1840,Aurora Academies Trust,multi-academy trust,,company:08107711,2206,company:08107711,AURORA ACADEMIES TRUST
+1841,London Academy of Excellence,single-academy trust,,,,company:07643795,LONDON ACADEMY OF EXCELLENCE
+1842,Salford Academy Trust,multi-academy trust,,company:08115121,4447,company:08115121,SALFORD ACADEMY TRUST
+1843,Academy Transformation Trust,multi-academy trust,,company:07846852,2062,company:07846852,ACADEMY TRANSFORMATION TRUST
+1844,"Elliot Foundation Academies Trust, The",multi-academy trust,,company:08116706,3025,company:08116706,THE ELLIOT FOUNDATION ACADEMIES TRUST
+1845,"St Clement's C of E Primary Academy, Nechells",single-academy trust,,,,company:08165736,"ST CLEMENT'S C OF E PRIMARY ACADEMY, NECHELLS"
+1846,"St Michael's CofE Primary Academy, Handsworth",single-academy trust,,,,company:08177570,"ST MICHAEL'S C OF E PRIMARY ACADEMY, HANDSWORTH"
+1847,Trust in Learning (Academies),multi-academy trust,,company:08089704,5122,company:08089704,TRUST IN LEARNING (ACADEMIES)
+1848,Hornbeam Academy Trust,multi-academy trust,,company:08153765,3485,company:08153765,HORNBEAM ACADEMY TRUST
+1849,Wembley High Technology College,multi-academy trust,,company:08137772,16250,company:08137772,WEMBLEY MULTI ACADEMY TRUST
+1850,Salvatorian College,single-academy trust,,,,company:08134861,SALVATORIAN COLLEGE
+1851,"Holy Cross School, The",single-academy trust,,,,company:07966826,THE HOLY CROSS SCHOOL
+1852,Teddington School,single-academy trust,,,,company:08130502,TEDDINGTON SCHOOL
+1853,"Waldegrave Trust, The",multi-academy trust,,company:08130508,5199,company:08130508,THE WALDEGRAVE TRUST
+1854,Hockley Heath Academy Trust,single-academy trust,,,,company:08104539,HOCKLEY HEATH ACADEMY TRUST
+1855,St Francis Xavier's College,single-academy trust,,,,company:08137421,ST FRANCIS XAVIER'S COLLEGE
+1856,Loreto Grammar School,single-academy trust,,,,company:08125396,LORETO GRAMMAR SCHOOL
+1857,St Patrick's Catholic Primary School,single-academy trust,,,,company:08135761,ST PATRICK'S CATHOLIC PRIMARY SCHOOL
+1858,Nailsea School,single-academy trust,,,,company:08084047,NAILSEA SCHOOL
+1859,Bursar Primary Academy,single-academy trust,,,,company:08018275,BURSAR PRIMARY ACADEMY
+1860,Thrunscoe Primary and Nursery Academy,single-academy trust,,,,company:08018237,THRUNSCOE PRIMARY AND NURSERY ACADEMY
+1861,Chantry Primary Academy Trust,single-academy trust,,,,company:08133360,CHANTRY PRIMARY ACADEMY TRUST
+1862,"Marian Catholic Academy Trust, The",single-academy trust + umbrella trust,yes,,,company:08096772,THE MARIAN CATHOLIC ACADEMY TRUST
+1863,St Mary's Catholic High School Academy Trust,single-academy trust + umbrella trust,,,,company:08107212,ST MARY'S CATHOLIC HIGH SCHOOL ACADEMY TRUST
+1864,"Gryphon School, The",single-academy trust,,,,company:08130468,THE GRYPHON SCHOOL
+1865,Hailsham Community College Academy Trust,single-academy trust,,,,company:08127108,HAILSHAM COMMUNITY COLLEGE ACADEMY TRUST
+1866,Seaford Head Academy Trust,single-academy trust,,,,company:08122579,SEAFORD HEAD ACADEMY TRUST
+1867,Ratton School Academy Trust,single-academy trust,,,,company:08130302,RATTON SCHOOL ACADEMY TRUST
+1868,"Cavendish School (Eastbourne), The",single-academy trust,,,,company:08135372,THE CAVENDISH SCHOOL (EASTBOURNE)
+1869,St Anne's Catholic School,single-academy trust,,,,company:08135868,ST ANNE'S CATHOLIC SCHOOL
+1870,Mount Grace High School Academy Trust,single-academy trust,,,,company:08121030,MOUNT GRACE HIGH SCHOOL ACADEMY TRUST
+1871,Castle Rock High School,single-academy trust,,,,company:08114513,CASTLE ROCK HIGH SCHOOL
+1872,King William Street CE Primary School,single-academy trust,,,,company:08117139,KING WILLIAM STREET CE PRIMARY SCHOOL
+1873,"Harvey Academy, The",multi-academy trust,,company:08142275,3333,company:08142275,THE HARVEY ACADEMY
+1874,Kirkby College Trust,single-academy trust,,,,company:08124416,KIRKBY COLLEGE TRUST
+1875,Tarporley High School and Sixth Form College,single-academy trust,,,,company:08100344,TARPORLEY HIGH SCHOOL AND SIXTH FORM COLLEGE
+1876,"Sele School, The",single-academy trust,,,,company:08124615,THE SELE SCHOOL
+1877,Knightsfield School,single-academy trust,,,,company:08130253,KNIGHTSFIELD SCHOOL
+1878,Branston Junior Academy,single-academy trust,,,,company:08131708,BRANSTON JUNIOR ACADEMY
+1879,St Andrew's Church of England Academy,single-academy trust,,,,company:08128214,ST ANDREW'S CHURCH OF ENGLAND ACADEMY
+1880,Didcot Academy of Schools,multi-academy trust,,company:08104201,2887,company:08104201,DIDCOT ACADEMY OF SCHOOLS
+1881,"Bishop Wand Church of England School, The",single-academy trust,,,,company:08144566,THE BISHOP WAND CHURCH OF ENGLAND SCHOOL
+1882,Greenway Academy,single-academy trust,,,,company:08116954,GREENWAY ACADEMY
+1883,"Collaborative Academies Trust, The",multi-academy trust,,company:08168307,2741,company:08168307,THE COLLABORATIVE ACADEMIES TRUST
+1884,South Gloucestershire and Stroud Academy Trust,multi-academy trust,,company:09353480,5516,company:09353480,SOUTH GLOUCESTERSHIRE AND STROUD ACADEMY TRUST
+1885,Redditch RSA Academies Trust,multi-academy trust,,company:08166526,4335,company:08166526,REDDITCH RSA ACADEMIES TRUST
+1886,St Augustine's Catholic Academy Trust,single-academy trust,,,,company:08169229,ST AUGUSTINE'S CATHOLIC ACADEMY TRUST
+1887,Portsmouth and Winchester Diocesan Academies Trust,multi-academy trust + umbrella trust,,company:08161468,4230,company:08161468,PORTSMOUTH AND WINCHESTER DIOCESAN ACADEMIES TRUST
+1888,Portsmouth and Winchester Diocesan Academy Umbrella Trust,multi-academy trust + umbrella trust,yes,,,company:08004986,PORTSMOUTH AND WINCHESTER DIOCESAN ACADEMY UMBRELLA TRUST
+1889,St. John Fisher Catholic Academy Trust,single-academy trust,,,,company:08172988,ST. JOHN FISHER CATHOLIC ACADEMY TRUST
+1890,Brockington College,single-academy trust,,,,company:08138965,BROCKINGTON COLLEGE
+1891,Palladian Academy Trust,multi-academy trust,,company:08061092,16158,company:08061092,PALLADIAN ACADEMY TRUST
+1892,St Bede's RC Primary School,single-academy trust,,,,company:08085993,ST BEDE'S RC PRIMARY SCHOOL
+1893,Countesthorpe Community College Trust,single-academy trust + umbrella trust,,,,company:08137363,COUNTESTHORPE COMMUNITY COLLEGE TRUST
+1894,The South Leicestershire Learning Partnership,single-academy trust + umbrella trust,yes,,,company:08162613,THE SOUTH LEICESTERSHIRE LEARNING PARTNERSHIP
+1895,Newbury Academy Trust,multi-academy trust,,company:08142572,3987,company:08142572,NEWBURY ACADEMY TRUST
+1896,"Ascent Academies Trust, The",multi-academy trust,,company:08098007,2168,company:08098007,THE ASCENT ACADEMIES' TRUST
+1897,Thomas Estley Community College,single-academy trust,,,,company:08135389,SUCCESS ACADEMY TRUST
+1898,Cosby Primary School,single-academy trust + umbrella trust,,,,company:08137451,COSBY PRIMARY SCHOOL
+1899,Leysland High School,single-academy trust,,,,company:08135122,LEYSLAND HIGH SCHOOL
+1900,Westbury Park School,single-academy trust,,,,company:08130158,WESTBURY PARK SCHOOL
+1901,Newlands Spring Primary School Academy Trust,single-academy trust,,,,company:08132067,ATTAIN ACADEMY PARTNERSHIP
+1902,Holley Park Academy,single-academy trust,,,,company:08158718,ACER LEARNING TRUST
+1903,Central Schools Trust,multi-academy trust,,company:08148546,16178,company:08148546,CENTRAL SCHOOLS TRUST
+1904,Winstanley Community College Academy Trust,single-academy trust,,,,company:08094234,WINSTANLEY COMMUNITY COLLEGE ACADEMY TRUST
+1905,Hawes Side Academy,single-academy trust,,,,company:08161246,HAWES SIDE ACADEMY
+1906,Northgate Primary School Trust,single-academy trust,,,,company:08128432,NORTHGATE PRIMARY SCHOOL TRUST
+1907,King Ina Church of England Academy,multi-academy trust,,company:08120037,3628,company:08120037,KING INA CHURCH OF ENGLAND ACADEMY
+1908,Yarborough Academy,single-academy trust,,,,company:08018146,YARBOROUGH ACADEMY
+1909,Broughton Jewish Cassel Fox,single-academy trust,,,,company:08133686,BROUGHTON JEWISH CASSEL FOX
+1910,Albany Learning Trust,multi-academy trust,,company:08123168,5692,company:08123168,ALBANY LEARNING TRUST
+1911,Meadowhead School Academy Trust,single-academy trust,,,,company:07933749,MEADOWHEAD SCHOOL ACADEMY TRUST
+1912,Charlton Park Academy,single-academy trust,,,,company:08133047,CHARLTON PARK ACADEMY
+1913,Sutherland Primary Academy,single-academy trust,,,,company:07845470,SUTHERLAND PRIMARY ACADEMY
+1914,City Learning Trust,single-academy trust,,,,company:07746561,CITY LEARNING TRUST
+1915,EPA Multi Academy Trust (Excellent Partnerships Achieve),multi-academy trust,,company:07896123,15937,company:07896123,EPA MULTI ACADEMY TRUST (EXCELLENT PARTNERSHIPS ACHIEVE)
+1916,"Cresecent Academy, The",single-academy trust,,,,company:07735646,THE CRESCENT ACADEMY
+1917,Tudhoe Learning Trust,multi-academy trust,,company:08270151,5125,company:08270151,TUDHOE LEARNING TRUST
+1918,St Augustine's Academy Trust,single-academy trust,,,,company:08168245,ST AUGUSTINE'S ACADEMY TRUST
+1919,TEES VALLEY EDUCATION,multi-academy trust,,company:09630999,15748,company:09630999,TEES VALLEY EDUCATION
+1920,Harpenden Academy Limited,single-academy trust,,,,company:07649122,HARPENDEN ACADEMY LIMITED
+1921,Grindon Hall Christian School,single-academy trust,,,,company:05530130,GRINDON HALL CHRISTIAN SCHOOL
+1922,Grasmere Academy,single-academy trust,,,,company:08132137,GRASMERE ACADEMY
+1923,Canterbury Diocesan Umbrella Trust,multi-academy trust + umbrella trust,yes,,,company:07793458,THE DIOCESE OF CANTERBURY ACADEMIES COMPANY LIMITED
+1924,"Stour Academy Trust, The",multi-academy trust + umbrella trust,,company:08179242,4850,company:08179242,THE STOUR ACADEMY TRUST
+1925,Wakefield Diocesan Academies Trust,multi-academy trust,,company:07904096,5196,company:07904096,ENHANCE ACADEMY TRUST
+1926,St Laurence in Thanet Church of England Junior Academy,single-academy trust,,,,company:08291666,ST LAURENCE IN THANET CHURCH OF ENGLAND JUNIOR ACADEMY
+1927,Inspirational Futures Trust,multi-academy trust,,company:08329993,5299,company:08329993,INSPIRATIONAL FUTURES TRUST
+1928,EMLC Academy Trust,multi-academy trust,,company:08149829,3033,company:08149829,EMLC ACADEMY TRUST
+1929,Blue Coat Church of England Academy (Walsall) Trust,single-academy trust,,,,company:08137486,BLUE COAT CHURCH OF ENGLAND ACADEMY (WALSALL) TRUST
+1930,Lady Margaret School,single-academy trust,,,,company:08156535,LADY MARGARET SCHOOL
+1931,Sudbury Primary School,single-academy trust,,,,company:08147330,SUDBURY PRIMARY SCHOOL
+1932,Queens Park Community School Academy Trust,single-academy trust,,,,company:08146138,QUEENS PARK COMMUNITY SCHOOL ACADEMY TRUST
+1933,Alperton Community School,single-academy trust,,,,company:08163458,ALPERTON COMMUNITY SCHOOL
+1934,St Thomas Becket Catholic Primary School,single-academy trust,,,,company:08163424,ST THOMAS BECKET CATHOLIC PRIMARY SCHOOL
+1935,Altrincham College of Arts,single-academy trust,,,,company:08137701,ALTRINCHAM COLLEGE OF ARTS
+1936,Upperwood Academy,single-academy trust,,,,company:08152109,UPPERWOOD ACADEMY
+1937,"Wey Valley School and Sports College, The",single-academy trust,,,,company:08128803,THE WEY VALLEY SCHOOL
+1938,Chew Stoke Church School,single-academy trust,,,,company:08165319,CHEW STOKE CHURCH SCHOOL
+1939,St Catherine's Catholic Primary School (Academy) Swindon,single-academy trust,,,,company:08132338,ST CATHERINE'S CATHOLIC PRIMARY SCHOOL (ACADEMY) SWINDON
+1940,Holy Family Catholic Academy Trust,multi-academy trust,,company:08155184,3457,company:08155184,HOLY FAMILY CATHOLIC ACADEMY TRUST
+1941,Excalibur Academies Trust,multi-academy trust,,company:08146633,3065,company:08146633,EXCALIBUR ACADEMIES TRUST
+1942,Rye Academy Trust,multi-academy trust,,company:08177657,4426,company:08177657,RYE ACADEMY TRUST
+1943,Ludlow Infant Academy,single-academy trust,,,,company:08152049,LUDLOW INFANT ACADEMY
+1944,Portswood Primary Academy Trust,multi-academy trust,,company:08158400,4232,company:08158400,PORTSWOOD PRIMARY ACADEMY TRUST
+1945,Groby Community College,single-academy trust,,,,company:08133601,GROBY COMMUNITY COLLEGE
+1946,Devizes School,single-academy trust,,,,company:08158582,DEVIZES SCHOOL
+1947,Monk's Walk School,single-academy trust,,,,company:08171632,MONK'S WALK SCHOOL
+1948,Ribbon Academy Trust,single-academy trust,,,,company:08132353,RIBBON ACADEMY TRUST
+1949,Maplefields Academy,single-academy trust,,,,company:08068464,MAPLEFIELDS ACADEMY
+1950,Ashley Hill Multi Academy Trust,multi-academy trust,,company:08163445,2177,company:08163445,ASHLEY HILL MULTI ACADEMY TRUST
+1951,Holy Family Catholic Primary School,single-academy trust,,,,company:08139885,HOLY FAMILY CATHOLIC PRIMARY SCHOOL
+1952,Kidgate Primary Academy,single-academy trust,,,,company:08151355,KIDGATE PRIMARY ACADEMY
+1953,Kesteven and Grantham Girls' School Academy Trust,single-academy trust,,,,company:08133675,KESTEVEN AND GRANTHAM GIRLS' SCHOOL ACADEMY TRUST
+1954,Nettleham Infant School,single-academy trust,,,,company:08163457,NETTLEHAM INFANT SCHOOL
+1955,"Gainsborough Parish Church CE Primary School Limited, The",single-academy trust,,,,company:08166270,THE GAINSBOROUGH PARISH CHURCH CE PRIMARY SCHOOL LTD
+1956,Evolution Academy Trust,multi-academy trust,,company:08158619,3062,company:08158619,EVOLUTION ACADEMY TRUST
+1957,Northern House School Academy Trust,multi-academy trust,,company:08140768,4038,company:08140768,NORTHERN HOUSE SCHOOL ACADEMY TRUST
+1958,Parklands High School,single-academy trust,,,,company:08151601,PARKLANDS HIGH SCHOOL
+1959,Grasvenor Avenue Infant School,multi-academy trust,,company:08164849,3218,company:08164849,GRASVENOR AVENUE INFANT SCHOOL
+1960,St Columba's Catholic Boys' School,single-academy trust,,,,company:08088957,ST COLUMBA'S CATHOLIC BOYS' SCHOOL
+1961,Orleans Park School,single-academy trust,,,,company:08165744,ORLEANS PARK SCHOOL
+1962,"Cedars Academy Trust, The",single-academy trust,,,,company:08168042,THE CEDARS ACADEMY TRUST
+1963,Wise Owl Trust,multi-academy trust,,company:08053288,5372,company:08053288,WISE OWL TRUST
+1964,"Dunham Trust, The",multi-academy trust,,company:08120128,3028,company:08120128,THE DUNHAM TRUST
+1965,Chandlers Ridge Academy,single-academy trust,,,,company:08149765,CHANDLERS RIDGE ACADEMY
+1966,Castleview School,single-academy trust,,,,company:08146452,CASTLEVIEW SCHOOL
+1967,Baxter College,single-academy trust,,,,company:08158232,BAXTER COLLEGE
+1968,Foxwood Academy,single-academy trust,,,,company:08151281,FOXWOOD ACADEMY
+1969,Eaton Bank Academy,single-academy trust,,,,company:08156927,EATON BANK ACADEMY
+1970,Whitemoor Academy (Primary and Nursery),single-academy trust,,,,company:08163448,WHITEMOOR ACADEMY (PRIMARY AND NURSERY)
+1971,Waseley Hills High School,single-academy trust,,,,company:08160225,WASELEY HILLS HIGH SCHOOL
+1972,Queen Elizabeth's Grammar School Horncastle,single-academy trust,,,,company:08175402,QUEEN ELIZABETH'S GRAMMAR SCHOOL HORNCASTLE
+1973,Thame Partnership Academy Trust,multi-academy trust,,company:08154932,4923,company:08154932,THAME PARTNERSHIP ACADEMY TRUST
+1974,"Tregolls School, An Academy",single-academy trust,,,,company:08180623,"TREGOLLS SCHOOL, AN ACADEMY"
+1975,Southfields Academy,single-academy trust,,,,company:08190187,SOUTHFIELDS ACADEMY
+1976,Thames View Infants,single-academy trust,,,,company:08163191,THAMES VIEW INFANTS
+1977,Copthall School,single-academy trust,,,,company:08161745,COPTHALL SCHOOL
+1978,Latchmere School,single-academy trust,,,,company:08135633,LATCHMERE SCHOOL
+1979,Lion Academy Trust,multi-academy trust,,company:08171341,3758,company:08171341,LION ACADEMY TRUST
+1980,Chingford Academies Trust,multi-academy trust,,company:08179498,2662,company:08179498,CHINGFORD ACADEMIES TRUST
+1981,Greenholm Primary School,single-academy trust,,,,company:08146396,GREENHOLM PRIMARY SCHOOL
+1982,Great Barr Primary School,single-academy trust,,,,company:08144490,GREAT BARR PRIMARY SCHOOL
+1983,George Dixon Academy,single-academy trust,,,,company:08173271,GEORGE DIXON ACADEMY
+1984,West Derby School,single-academy trust,,,,company:08166938,WEST DERBY SCHOOL
+1985,New Bridge Multi Academy Trust,multi-academy trust,,company:08131158,15769,company:08131158,NEW BRIDGE MULTI ACADEMY TRUST
+1986,Beis Yaakov Jewish High School Academy,single-academy trust,,,,company:08140850,BEIS YAAKOV JEWISH HIGH SCHOOL ACADEMY
+1987,Byrchall High School Academy Trust,multi-academy trust,,company:08175642,2514,company:08175642,BYRCHALL HIGH SCHOOL ACADEMY TRUST
+1988,St Oswald's Church of England Academy,multi-academy trust,,company:08176968,4777,company:08176968,ST OSWALD'S CHURCH OF ENGLAND ACADEMY
+1989,Armthorpe Shaw Wood Academy Limited,single-academy trust,,,,company:08082204,ARMTHORPE SHAW WOOD ACADEMY LIMITED
+1990,King James's School,single-academy trust,,,,company:08164889,KING JAMES'S SCHOOL
+1991,Horbury Academy Trust,single-academy trust,,,,company:08139427,HORBURY ACADEMY TRUST
+1992,Colston's Primary School,single-academy trust,,,,company:08144135,COLSTON'S PRIMARY SCHOOL
+1993,Westwoodside Church of England Academy Trust,single-academy trust,,,,company:08161921,WESTWOODSIDE CHURCH OF ENGLAND ACADEMY TRUST
+1994,Wyvern Academy,single-academy trust,,,,company:08123602,WYVERN ACADEMY
+1995,Woodham Academy,single-academy trust,,,,company:08167333,WOODHAM ACADEMY
+1996,Hook-with-Warsash Church of England Academy,single-academy trust,,,,company:08153776,HOOK-WITH-WARSASH CHURCH OF ENGLAND ACADEMY
+1997,Eggar's School,single-academy trust,,,,company:08036151,EGGAR'S SCHOOL
+1998,Ibstock Community College,single-academy trust,,,,company:08135574,IBSTOCK COMMUNITY COLLEGE
+1999,"Painsley Catholic Academy, The",multi-academy trust,,company:08146661,4127,company:08146661,THE PAINSLEY CATHOLIC ACADEMY
+2000,"Academy Trust of Melksham, The",multi-academy trust,,company:08153550,5642,company:08153550,THE ACADEMY TRUST OF MELKSHAM
+2001,Lymm High School,single-academy trust,,,,company:08171068,LYMM HIGH SCHOOL
+2002,"Joyce Frankland Academy, Newport",single-academy trust,,,,company:08135395,"JOYCE FRANKLAND ACADEMY, NEWPORT"
+2003,Kenningtons Primary Academy,single-academy trust,,,,company:08187197,KENNINGTONS PRIMARY ACADEMY
+2004,Beacon Hill Academy,single-academy trust,,,,company:08183461,BEACON HILL ACADEMY
+2005,West Malling Church of England Academy Trust,single-academy trust,,,,company:08144271,WEST MALLING CHURCH OF ENGLAND ACADEMY TRUST
+2006,Norbreck Primary Academy,single-academy trust,,,,company:08151859,NORBRECK PRIMARY ACADEMY
+2007,Old Basford School,single-academy trust,,,,company:08168813,OLD BASFORD SCHOOL
+2008,"Milford Academy, The",single-academy trust,,,,company:08163499,THE MILFORD ACADEMY
+2009,Cheshire Academies Trust Ltd,multi-academy trust,,company:08108086,5455,company:08108086,CHESHIRE ACADEMIES TRUST
+2010,"County High School, Leftwich, The",single-academy trust,,,,company:08126953,"THE COUNTY HIGH SCHOOL, LEFTWICH"
+2011,Ghyllside School,single-academy trust,,,,company:08178033,GHYLLSIDE SCHOOL
+2012,St John's Church of England Academy Coleford,single-academy trust,,,,company:08144420,ST JOHN'S CHURCH OF ENGLAND ACADEMY COLEFORD
+2013,Newent Community School and Sixth Form Centre,single-academy trust,,,,company:08153177,NEWENT COMMUNITY SCHOOL AND SIXTH FORM CENTRE
+2014,Hertswood Academy,single-academy trust,,,,company:07992852,HERTSWOOD ACADEMY
+2015,Ling Moor Primary Academy Ltd,single-academy trust,,,,company:08141618,LING MOOR PRIMARY ACADEMY LTD
+2016,"Boston Witham Academies Federation, The",multi-academy trust,,company:08158309,2376,company:08158309,THE BOSTON WITHAM ACADEMIES FEDERATION
+2017,Ellison Boulters Church Of England Academy Ltd,single-academy trust,,,,company:08169622,ELLISON BOULTERS CHURCH OF ENGLAND ACADEMY LTD
+2018,"Thomas Cowley High School Limited, The",single-academy trust,,,,company:08149761,THE THOMAS COWLEY HIGH SCHOOL LTD
+2019,Acle Academy,single-academy trust,,,,company:08169571,ACLE ACADEMY
+2020,Flegg Education Academy Trust,single-academy trust,,,,company:08142724,FLEGG EDUCATION ACADEMY TRUST
+2021,Boughton Primary School Trust,single-academy trust,,,,company:08132405,BOUGHTON PRIMARY SCHOOL TRUST
+2022,Axbridge Church of England First School Academy,single-academy trust,,,,company:08163433,AXBRIDGE CHURCH OF ENGLAND FIRST SCHOOL ACADEMY
+2023,Shipston High School,single-academy trust,,,,company:08174462,SHIPSTON HIGH SCHOOL
+2024,Oxford Diocesan Schools Trust,multi-academy trust,,company:08143249,4124,company:08143249,OXFORD DIOCESAN SCHOOLS TRUST
+2025,EBN Trust,multi-academy trust,,company:07665550,15856,company:07665550,EBN TRUST
+2026,Al-Madinah Education Trust,single-academy trust,,,,company:07970052,AL-MADINAH EDUCATION TRUST
+2027,Diocese of Bristol Academies Trust,multi-academy trust,,company:08156759,2894,company:08156759,DIOCESE OF BRISTOL ACADEMIES TRUST
+2028,Ambleside Primary School,single-academy trust,,,,company:08246275,AMBLESIDE PRIMARY SCHOOL
+2029,Ashby Hill Top Primary School Academy Trust,single-academy trust,,,,company:08197381,ASHBY HILL TOP PRIMARY SCHOOL ACADEMY TRUST
+2030,Broomfield Primary School,single-academy trust,,,,company:08168510,BROOMFIELD PRIMARY SCHOOL
+2031,Eastfield Primary School,single-academy trust,,,,company:08181149,EASTFIELD PRIMARY SCHOOL
+2032,Gaddesby Primary School,single-academy trust,,,,company:08168237,BRADGATE EDUCATION PARTNERSHIP
+2033,Huttoft Primary School (Academy),single-academy trust,,,,company:08177181,HUTTOFT PRIMARY SCHOOL (ACADEMY)
+2034,Lady Jane Grey Primary School,single-academy trust,,,,company:08197353,LADY JANE GREY PRIMARY SCHOOL
+2035,Pax Christi Catholic Academy Trust,multi-academy trust,,company:08192900,4161,company:08192900,PAX CHRISTI CATHOLIC ACADEMY TRUST
+2036,Stourfield Infant Academy Trust,multi-academy trust,,company:08201675,4853,company:08201675,STOURFIELD INFANT ACADEMY TRUST
+2037,Little Gonerby Church of England Infant School Academy Trust,single-academy trust,,,,company:08210494,LITTLE GONERBY CHURCH OF ENGLAND INFANT SCHOOL ACADEMY TRUST
+2038,"Marlborough Church of England School, The",single-academy trust,,,,company:08194349,THE MARLBOROUGH CHURCH OF ENGLAND SCHOOL
+2039,"Merton Primary School, The",single-academy trust,,,,company:08172647,THE MERTON PRIMARY SCHOOL
+2040,Belvoir and Melton Academy Trust,single-academy trust,,,,company:08165692,BELVOIR AND MELTON ACADEMY TRUST
+2041,Castle Donington College,single-academy trust,,,,company:08203218,CASTLE DONINGTON COLLEGE
+2042,King Edward VII Science and Sport College,single-academy trust,,,,company:08158225,KING EDWARD VII SCIENCE AND SPORT COLLEGE
+2043,Wootton Primary School,single-academy trust,,,,company:08199843,WOOTTON PRIMARY SCHOOL
+2044,Charters School,single-academy trust,,,,company:08208767,CHARTERS SCHOOL
+2045,"Every Child, Every Day Academy Trust",multi-academy trust,,company:08185432,16253,company:08185432,"EVERY CHILD, EVERY DAY ACADEMY TRUST"
+2046,New Seaham Academy,single-academy trust,,,,company:08221351,NEW SEAHAM ACADEMY
+2047,Our Lady Seat of Wisdom,single-academy trust + umbrella trust,yes,,,company:08180450,OUR LADY SEAT OF WISDOM
+2048,St Thomas of Canterbury Trust,single-academy trust + umbrella trust,,,,company:08181927,ST THOMAS OF CANTERBURY TRUST
+2049,Synergy Multi Academy Trust,multi-academy trust,,company:08198980,16163,company:08198980,SYNERGY MULTI ACADEMY TRUST
+2050,"St Wilfrid's Primary School, A Catholic Voluntary Academy",single-academy trust,,,,company:08182289,"ST WILFRID'S PRIMARY SCHOOL, A CATHOLIC VOLUNTARY ACADEMY"
+2051,Winterton Community Academy,single-academy trust,,,,company:08140747,WINTERTON COMMUNITY ACADEMY
+2052,"White Hills Park Federation Trust, The",multi-academy trust,,company:08195720,5314,company:08195720,THE WHITE HILLS PARK FEDERATION TRUST
+2053,Ashby School,single-academy trust,,,,company:08126868,ASHBY SCHOOL
+2054,Brentwood Ursuline Convent High School,single-academy trust,,,,company:08212425,BRENTWOOD URSULINE CONVENT HIGH SCHOOL
+2055,Bacup and Rawtenstall Grammar School,single-academy trust,,,,company:08205021,BACUP AND RAWTENSTALL GRAMMAR SCHOOL
+2056,"Bolsover School Academy Trust, The",single-academy trust,,,,company:07913309,THE BOLSOVER SCHOOL ACADEMY TRUST
+2057,"Pochin School, The",single-academy trust,,,,company:08204075,THE POCHIN SCHOOL
+2058,Sir William Robertson Academy,single-academy trust,,,,company:08208522,SIR WILLIAM ROBERTSON ACADEMY
+2059,Mercia Learning Trust,multi-academy trust,,company:08119703,3899,company:08119703,MERCIA LEARNING TRUST
+2060,Goose Green Education Trust,single-academy trust,,,,company:08149796,GOOSE GREEN EDUCATION TRUST
+2061,St. Michael's Academy,single-academy trust,,,,company:08210739,ST. MICHAEL'S ACADEMY
+2062,Holywell Church of England Academy,single-academy trust,,,,company:08224216,HOLYWELL CHURCH OF ENGLAND ACADEMY
+2063,Nunthorpe Academy Limited,single-academy trust,,,,company:08188507,NUNTHORPE ACADEMY LIMITED
+2064,Roseacre Primary Academy,single-academy trust,,,,company:08221228,ROSEACRE PRIMARY ACADEMY
+2065,"St Marie's School, A Catholic Voluntary Academy",single-academy trust + umbrella trust,,,,company:08181858,"ST MARIE'S SCHOOL, A CATHOLIC VOLUNTARY ACADEMY"
+2066,Pen Mill Infant and Nursery Academy,single-academy trust,,,,company:08210466,PEN MILL INFANT AND NURSERY ACADEMY
+2067,St Margaret's Church of England Academy,single-academy trust,,,,company:08160433,ST MARGARET'S CHURCH OF ENGLAND ACADEMY
+2068,St Paul's (Astley Bridge) Church of England Primary School,multi-academy trust,,company:08212263,5643,company:08212263,ST PAUL'S (ASTLEY BRIDGE) CHURCH OF ENGLAND PRIMARY SCHOOL
+2069,S. Peter's Collegiate Church of England Academy Trust,single-academy trust,,,,company:08172888,S. PETER'S COLLEGIATE CHURCH OF ENGLAND ACADEMY TRUST
+2070,Woodchurch High School,single-academy trust,,,,company:07775671,WOODCHURCH HIGH SCHOOL
+2071,Redland Green School,single-academy trust,,,,company:08203318,REDLAND GREEN SCHOOL
+2072,JHS Academy Trust,single-academy trust,,,,company:08196566,JHS ACADEMY TRUST
+2073,"Education Fellowship Trust, The",multi-academy trust,,company:07848783,3013,company:07848783,THE EDUCATION FELLOWSHIP TRUST
+2074,"All Saints Multi Academy Trust, Birmingham",multi-academy trust,,company:08255653,15906,company:08255653,"ALL SAINTS MULTI ACADEMY TRUST, BIRMINGHAM"
+2075,Broom Leys Primary School Academy Trust,single-academy trust,,,,company:08240680,BROOM LEYS PRIMARY SCHOOL ACADEMY TRUST
+2076,Attwood Academies,multi-academy trust,,company:09148479,2200,company:09148479,ATTWOOD ACADEMIES
+2077,Crosby on Eden Church of England Primary School,single-academy trust,,,,company:08242198,CROSBY ON EDEN CHURCH OF ENGLAND PRIMARY SCHOOL
+2078,Gosford Hill School,single-academy trust,,,,company:08237106,GOSFORD HILL SCHOOL
+2079,"Mosley Academy, The",single-academy trust,,,,company:08234858,THE MOSLEY ACADEMY
+2080,Little Mead Academy Trust,multi-academy trust,,company:08245853,3765,company:08245853,LITTLE MEAD ACADEMY TRUST
+2081,Change Schools Partnership,multi-academy trust,,company:08182064,2605,company:08182064,CHANGE SCHOOLS PARTNERSHIP
+2082,St Michael & All Angels Church of England Primary School,single-academy trust,,,,company:08233527,ST MICHAEL & ALL ANGELS CHURCH OF ENGLAND PRIMARY SCHOOL
+2083,Bottesford Church of England Primary School Trust,single-academy trust,,,,company:08259654,BOTTESFORD CHURCH OF ENGLAND PRIMARY SCHOOL TRUST
+2084,Holywell Primary School,single-academy trust,,,,company:08150822,HOLYWELL PRIMARY SCHOOL
+2085,Dunsville Primary Academy Trust,single-academy trust,,,,company:08237807,DUNSVILLE PRIMARY ACADEMY TRUST
+2086,Rendell Primary School,single-academy trust,,,,company:08219443,RENDELL PRIMARY SCHOOL
+2087,Tanworth in Arden Academy Trust,single-academy trust,,,,company:08210410,TANWORTH IN ARDEN ACADEMY TRUST
+2088,Kirk Sandall Academy Trust,multi-academy trust,,company:08248173,5596,company:08248173,KIRK SANDALL ACADEMY TRUST
+2089,Discover Learning Trust,multi-academy trust,,company:08249250,2930,company:08249250,DISCOVER LEARNING TRUST
+2090,Heston Community Academy Trust,single-academy trust,,,,company:07964015,HESTON COMMUNITY ACADEMY TRUST
+2091,Fir Vale School Academy Trust,single-academy trust,,,,company:08090074,FIR VALE SCHOOL ACADEMY TRUST
+2092,Thrussington Church of England Primary School,single-academy trust,,,,company:08248063,THRUSSINGTON CHURCH OF ENGLAND PRIMARY SCHOOL
+2093,Thames Primary Academy,single-academy trust,,,,company:08228024,THAMES PRIMARY ACADEMY
+2094,Warlingham School,single-academy trust,,,,company:08248059,WARLINGHAM SCHOOL
+2095,Church Hill Infant School,single-academy trust,,,,company:08183463,CHURCH HILL INFANT SCHOOL
+2096,Church Hill Church of England Junior School,single-academy trust,,,,company:08242856,CHURCH HILL CHURCH OF ENGLAND JUNIOR SCHOOL
+2097,Queniborough Church of England Primary School,single-academy trust,,,,company:08235194,QUENIBOROUGH CHURCH OF ENGLAND PRIMARY SCHOOL
+2098,Rickley Park Primary School,single-academy trust,,,,company:08246313,RICKLEY PARK PRIMARY SCHOOL
+2099,Birkett House School,single-academy trust,,,,company:08231964,BIRKETT HOUSE SCHOOL
+2100,Handsworth Wood Girls' Academy,single-academy trust,,,,company:08261780,HANDSWORTH WOOD GIRLS' ACADEMY
+2101,"Harlington and Sundon Academy Trust, The",multi-academy trust,,company:08231721,3313,company:08231721,THE HARLINGTON AND SUNDON ACADEMY TRUST
+2102,Christ Church C of E Primary School (Cheltenham),single-academy trust,,,,company:08248966,CHRIST CHURCH C OF E PRIMARY SCHOOL (CHELTENHAM)
+2103,"Bishop Konstant Catholic Academy Trust, The",multi-academy trust,,company:08253770,2332,company:08253770,THE BISHOP KONSTANT CATHOLIC ACADEMY TRUST
+2104,St Cuthbert's Church of England Infants School,single-academy trust,,,,company:08249992,ST CUTHBERT'S CHURCH OF ENGLAND INFANTS SCHOOL
+2105,Upminster Academies Trust,multi-academy trust,,company:08214798,5162,company:08214798,UPMINSTER ACADEMIES TRUST
+2106,Penwortham Priory Academy Trust,single-academy trust,,,,company:08133703,PENWORTHAM PRIORY ACADEMY TRUST
+2107,Northampton Primary Academy Trust,multi-academy trust,,company:08172039,4031,company:08172039,NORTHAMPTON PRIMARY ACADEMY TRUST
+2108,Weston Favell Church of England Primary School,single-academy trust,,,,company:08208801,WESTON FAVELL CHURCH OF ENGLAND PRIMARY SCHOOL
+2109,SS Simon and Jude Church of England Academy Trust,multi-academy trust,,company:08240918,4616,company:08240918,SS SIMON AND JUDE CHURCH OF ENGLAND MULTI ACADEMY TRUST
+2110,Thornhill Community Academy Trust,single-academy trust,,,,company:08073959,THORNHILL COMMUNITY ACADEMY TRUST
+2111,Sacred Heart Catholic School,single-academy trust,,,,company:08160195,SACRED HEART CATHOLIC SCHOOL
+2112,St. Michael's Catholic College,single-academy trust,,,,company:08160034,ST. MICHAEL'S CATHOLIC COLLEGE
+2113,Barwell Church of England Academy,single-academy trust,,,,company:08247528,BARWELL CHURCH OF ENGLAND ACADEMY
+2114,Shooters Hill Campus,single-academy trust,,,,company:08270802,SHOOTERS HILL CAMPUS
+2115,"Complementary Education Academy Limited, The",multi-academy trust,,company:08190591,2762,company:08190591,THE COMPLEMENTARY EDUCATION ACADEMY LIMITED
+2116,St James Church of England Academy Trust Company,multi-academy trust,,company:08022455,4700,company:08022455,ST JAMES CHURCH OF ENGLAND ACADEMY TRUST COMPANY
+2117,Cambridge Primary Education Trust,multi-academy trust,,company:08304433,2528,company:08304433,CAMBRIDGE PRIMARY EDUCATION TRUST
+2118,Education Central Multi Academy Trust,multi-academy trust,,company:08255492,3012,company:08255492,EDUCATION CENTRAL MULTI ACADEMY TRUST
+2119,Fulwell Infant School Academy,single-academy trust,,,,company:08277622,FULWELL INFANT SCHOOL ACADEMY
+2120,Ludlow Junior School,single-academy trust,,,,company:08291623,LUDLOW JUNIOR SCHOOL
+2121,Redcar Academy - A Community School for For the Performing and Visual Arts,single-academy trust,,,,company:08281046,REDCAR ACADEMY - A COMMUNITY SCHOOL FOR THE PERFORMING AND VISUAL ARTS
+2122,Ridgeway Academy Trust,single-academy trust,,,,company:08284164,RIDGEWAY ACADEMY TRUST
+2123,Southfield Primary School,single-academy trust,,,,company:08252316,SOUTHFIELD PRIMARY SCHOOL
+2124,Holy Family Catholic Multi Academy Trust,multi-academy trust,,company:08269066,3458,company:08269066,HOLY FAMILY CATHOLIC MULTI ACADEMY TRUST
+2125,St Nicholas of Tolentine Catholic Primary School,single-academy trust,,,,company:08278118,ST NICHOLAS OF TOLENTINE CATHOLIC PRIMARY SCHOOL
+2126,St Teresa's Catholic Primary School Bristol,single-academy trust,,,,company:08260020,ST TERESA'S CATHOLIC PRIMARY SCHOOL BRISTOL
+2127,Mountfields Lodge School,single-academy trust,,,,company:08240864,MOUNTFIELDS LODGE SCHOOL
+2128,Crowle Primary Academy,single-academy trust,,,,company:08284371,CROWLE PRIMARY ACADEMY
+2129,Kings Langley School,single-academy trust,,,,company:08271760,KINGS LANGLEY SCHOOL
+2130,Outwoods Edge Primary School,single-academy trust,,,,company:08188239,OUTWOODS EDGE PRIMARY SCHOOL
+2131,Preston Hedges Primary School,single-academy trust,,,,company:08282041,PRESTON HEDGES ACADEMY TRUST
+2132,"St John's Church of England Primary School, Rishworth",single-academy trust + umbrella trust,,,,company:08296540,"ST JOHN'S CHURCH OF ENGLAND PRIMARY SCHOOL, RISHWORTH"
+2133,"St Mary's C of E Primary and Nursery Academy, Handsworth",single-academy trust,,,,company:08296506,"ST MARY'S C OF E PRIMARY AND NURSERY ACADEMY, HANDSWORTH"
+2134,Woodside Academy Trust,single-academy trust,,,,company:08286418,WOODSIDE ACADEMY TRUST
+2135,Derby College Education Trust,multi-academy trust,,company:08072758,2878,company:08072758,DERBY COLLEGE EDUCATION TRUST
+2136,Temple Grove Academy Trust,single-academy trust,,,,company:08309965,TEMPLE GROVE ACADEMY TRUST
+2137,Pendle Education Trust,multi-academy trust,,company:08263591,4174,company:08263591,PENDLE EDUCATION TRUST
+2138,NET Academies Trust,multi-academy trust,,company:08221088,3965,company:08221088,NET ACADEMIES TRUST
+2139,"Propeller Academy Trust, The",multi-academy trust,,company:08340120,4257,company:08340120,THE PROPELLER ACADEMY TRUST
+2140,Pioneer Academies Co-operative Trust (PACT),multi-academy trust,,company:08255683,4208,company:08255683,PIONEER ACADEMIES CO-OPERATIVE TRUST (PACT)
+2141,Askel Veur (Diocese of Truro Academies Umbrella Trust),multi-academy trust + umbrella trust,yes,,,company:07817737,ASKEL VEUR THE DIOCESE OF TRURO ACADEMIES UMBRELLA COMPANY LIMITED
+2142,"Saints' Way Church of England Multi Academy Trust, The",multi-academy trust + umbrella trust,,company:08269215,4443,company:08269215,THE SAINTS' WAY CHURCH OF ENGLAND MULTI ACADEMY TRUST
+2143,Brentford School for Girls,single-academy trust,,,,company:08286030,BRENTFORD SCHOOL FOR GIRLS
+2144,Orchard Academy Trust,multi-academy trust,,company:08249884,16157,company:08249884,ORCHARD ACADEMY TRUST
+2145,Measham Church of England Primary School Academy Trust,single-academy trust,,,,company:08270314,MEASHAM CHURCH OF ENGLAND PRIMARY SCHOOL ACADEMY TRUST
+2146,St Peter's Church of England Primary Academy,single-academy trust,,,,company:08295240,ST PETER'S CHURCH OF ENGLAND PRIMARY ACADEMY
+2147,RIGHTFORSUCCESS TRUST,multi-academy trust,,company:08282834,4362,company:08282834,RIGHTFORSUCCESS TRUST
+2148,Bradfield School,single-academy trust,,,,company:08265058,BRADFIELD SCHOOL
+2149,Lakelands Educational Trust,single-academy trust,,,,company:08273802,LAKELANDS EDUCATIONAL TRUST
+2150,Inspire Multi Academy Trust,multi-academy trust,,company:08287012,3534,company:08287012,INSPIRE MULTI ACADEMY TRUST
+2151,Dilkes Academy,single-academy trust,,,,company:08249779,DILKES ACADEMY
+2152,Belmont Castle Academy,single-academy trust,,,,company:08239056,BELMONT CASTLE ACADEMY
+2153,Woodside Academy,single-academy trust,,,,company:08272256,WOODSIDE ACADEMY
+2154,Knottingley St Botolph's C Of E Academy Trust,single-academy trust + umbrella trust,,,,company:08291492,KNOTTINGLEY ST BOTOLPH'S C OF E ACADEMY TRUST
+2155,Worthing High School,single-academy trust,,,,company:08276210,WORTHING HIGH SCHOOL
+2156,Kilton Thorpe Specialist Academy,single-academy trust,,,,company:08299166,KILTON THORPE SPECIALIST ACADEMY
+2157,Lighthouse Harmonize Education Trust,single-academy trust,,,,company:07657235,LIGHTHOUSE HARMONIZE EDUCATION TRUST
+2158,South Tyneside Academy Trust Sponsored By South Tyneside College,multi-academy trust,,company:08313162,4586,company:08313162,SOUTH TYNESIDE ACADEMY TRUST SPONSORED BY SOUTH TYNESIDE COLLEGE
+2159,"St George's Church of England Academy, Newtown",single-academy trust,,,,company:08328369,"ST GEORGE'S CHURCH OF ENGLAND ACADEMY, NEWTOWN"
+2160,"Nethersole Church of England Primary School, The",single-academy trust,,,,company:08309048,THE NETHERSOLE CHURCH OF ENGLAND ACADEMY
+2161,Steel City Schools Partnership,multi-academy trust,,company:08356745,4828,company:08356745,STEEL CITY SCHOOLS PARTNERSHIP
+2162,Aldersley Academies Trust,multi-academy trust,,company:08310900,2095,company:08310900,ALDERSLEY ACADEMIES TRUST
+2163,"Holy Family of Nazareth Catholic Academy Trust, The",multi-academy trust,,company:08307881,3460,company:08307881,THE HOLY FAMILY OF NAZARETH CATHOLIC ACADEMY TRUST
+2164,Boston High School,single-academy trust,,,,company:08314283,BOSTON HIGH SCHOOL
+2165,Bracebridge Infant And Nursery School Ltd,single-academy trust,,,,company:08305764,BRACEBRIDGE INFANT AND NURSERY SCHOOL LTD
+2166,Bridgnorth Endowed School,single-academy trust,,,,company:08296889,BRIDGNORTH ENDOWED SCHOOL
+2167,Calday Grange Grammar School,single-academy trust,,,,company:08332696,CALDAY GRANGE GRAMMAR SCHOOL
+2168,Cheney School Academy Trust,multi-academy trust,,company:08319810,2639,company:08319810,CHENEY SCHOOL ACADEMY TRUST
+2169,Chickerell Primary Academy,single-academy trust,,,,company:08311200,CHICKERELL PRIMARY ACADEMY
+2170,CHS Learning Trust,multi-academy trust,,company:08321679,5644,company:08321679,CHS LEARNING TRUST
+2171,Elveden Church of England Primary Academy,single-academy trust,,,,company:08327233,ELVEDEN CHURCH OF ENGLAND PRIMARY ACADEMY
+2172,Forest View Primary School,single-academy trust,,,,company:08322915,FOREST VIEW PRIMARY SCHOOL
+2173,Gordon's School Academy Trust,single-academy trust,,,,company:07723861,GORDON'S SCHOOL ACADEMY TRUST
+2174,Great Sankey High School,single-academy trust,,,,company:08313108,GREAT SANKEY HIGH SCHOOL
+2175,Hedingham School and Sixth Form,single-academy trust,,,,company:08330173,HEDINGHAM SCHOOL AND SIXTH FORM
+2176,Hitchin Boys' School,single-academy trust,,,,company:08286295,HITCHIN BOYS' SCHOOL
+2177,Launceston College,multi-academy trust,,company:08150106,16055,company:08150106,LAUNCESTON COLLEGE
+2178,Magdalen College School Brackley Academy Trust,single-academy trust,,,,company:08316633,MAGDALEN COLLEGE SCHOOL BRACKLEY ACADEMY TRUST
+2179,Spiral Academies Trust,multi-academy trust,,company:08322127,4610,company:08322127,SPIRAL ACADEMIES TRUST
+2180,Mark Rutherford School Trust,single-academy trust,,,,company:08316719,MARK RUTHERFORD SCHOOL TRUST
+2181,Marston Vale Academy Trust,single-academy trust,,,,company:08326476,MARSTON VALE ACADEMY TRUST
+2182,Parkfield Academy Trust,single-academy trust,,,,company:08314293,EXCELSIOR MULTI ACADEMY TRUST
+2183,Rowde C of E Primary Academy Trust,single-academy trust,,,,company:08310027,ROWDE C OF E PRIMARY ACADEMY TRUST
+2184,Seer Green Church of England School,single-academy trust,,,,company:08318511,SEER GREEN CHURCH OF ENGLAND SCHOOL
+2185,Severnbanks Primary School,single-academy trust,,,,company:08322813,SEVERNBANKS PRIMARY SCHOOL
+2186,Shaw Primary Academy,single-academy trust,,,,company:08333159,SHAW PRIMARY ACADEMY
+2187,Silverdale School,single-academy trust,,,,company:08289609,SILVERDALE MULTI ACADEMY TRUST
+2188,LDBS Academies Trust,multi-academy trust,,company:08182235,3703,company:08182235,LDBS ACADEMIES TRUST
+2189,St David's Church of England Primary Academy,single-academy trust,,,,company:08322707,ST DAVID'S CHURCH OF ENGLAND PRIMARY ACADEMY
+2190,"St Edward's Church of England Academy Trust, Leek",single-academy trust,,,,company:08316327,"ST EDWARD'S CHURCH OF ENGLAND ACADEMY TRUST, LEEK"
+2191,"St John's Church Of England Primary School,Sparkhill",single-academy trust,,,,company:08270275,"ST JOHN'S CHURCH OF ENGLAND PRIMARY SCHOOL,SPARKHILL"
+2192,Barchelai Academy Trust,multi-academy trust,,company:08326570,15972,company:08326570,BARCHELAI ACADEMY TRUST
+2193,St Gilbert's Church of England Primary School,single-academy trust,,,,company:08321824,ST GILBERT'S CHURCH OF ENGLAND PRIMARY SCHOOL
+2194,Boston Grammar School,single-academy trust,,,,company:08314056,BOSTON GRAMMAR SCHOOL
+2195,"Bromfords School and Sixth Form College, The",single-academy trust,,,,company:08326579,THE BROMFORDS SCHOOL AND SIXTH FORM COLLEGE
+2196,"Crossley Heath School Academy Trust Limited, The",single-academy trust,,,,company:08225755,THE CROSSLEY HEATH SCHOOL ACADEMY TRUST LIMITED
+2197,Dayspring Trust,multi-academy trust,,company:08310825,2858,company:08310825,DAYSPRING TRUST
+2198,Walkwood Academy Trust,single-academy trust,,,,company:08319098,WALKWOOD ACADEMY TRUST
+2199,Warden House Trust,multi-academy trust,,company:09692191,15750,company:09692191,WARDEN HOUSE TRUST
+2200,Welton St Mary's Church of England Primary Academy,single-academy trust,,,,company:08314146,WELTON ST MARY'S CHURCH OF ENGLAND PRIMARY ACADEMY
+2201,Whitecross Hereford,single-academy trust,,,,company:07793019,WHITECROSS HEREFORD
+2202,"Phoenix Family of Schools Academy Trust, The",multi-academy trust,,company:08324412,4197,company:08324412,THE PHOENIX FAMILY OF SCHOOLS ACADEMY TRUST
+2203,Guildford County School,single-academy trust,,,,company:08303773,GUILDFORD COUNTY SCHOOL
+2204,Diocese Of Leicester Academies Trust,multi-academy trust,,company:08138372,3722,company:08138372,DIOCESE OF LEICESTER ACADEMIES TRUST
+2205,Warrington Collegiate Education Trust,multi-academy trust,,company:08298534,5222,company:08298534,WARRINGTON COLLEGIATE EDUCATION TRUST
+2206,Links Academy Trust,single-academy trust,,,,company:08231006,LINKS ACADEMY TRUST
+2207,"Bath and Wells Diocesan Academies Trust, The",multi-academy trust,,company:08207095,2250,company:08207095,THE BATH AND WELLS DIOCESAN ACADEMIES TRUST
+2208,Transform Trust,multi-academy trust,,company:08671076,5098,company:08671076,TT2014 LIMITED
+2209,Transform Trust,multi-academy trust,,company:08320065,5456,company:08320065,TRANSFORM TRUST
+2210,Whipperley Infant Academy Trust,single-academy trust,,,,company:08310694,WHIPPERLEY INFANT ACADEMY TRUST
+2211,Shrewsbury Academies Trust,multi-academy trust,,company:08407961,4518,company:08407961,SHREWSBURY ACADEMIES TRUST
+2212,"JCB Academy Trust, The",single-academy trust,,,,company:06346630,THE JCB ACADEMY TRUST
+2213,"St Mary's Church of England Primary Academy, Dilwyn",single-academy trust,,,,company:07745424,"ST MARY'S CHURCH OF ENGLAND PRIMARY ACADEMY, DILWYN"
+2213,New Hall Multi Academy Trust,multi-academy trust,,company:08643881,3980,company:08643881,NEW HALL MULTI ACADEMY TRUST
+2214,"Christ Church Church Of England Junior School, Ramsgate",single-academy trust,,,,company:08574692,"CHRIST CHURCH CHURCH OF ENGLAND JUNIOR SCHOOL, RAMSGATE"
+2215,Blackbird Academy Trust,multi-academy trust,,company:08544741,2348,company:08544741,BLACKBIRD ACADEMY TRUST
+2216,Children of Success Schools Trust,multi-academy trust,,company:08438964,2657,company:08438964,CHILDREN OF SUCCESS SCHOOLS TRUST
+2217,Rosewood School Limited,single-academy trust,,,,company:07667999,ROSEWOOD SCHOOL LIMITED
+2218,St George's Church of England Primary School,single-academy trust,,,,company:08509022,ST GEORGE'S CHURCH OF ENGLAND PRIMARY SCHOOL
+2219,UTC Reading Trust,single-academy trust,,,,company:07652565,UTC READING TRUST
+2220,Hawkesley Church Primary Academy,single-academy trust,,,,company:08528914,HAWKESLEY CHURCH PRIMARY ACADEMY
+2221,LDBS Frays Academy Trust,multi-academy trust,,company:08335073,3705,company:08335073,LDBS FRAYS ACADEMY TRUST
+2222,Ratby Primary School,single-academy trust,,,,company:08293293,RATBY PRIMARY SCHOOL
+2223,St John's Church of England Middle School Academy,single-academy trust,,,,company:08355037,ST JOHN'S CHURCH OF ENGLAND MIDDLE SCHOOL ACADEMY
+2224,Stonebow Primary School,single-academy trust,,,,company:08353034,STONEBOW PRIMARY SCHOOL
+2225,Widewell Primary Academy,single-academy trust,,,,company:08330578,WIDEWELL PRIMARY ACADEMY
+2226,Academy @ Worden,single-academy trust,,,,company:08360915,ACADEMY @ WORDEN
+2227,Bourton-on-the-Water Primary Academy,single-academy trust,,,,company:08321599,BOURTON-ON-THE-WATER PRIMARY ACADEMY
+2228,Castle Phoenix Trust,multi-academy trust,,company:08331385,2565,company:08331385,CASTLE PHOENIX TRUST
+2229,Connaught School for Girls,single-academy trust,,,,company:08354009,CONNAUGHT SCHOOL FOR GIRLS
+2230,Infinity Academies Trust Ltd,multi-academy trust,,company:08358124,3539,company:08358124,INFINITY ACADEMIES TRUST LTD
+2231,Hooe Primary Academy Trust,single-academy trust,,,,company:08319686,HOOE PRIMARY ACADEMY TRUST
+2232,Community First Academy Trust,multi-academy trust,,company:08359889,2757,company:08359889,COMMUNITY FIRST ACADEMY TRUST
+2233,Sir Thomas Wharton Community College Co-operative Academy Trust,single-academy trust,,,,company:08261114,SIR THOMAS WHARTON COMMUNITY COLLEGE CO-OPERATIVE ACADEMY TRUST
+2234,Wansdyke School (2013) Ltd,single-academy trust,,,,company:08368979,WANSDYKE SCHOOL (2013) LTD
+2235,Spalding Grammar School,single-academy trust,,,,company:08357352,SPALDING GRAMMAR SCHOOL
+2236,Canon Pyon CE Academy,single-academy trust,,,,company:08337745,CANON PYON CE ACADEMY
+2237,"Christ Church Church of England Primary Academy, Folkestone",single-academy trust,,,,company:08347877,"CHRIST CHURCH CHURCH OF ENGLAND PRIMARY ACADEMY, FOLKESTONE"
+2238,Folkestone St Mary's Church of England Primary Academy,single-academy trust,,,,company:08352159,FOLKESTONE ST MARY'S CHURCH OF ENGLAND PRIMARY ACADEMY
+2239,Hobart High School (Academy Trust) Limited,single-academy trust,,,,company:08347874,HOBART HIGH SCHOOL (ACADEMY TRUST) LIMITED
+2240,"Iffley Academy Trust Company, The",multi-academy trust,,company:08334718,3540,company:08334718,THE IFFLEY ACADEMY TRUST COMPANY
+2241,Llangrove C E Academy,single-academy trust,,,,company:08333208,LLANGROVE C E ACADEMY
+2242,Monkton Infants School,single-academy trust,,,,company:08354212,MONKTON INFANTS SCHOOL
+2243,St Eanswythe's Church of England Primary School,single-academy trust,,,,company:08351355,ST EANSWYTHE'S CHURCH OF ENGLAND PRIMARY SCHOOL
+2244,"Phoenix Academy Trust, The",single-academy trust,,,,company:08357097,THE PHOENIX ACADEMY TRUST
+2245,Conyers School,single-academy trust,,,,company:08366005,CONYERS SCHOOL
+2246,Preston Manor Academy Trust,single-academy trust,,,,company:08359584,PRESTON MANOR ACADEMY TRUST
+2247,Greys Education Centre,multi-academy trust,,company:08156641,16258,company:08156641,GREYS EDUCATION CENTRE
+2248,Tall Oaks Academy Trust Ltd,multi-academy trust,,company:08395421,4895,company:08395421,TALL OAKS ACADEMY TRUST LTD
+2249,Asfordby Hill Primary School,single-academy trust,,,,company:08385139,ASFORDBY HILL PRIMARY SCHOOL
+2250,Swallowdale Primary School,single-academy trust,,,,company:08383047,SWALLOWDALE PRIMARY SCHOOL
+2251,Great Dalby Primary School,single-academy trust,,,,company:08391101,GREAT DALBY PRIMARY SCHOOL
+2252,"Chester Catholic Academies Partnership, The",multi-academy trust,,company:08375925,2646,company:08375925,THE CHESTER CATHOLIC ACADEMIES PARTNERSHIP
+2253,Red Hill Field Primary School,single-academy trust,,,,company:08384805,RED HILL FIELD PRIMARY SCHOOL
+2254,Castle School Education Trust,multi-academy trust,,company:08397975,2567,company:08397975,CASTLE SCHOOL EDUCATION TRUST
+2255,"St Joseph's Primary School, A Catholic Voluntary Academy",single-academy trust + umbrella trust,,,,company:08379788,"ST JOSEPH'S PRIMARY SCHOOL, A CATHOLIC VOLUNTARY ACADEMY"
+2256,St Patrick's Catholic Academy Trust,single-academy trust + umbrella trust,,,,company:08379733,ST PATRICK'S CATHOLIC ACADEMY TRUST
+2257,"Bishop Wheeler Catholic Academy Trust, The",multi-academy trust,,company:08399801,2342,company:08399801,THE BISHOP WHEELER CATHOLIC ACADEMY TRUST
+2258,Focus Academy Trust (UK) Ltd,multi-academy trust,,company:08071176,3112,company:08071176,FOCUS ACADEMY TRUST (UK) LTD
+2259,Kelvedon Academy Trust,single-academy trust,,,,company:08403703,KELVEDON ACADEMY TRUST
+2260,"Cardinal Hume Academies Trust, The",multi-academy trust,,company:08148675,2543,company:08148675,THE CARDINAL HUME ACADEMIES TRUST
+2261,Haringey Sixth Form Education,single-academy trust,,,,company:08399769,HARINGEY SIXTH FORM EDUCATION
+2262,"Fulham College Academy Trust, The",multi-academy trust,,company:08398143,3142,company:08398143,THE FULHAM COLLEGE ACADEMY TRUST
+2263,Cobden Primary School,single-academy trust,,,,company:08387242,COBDEN PRIMARY SCHOOL
+2264,Beaconsfield School,single-academy trust,,,,company:08257392,BEACONSFIELD SCHOOL
+2265,Innovation Enterprise Academy,multi-academy trust,,company:08278808,3528,company:08278808,INNOVATION ENTERPRISE ACADEMY
+2266,"Fulbridge Academy, The",single-academy trust,,,,company:08303681,THE FULBRIDGE ACADEMY
+2267,Toddington St George Church of England Academy,single-academy trust,,,,company:08285812,TODDINGTON ST GEORGE CHURCH OF ENGLAND ACADEMY
+2268,"University Technical College for New Technologies at Daventry, The",single-academy trust,,,,company:07637061,THE UNIVERSITY TECHNICAL COLLEGE FOR NEW TECHNOLOGIES AT DAVENTRY
+2269,Grange Academy,single-academy trust,,,,company:08397744,GRANGE ACADEMY
+2270,Education Swanage Limited,single-academy trust,,,,company:07613612,EDUCATION SWANAGE LIMITED
+2271,North West Academies (St. Martin's) Limited,single-academy trust,,,,company:08203228,NORTH WEST ACADEMIES (ST. MARTIN'S) LIMITED
+2272,Catalyst Academies Trust,multi-academy trust,,company:08407989,2575,company:08407989,CATALYST ACADEMIES TRUST
+2273,"Diocese of Coventry Multi-academy Trust, The",multi-academy trust,,company:08422015,2901,company:08422015,THE DIOCESE OF COVENTRY MULTI-ACADEMY TRUST
+2274,Plymouth CAST,multi-academy trust,,company:08438686,4214,company:08438686,PLYMOUTH CAST
+2275,"Boulevard Academy Trust, The",single-academy trust,,,,company:08174233,THE BOULEVARD ACADEMY TRUST
+2276,East Anglia Schools Trust,multi-academy trust,,company:08432486,2722,company:08432486,EAST ANGLIA SCHOOLS TRUST
+2277,"Academy of Central Bedfordshire, The",single-academy trust,,,,company:07948348,THE ACADEMY OF CENTRAL BEDFORDSHIRE
+2278,Education Partnership Trust,multi-academy trust,,company:07950891,3016,company:07950891,EDUCATION PARTNERSHIP TRUST
+2279,"Elstree UTC, The",single-academy trust,,,,company:07906423,THE ELSTREE UTC
+2280,St Mary Magdalene Academy: the Courtyard,single-academy trust,,,,company:08619729,ST MARY MAGDALENE ACADEMY: THE COURTYARD
+2281,Hampton St Mary Academy Trust,single-academy trust,,,,company:07956455,HAMPTON ST MARY ACADEMY TRUST
+2282,Plymouth UTC Limited,single-academy trust,,,,company:07645326,PLYMOUTH UTC LIMITED
+2283,The Maltings Learning Trust Limited,single-academy trust,,,,company:08353051,THE MALTINGS LEARNING TRUST LIMITED
+2284,Buckinghamshire UTC.,single-academy trust,,,,company:07648803,BUCKINGHAMSHIRE UTC.
+2285,St Chad's Academies Trust,multi-academy trust,,company:08526973,4652,company:08526973,ST CHAD'S ACADEMIES TRUST
+2286,"Diocese of Canterbury Academies Trust, The",multi-academy trust,,company:09035788,2897,company:09035788,THE DIOCESE OF CANTERBURY ACADEMIES TRUST
+2287,Mercenfeld Primary School,single-academy trust,,,,company:08423518,MERCENFELD PRIMARY SCHOOL
+2288,South Charnwood High School,single-academy trust,,,,company:08423539,SOUTH CHARNWOOD HIGH SCHOOL
+2289,Acocks Green Primary School,single-academy trust,,,,company:08424090,ACOCKS GREEN PRIMARY SCHOOL
+2290,Advance Trust,multi-academy trust,,company:08414933,2079,company:08414933,ADVANCE TRUST
+2291,Webster Primary School,single-academy trust,,,,company:08403949,WEBSTER PRIMARY SCHOOL
+2292,Brill Church of England School,single-academy trust,,,,company:08436371,BRILL CHURCH OF ENGLAND SCHOOL
+2293,Queen's Park Infant Academy,single-academy trust,,,,company:08434359,QUEEN'S PARK INFANT ACADEMY
+2294,St Louis Catholic Academy,single-academy trust,,,,company:08444133,ST LOUIS CATHOLIC ACADEMY
+2295,Telford Co-operative Multi Academy Trust,multi-academy trust,,company:08447216,4916,company:08447216,TELFORD CO-OPERATIVE MULTI ACADEMY TRUST
+2296,Pokesdown Community Primary School,multi-academy trust,,company:08425359,4219,company:08425359,POKESDOWN COMMUNITY PRIMARY SCHOOL
+2297,Northwood Primary School Academy Trust,single-academy trust,,,,company:08405075,NORTHWOOD PRIMARY SCHOOL ACADEMY TRUST
+2298,South Shropshire Academy Trust,multi-academy trust,,company:08439425,4584,company:08439425,SOUTH SHROPSHIRE ACADEMY TRUST
+2299,"Wythenshawe Catholic Academy Trust, The",multi-academy trust,,company:08440868,5426,company:08440868,THE WYTHENSHAWE CATHOLIC ACADEMY TRUST
+2300,Knowle Church of England Primary Academy,single-academy trust,,,,company:08437300,KNOWLE CHURCH OF ENGLAND PRIMARY ACADEMY
+2301,Worth Primary School,single-academy trust,,,,company:08407889,WORTH PRIMARY SCHOOL
+2302,St Mary's Church of England VA Primary Academy,single-academy trust,,,,company:08441554,ST MARY'S CHURCH OF ENGLAND VA PRIMARY ACADEMY
+2303,Freeman's Endowed Church Of England Junior Academy,single-academy trust,,,,company:08441736,FREEMAN'S ENDOWED CHURCH OF ENGLAND JUNIOR ACADEMY
+2304,Highwoods Community Primary School,single-academy trust,,,,company:08446789,HIGHWOODS COMMUNITY PRIMARY SCHOOL
+2305,St Mary's Church of England Primary Academy,single-academy trust,,,,company:08441458,ST MARY'S CHURCH OF ENGLAND PRIMARY ACADEMY
+2306,Oak Wood Schools Academy,multi-academy trust,,company:08425914,4065,company:08425914,OAK WOOD SCHOOLS ACADEMY
+2307,Manor Leas Junior Academy,single-academy trust,,,,company:08432565,MANOR LEAS JUNIOR ACADEMY
+2308,Birdwell School,single-academy trust,,,,company:08425918,BIRDWELL SCHOOL
+2309,Old Clee Primary Academy,single-academy trust,,,,company:08391057,OLD CLEE PRIMARY ACADEMY
+2310,Raynsford Church of England Academy,single-academy trust,,,,company:08287618,RAYNSFORD CHURCH OF ENGLAND ACADEMY
+2311,One In A Million Free School,single-academy trust,,,,company:08008193,ONE IN A MILLION FREE SCHOOL
+2312,"Dominic Barberi Multi Academy Company, The",multi-academy trust,,company:08453966,2943,company:08453966,THE DOMINIC BARBERI MULTI ACADEMY COMPANY
+2313,Broadmere and New Monument Multi Academy Trust,multi-academy trust,,company:08407871,2455,company:08407871,BROADMERE AND NEW MONUMENT MULTI ACADEMY TRUST
+2314,Leighfield Academy,single-academy trust,,,,company:08432347,LEIGHFIELD ACADEMY
+2315,"Woodlands Academy Scarborough, The",single-academy trust,,,,company:08436037,THE WOODLANDS ACADEMY SCARBOROUGH
+2316,Ashwell Academy,single-academy trust,,,,company:08418435,ASHWELL ACADEMY
+2317,Kedington Primary Academy,single-academy trust,,,,company:08432234,KEDINGTON PRIMARY ACADEMY
+2318,Farnham Heath End School,single-academy trust,,,,company:08364273,FARNHAM HEATH END SCHOOL
+2319,Taverham High School,single-academy trust,,,,company:08204680,TAVERHAM HIGH SCHOOL
+2320,Brentside Primary Academy,single-academy trust,,,,company:08441848,BRENTSIDE PRIMARY ACADEMY
+2321,"Heart Education Trust, The",multi-academy trust,,company:08286818,15730,company:08286818,THE HEART EDUCATION TRUST
+2322,"Academy of Woodlands, The",multi-academy trust,,company:08444770,2060,company:08444770,THE ACADEMY OF WOODLANDS
+2323,Pelham Academy Trust,multi-academy trust,,company:08439184,5645,company:08439184,PELHAM ACADEMY TRUST
+2324,Moorside Community Primary Academy School,single-academy trust,,,,company:08447546,MOORSIDE COMMUNITY PRIMARY ACADEMY SCHOOL
+2325,King's Group Academies,multi-academy trust,,company:09017776,16043,company:09017776,KING'S GROUP ACADEMIES
+2326,"King David Primary School, The",single-academy trust,,,,company:08424154,THE KING DAVID PRIMARY SCHOOL
+2327,"Delta Education Trust, The",multi-academy trust,,company:08382383,2870,company:08382383,THE DELTA EDUCATION TRUST
+2328,Pontefract Academies Trust,multi-academy trust,,company:08445158,4223,company:08445158,PONTEFRACT ACADEMIES TRUST
+2329,Stoke Bishop Church of England Primary School,single-academy trust,,,,company:08422944,STOKE BISHOP CHURCH OF ENGLAND PRIMARY SCHOOL
+2330,Penketh Academy Trust,single-academy trust,,,,company:08438991,PENKETH ACADEMY TRUST
+2331,Christ Church Chorleywood C of E School,single-academy trust,,,,company:08240619,CHRIST CHURCH CHORLEYWOOD C OF E SCHOOL
+2332,Biggin Hill Primary Academy,single-academy trust,,,,company:08411590,BIGGIN HILL PRIMARY ACADEMY
+2333,TBAP Trust,multi-academy trust,,company:08425513,4908,company:08425513,TBAP TRUST
+2334,Sharnbrook John Gibbard Lower School,single-academy trust,,,,company:08370592,SHARNBROOK JOHN GIBBARD LOWER SCHOOL
+2335,North Carr Collaborative Academy Trust,multi-academy trust,,company:08395383,4014,company:08395383,NORTH CARR COLLABORATIVE ACADEMY TRUST
+2336,Hull Collaborative Academy Trust,multi-academy trust,,company:08542806,3502,company:08542806,HULL COLLABORATIVE ACADEMY TRUST
+2337,Wensley Fold Church of England Academy Trust,single-academy trust,,,,company:08353730,WENSLEY FOLD CHURCH OF ENGLAND ACADEMY TRUST
+2338,St Francis of Assisi Academies Trust,multi-academy trust,,company:08462151,4680,company:08462151,ST FRANCIS OF ASSISI ACADEMIES TRUST
+2339,St Nicholas' CofE School Alcester,single-academy trust,,,,company:08248830,ST NICHOLAS' COFE SCHOOL ALCESTER
+2340,Putnoe Primary School,single-academy trust,,,,company:08434113,PUTNOE PRIMARY SCHOOL
+2341,Glyne Gap School,single-academy trust,,,,company:08410002,GLYNE GAP SCHOOL
+2342,"Hills Academy, The",single-academy trust,,,,company:08434199,THE HILLS ACADEMY
+2343,Goldington Green Academy,single-academy trust,,,,company:08434141,GOLDINGTON GREEN ACADEMY
+2344,Blockley Educational Academy,single-academy trust,,,,company:08434233,BLOCKLEY EDUCATIONAL ACADEMY
+2345,James Brindley School,single-academy trust,,,,company:07844694,JAMES BRINDLEY SCHOOL
+2346,"Sweyne Park School, The",single-academy trust,,,,company:08401607,THE SWEYNE PARK SCHOOL
+2347,All Saints Inter-church Academy,single-academy trust,,,,company:08454781,ALL SAINTS INTER-CHURCH ACADEMY
+2348,St Aidan's Education Trust,multi-academy trust,,company:08442124,4620,company:08442124,ST AIDAN'S EDUCATION TRUST
+2349,Stapeley Broad Lane C E Primary School,single-academy trust,,,,company:08445776,STAPELEY BROAD LANE C E PRIMARY SCHOOL
+2350,Combe Pafford School,single-academy trust,,,,company:08426682,COMBE PAFFORD SCHOOL
+2351,Wrotham School,multi-academy trust,,company:07662701,5418,company:07662701,WROTHAM SCHOOL
+2352,"Rayleigh Primary School Academy Trust, The",single-academy trust,,,,company:08445314,THE RAYLEIGH PRIMARY SCHOOL ACADEMY TRUST
+2353,Flamstead End School,single-academy trust,,,,company:08436788,FLAMSTEAD END SCHOOL
+2354,Stamp Education Trust,multi-academy trust,,company:07916297,4815,company:07916297,STAMP EDUCATION TRUST
+2355,St Christopher's C of E (Secondary) Multi Academy Trust,multi-academy trust,,company:08486531,4657,company:08486531,ST CHRISTOPHER'S C OF E (SECONDARY) MULTI ACADEMY TRUST
+2356,Trinity School Sevenoaks Ltd,single-academy trust,,,,company:07949294,TRINITY SCHOOL SEVENOAKS LTD
+2357,New Generation Schools Trust,single-academy trust,,,,company:07963778,NEW GENERATION SCHOOLS TRUST
+2358,Alma Primary,single-academy trust,,,,company:07958546,ALMA PRIMARY
+2359,Birmingham City University Academies Trust,multi-academy trust,,company:08497028,2322,company:08497028,BIRMINGHAM CITY UNIVERSITY ACADEMIES TRUST
+2360,Stranton Academy Trust,multi-academy trust,,company:08561049,4858,company:08561049,STRANTON ACADEMY TRUST
+2361,Compass Schools Trust,single-academy trust,,,,company:07644380,COMPASS SCHOOLS TRUST
+2362,Inspire Academy Trust,multi-academy trust,,company:07781921,3532,company:07781921,INSPIRE ACADEMY TRUST
+2363,Stockport Technical School,single-academy trust,,,,company:07962246,STOCKPORT TECHNICAL SCHOOL
+2364,"Archer Academy, The",single-academy trust,,,,company:07952786,THE ARCHER ACADEMY
+2365,Hackney New School Limited,multi-academy trust,,company:07923624,5668,company:07923624,HACKNEY NEW SCHOOL LIMITED
+2366,Parkfield Education Limited,single-academy trust,,,,company:07641673,PARKFIELD EDUCATION LIMITED
+2367,New Islington Free School,single-academy trust,,,,company:07937849,NEW ISLINGTON FREE SCHOOL
+2368,"St Marylebone Church of England Bridge School, The",single-academy trust,,,,company:08270125,THE ST MARYLEBONE CHURCH OF ENGLAND BRIDGE SCHOOL
+2369,Abbots Hall Primary Academy,single-academy trust,,,,company:08484553,ABBOTS HALL PRIMARY ACADEMY
+2370,All Saints Academy,single-academy trust,,,,company:08372064,ALL SAINTS ACADEMY
+2371,Barrs Court Academy Trust,single-academy trust,,,,company:08426360,BARRS COURT ACADEMY TRUST
+2372,Burghill Community Academy,single-academy trust,,,,company:08472117,BURGHILL COMMUNITY ACADEMY
+2373,Charville Primary School Academy Trust,single-academy trust,,,,company:08451827,CHARVILLE PRIMARY SCHOOL ACADEMY TRUST
+2374,St Gilbert of Sempringham Catholic Academy Trust,multi-academy trust,,company:08462512,4688,company:08462512,ST GILBERT OF SEMPRINGHAM CATHOLIC ACADEMY TRUST
+2375,Ferrars Academy,single-academy trust,,,,company:08174123,FERRARS ACADEMY
+2376,Graham James Primary Academy,single-academy trust,,,,company:08476253,GRAHAM JAMES PRIMARY ACADEMY
+2377,Halewood Academy Centre for Learning,multi-academy trust,,company:07909397,3288,company:07909397,HALEWOOD ACADEMY CENTRE FOR LEARNING
+2378,Heartlands Community Trust,multi-academy trust,,company:08482398,3368,company:08482398,HEARTLANDS COMMUNITY TRUST
+2379,Horrington Primary School,single-academy trust,,,,company:08441991,HORRINGTON PRIMARY SCHOOL
+2380,Huntingtower Community Primary Academy,single-academy trust,,,,company:08466505,HUNTINGTOWER COMMUNITY PRIMARY ACADEMY
+2381,Hinkler Academies Trust,multi-academy trust,,company:08479066,3432,company:08479066,HINKLER ACADEMIES TRUST
+2382,"Pastures Primary School, The",single-academy trust,,,,company:08474090,THE PASTURES PRIMARY SCHOOL
+2383,Lionheart Academies Trust,multi-academy trust,,company:08473899,3760,company:08473899,LIONHEART ACADEMIES TRUST
+2384,Tweendykes School,single-academy trust,,,,company:08432506,TWEENDYKES SCHOOL
+2385,Winifred Holtby Academy Trust,single-academy trust,,,,company:08426992,WINIFRED HOLTBY ACADEMY TRUST
+2386,Woodside Primary School,single-academy trust,,,,company:08239113,WOODSIDE PRIMARY SCHOOL
+2387,ContinU Plus Academy Trust,single-academy trust,,,,company:08228379,CONTINU PLUS ACADEMY TRUST
+2388,Holy Family Catholic Academy,single-academy trust,,,,company:08623002,HOLY FAMILY CATHOLIC ACADEMY
+2389,"Harmony Trust Limited, The",multi-academy trust,,company:08840373,3316,company:08840373,THE HARMONY TRUST LTD
+2390,CCT Learning,single-academy trust,,,,company:07962209,CCT LEARNING
+2391,Steiner Academy Exeter,single-academy trust,,,,company:07956691,STEINER ACADEMY EXETER
+2392,Reach Learning Limited,single-academy trust,,,,company:07311261,REACH LEARNING LIMITED
+2393,Sir Thomas Fremantle School,single-academy trust,,,,company:07955870,SIR THOMAS FREMANTLE SCHOOL
+2394,"Engage Multi Academy Trust, The",multi-academy trust,,company:08699493,5646,company:08699493,THE ENGAGE MULTI ACADEMY TRUST
+2395,Devon Studio School,single-academy trust,,,,company:07941664,DEVON STUDIO SCHOOL
+2396,Sussex Education Trust Ltd,single-academy trust,,,,company:07874411,SUSSEX EDUCATION TRUST LTD
+2397,Bristol and South Gloucestershire UTC,single-academy trust,,,,company:07638089,BRISTOL AND SOUTH GLOUCESTERSHIRE UTC
+2398,"Reach Free School Trust, The",single-academy trust,,,,company:07960515,THE REACH FREE SCHOOL TRUST
+2399,City Education Trust,multi-academy trust,,company:08528776,2703,company:08528776,CITY EDUCATION TRUST
+2400,"Ted Wragg Multi Academy Trust, The",multi-academy trust,,company:08545109,4909,company:08545109,THE TED WRAGG MULTI ACADEMY TRUST
+2401,Liverpool College Independent School Trust,single-academy trust,,,,company:08565932,LIVERPOOL COLLEGE INDEPENDENT SCHOOL TRUST
+2402,South London Jewish Primary School,single-academy trust,,,,company:07864383,SOUTH LONDON JEWISH PRIMARY SCHOOL
+2403,Khalsa Education Trust,single-academy trust,,,,company:07954683,KHALSA EDUCATION TRUST
+2404,"Silverstone Academy Trust, The",single-academy trust,,,,company:07649183,THE SILVERSTONE ACADEMY TRUST
+2405,"Sheffield UTC Academy Trust, The",multi-academy trust,,company:07652696,16038,company:07652696,THE SHEFFIELD UTC ACADEMY TRUST
+2406,"Wells Free School, The",single-academy trust,,,,company:07923267,THE WELLS FREE SCHOOL
+2407,Hadlow Rural Community School Limited,single-academy trust,,,,company:07645462,HADLOW RURAL COMMUNITY SCHOOL LIMITED
+2408,Chobham School Academy (Stratford),single-academy trust,,,,company:06846720,CHOBHAM SCHOOL ACADEMY (STRATFORD)
+2409,Talent & Enterprise Trust,multi-academy trust,,company:08562954,4893,company:08562954,TALENT & ENTERPRISE TRUST
+2410,"Good Shepherd Trust, The",multi-academy trust,,company:08366199,3201,company:08366199,THE GOOD SHEPHERD TRUST
+2411,Orchard Hill College Academy Trust,multi-academy trust,,company:08476149,4100,company:08476149,ORCHARD HILL COLLEGE ACADEMY TRUST
+2412,NAS Academies Trust,multi-academy trust,,company:07954396,3956,company:07954396,NAS ACADEMIES TRUST
+2413,West Newcastle Academy,multi-academy trust,,company:07647538,5273,company:07647538,WEST NEWCASTLE ACADEMY
+2414,"Titan Partnership Trust Limited, The",single-academy trust,,,,company:07947806,THE TITAN PARTNERSHIP TRUST LIMITED
+2415,St. Anselm's Catholic Multi Academy Trust,multi-academy trust,,company:08515862,4629,company:08515862,ST. ANSELM'S CATHOLIC MULTI ACADEMY TRUST
+2416,Arden Grove Infant and Nursery School,single-academy trust,,,,company:08510814,ARDEN GROVE INFANT AND NURSERY SCHOOL
+2417,Battling Brook Primary School,single-academy trust,,,,company:08512087,BATTLING BROOK PRIMARY SCHOOL
+2418,"Leap Academy Trust, The",multi-academy trust,,company:08482129,3708,company:08482129,THE LEAP ACADEMY TRUST
+2419,Brocks Hill Academy Trust,single-academy trust,,,,company:08511781,BROCKS HILL ACADEMY TRUST
+2420,Acorn Academy Cornwall,multi-academy trust,,company:08418341,2067,company:08418341,ACORN ACADEMY CORNWALL
+2421,"Blyth Quays Trust, The",multi-academy trust,,company:08428466,2365,company:08428466,THE BLYTH QUAYS TRUST
+2422,Frisby C.E. Primary School,single-academy trust,,,,company:08527173,FRISBY C.E. PRIMARY SCHOOL
+2423,Hamstead Hall Academy Trust,multi-academy trust,,company:08528845,3303,company:08528845,HAMSTEAD HALL ACADEMY TRUST
+2424,Edwin Jones Trust,multi-academy trust + umbrella trust,,company:08512105,3019,company:08512105,EDWIN JONES TRUST
+2425,Hamwic Trust,multi-academy trust + umbrella trust,yes,,,company:08508903,HAMWIC TRUST
+2426,Heather Garth Primary School,single-academy trust,,,,company:08431840,HEATHER GARTH PRIMARY SCHOOL
+2427,Honeybourne First School Academy,single-academy trust,,,,company:08496781,HONEYBOURNE FIRST SCHOOL ACADEMY
+2428,Ladygrove Park Primary School,single-academy trust,,,,company:08517429,LADYGROVE PARK PRIMARY SCHOOL
+2429,Launde Primary School Academy Trust,multi-academy trust,,company:08515149,3700,company:08515149,SCHOLARS ACADEMY TRUST
+2430,Leighton Academy,single-academy trust,,,,company:08500778,LEIGHTON ACADEMY
+2431,Malmesbury C of E Primary School,single-academy trust,,,,company:08483768,MALMESBURY C OF E PRIMARY SCHOOL
+2432,Manor School Didcot Academy Trust,single-academy trust,,,,company:08516551,MANOR SCHOOL DIDCOT ACADEMY TRUST
+2433,St John's Academy Trust,single-academy trust,,,,company:08517255,ST JOHN'S ACADEMY TRUST
+2434,Mid Essex Anglican Academy Trust,multi-academy trust,,company:08524638,16036,company:08524638,MID ESSEX ANGLICAN ACADEMY TRUST
+2435,"South Cheshire Catholic Multi-academy Trust, The",multi-academy trust + umbrella trust,,company:08518704,5693,company:08518704,THE SOUTH CHESHIRE CATHOLIC MULTI-ACADEMY TRUST
+2436,"Nottingham Emmanuel School, The",single-academy trust,,,,company:08472283,THE NOTTINGHAM EMMANUEL SCHOOL
+2437,Thringstone Primary School Academy Trust,single-academy trust,,,,company:08514901,THRINGSTONE PRIMARY SCHOOL ACADEMY TRUST
+2438,William Brookes Academy Trust,single-academy trust,,,,company:08520569,WILLIAM BROOKES ACADEMY TRUST
+2439,Willowcroft Academy Trust,single-academy trust,,,,company:08516562,WILLOWCROFT ACADEMY TRUST
+2440,"Leeds Jewish Free School, The",single-academy trust,,,,company:07647432,THE LEEDS JEWISH FREE SCHOOL
+2441,"Acorn EBS Free School Ltd., The",single-academy trust,,,,company:07654340,THE ACORN EBS FREE SCHOOL LTD.
+2442,Bellevue Place Education Trust,multi-academy trust,,company:07956784,2288,company:07956784,BELLEVUE PLACE EDUCATION TRUST
+2443,"Olive Tree Primary School Bolton Limited, The",single-academy trust,,,,company:07956473,THE OLIVE TREE PRIMARY SCHOOL BOLTON LIMITED
+2444,NCB Studio School,single-academy trust,,,,company:07960235,NCB STUDIO SCHOOL
+2445,Active Education Academy Trust,single-academy trust,,,,company:07650619,ACTIVE EDUCATION ACADEMY TRUST
+2446,"University Technical College, Royal Borough of Greenwich, The",single-academy trust,,,,company:07742547,"THE UNIVERSITY TECHNICAL COLLEGE, ROYAL BOROUGH OF GREENWICH"
+2447,"Waverley Education Foundation Ltd, The",multi-academy trust,,company:08331922,5232,company:08331922,THE WAVERLEY EDUCATION FOUNDATION LTD
+2448,Walsall Studio School,single-academy trust,,,,company:08285206,WALSALL STUDIO SCHOOL
+2449,Big Life Schools,multi-academy trust,,company:07945230,15759,company:07945230,BIG LIFE SCHOOLS
+2450,Partnership Learning,multi-academy trust,,company:08339345,5485,company:08339345,PARTNERSHIP LEARNING
+2451,UTC Lancashire,single-academy trust,,,,company:07653051,UTC LANCASHIRE
+2452,Sparkwell All Saints Primary Trust Limited,single-academy trust,,,,company:07952925,SPARKWELL ALL SAINTS PRIMARY TRUST LIMITED
+2453,Gildredge House Free School,single-academy trust,,,,company:08436285,GILDREDGE HOUSE FREE SCHOOL
+2454,Bishop Cleary Catholic Multi Academy Company,multi-academy trust,,company:08578428,2328,company:08578428,BISHOP CLEARY CATHOLIC MULTI ACADEMY COMPANY
+2455,Route 39 Academy Trust Limited,single-academy trust,,,,company:07945060,ROUTE 39 ACADEMY TRUST LIMITED
+2456,East London Science School Trust,single-academy trust,,,,company:07962059,EAST LONDON SCIENCE SCHOOL TRUST
+2457,Biddick Academy Trust,multi-academy trust,,company:08521080,2307,company:08521080,BIDDICK ACADEMY TRUST
+2458,Birchwood Community Academy Trust,single-academy trust,,,,company:08426967,BIRCHWOOD COMMUNITY ACADEMY TRUST
+2459,Broadway Academy Trust,single-academy trust,,,,company:08534233,BROADWAY ACADEMY TRUST
+2460,Burntwood School,single-academy trust,,,,company:08550180,BURNTWOOD SCHOOL
+2461,"Diocese of Ely Multi-academy Trust, The",multi-academy trust,,company:08464996,2905,company:08464996,THE DIOCESE OF ELY MULTI-ACADEMY TRUST
+2462,Carmountside Primary Academy,single-academy trust,,,,company:08170071,CARMOUNTSIDE PRIMARY ACADEMY
+2463,South Northamptonshire Village Schools Multi Academy Trust,multi-academy trust,,company:08567252,4580,company:08567252,SOUTH NORTHAMPTONSHIRE VILLAGE SCHOOLS MULTI ACADEMY TRUST
+2464,Diamond Hall Infant Academy,single-academy trust,,,,company:08565046,DIAMOND HALL INFANT ACADEMY
+2465,Extol Academy Trust,multi-academy trust,,company:08561360,3071,company:08561360,EXTOL ACADEMY TRUST
+2466,Brighter Academy Trust,multi-academy trust,,company:08557883,2440,company:08557883,BRIGHTER ACADEMY TRUST
+2467,"Forest School Academy Trust, The",single-academy trust,,,,company:08563159,THE FOREST SCHOOL ACADEMY TRUST
+2468,Gilmorton Chandler Church of England Primary School,single-academy trust,,,,company:08540699,GILMORTON CHANDLER CHURCH OF ENGLAND PRIMARY SCHOOL
+2469,"Oadby, Wigston and Leicestershire Schools Academy Trust",multi-academy trust,,company:08537140,3185,company:08537140,"OADBY, WIGSTON AND LEICESTERSHIRE SCHOOLS ACADEMY TRUST"
+2470,Brigantia Learning Trust Limited,multi-academy trust,,company:08506178,3431,company:08506178,BRIGANTIA LEARNING TRUST LIMITED
+2471,Langham Church of England Primary School,single-academy trust,,,,company:08560721,LANGHAM CHURCH OF ENGLAND PRIMARY SCHOOL
+2472,Loughton School,single-academy trust,,,,company:08565187,LOUGHTON SCHOOL
+2473,Lound Academy Trust,multi-academy trust,,company:08550854,3794,company:08550854,LOUND ACADEMY TRUST
+2474,Lubenham All Saints Church of England Primary School,single-academy trust,,,,company:08561329,LUBENHAM ALL SAINTS CHURCH OF ENGLAND PRIMARY SCHOOL
+2475,Meppershall Church of England Academy,single-academy trust,,,,company:08572815,MEPPERSHALL CHURCH OF ENGLAND ACADEMY
+2476,Norwood Green Junior School,single-academy trust,,,,company:08520286,NORWOOD GREEN JUNIOR SCHOOL
+2477,Perry Hall Multi-Academy Trust,multi-academy trust,,company:08566185,4186,company:08566185,PERRY HALL MULTI-ACADEMY TRUST
+2478,Connected Learning,multi-academy trust,,company:08579939,2771,company:08579939,CONNECTED LEARNING
+2479,Redhill School,single-academy trust,,,,company:08536774,REDHILL SCHOOL
+2480,Richard Hale School,single-academy trust,,,,company:08572898,RICHARD HALE SCHOOL
+2481,Rothley Church of England Primary School,single-academy trust,,,,company:08388074,ROTHLEY CHURCH OF ENGLAND PRIMARY SCHOOL
+2482,"St Bede's Catholic Primary School, A Voluntary Academy",single-academy trust + umbrella trust,,,,company:08543210,"ST BEDE'S CATHOLIC PRIMARY SCHOOL, A VOLUNTARY ACADEMY"
+2483,St Gerard's Catholic Primary,single-academy trust + umbrella trust,,,,company:08543748,ST GERARD'S CATHOLIC PRIMARY
+2484,St. Joseph's Catholic Education Trust,multi-academy trust,,company:08559647,4719,company:08559647,ST. JOSEPH'S CATHOLIC EDUCATION TRUST
+2485,Saint Lawrence Church of England Primary School Hurstpierpoint,single-academy trust,,,,company:08514898,SAINT LAWRENCE CHURCH OF ENGLAND PRIMARY SCHOOL HURSTPIERPOINT
+2486,"St Mary's Catholic Primary School (Herringthorpe), A Catholic Voluntary Academy",single-academy trust + umbrella trust,,,,company:08543115,"ST MARY'S CATHOLIC PRIMARY SCHOOL (HERRINGTHORPE), A CATHOLIC VOLUNTARY ACADEMY"
+2487,St Mary's Catholic Primary School (Maltby),single-academy trust + umbrella trust,,,,company:08543217,ST MARY'S CATHOLIC PRIMARY SCHOOL (MALTBY)
+2488,"Catholic Academy Trust in East Berkshire, The",multi-academy trust,,company:08561153,2579,company:08561153,THE CATHOLIC ACADEMY TRUST IN EAST BERKSHIRE
+2489,"Learning Together Trust, The",multi-academy trust,,company:08561302,5669,company:08561302,THE LEARNING TOGETHER TRUST
+2490,Washwood Heath Multi Academy Trust,multi-academy trust,,company:08531479,5226,company:08531479,WASHWOOD HEATH MULTI ACADEMY TRUST
+2491,Westbrook Primary School,single-academy trust,,,,company:08523370,WESTBROOK PRIMARY SCHOOL
+2492,"Robert Owen Academies Trust, The",single-academy trust,,,,company:08220540,THE ROBERT OWEN ACADEMIES TRUST
+2493,The Khalsa Academies Trust Limited,multi-academy trust,,company:07549443,15763,company:07549443,THE KHALSA ACADEMIES TRUST LIMITED
+2494,South Essex Community School Ltd,single-academy trust,,,,company:07954295,SOUTH ESSEX COMMUNITY SCHOOL LTD
+2495,St Bart's Multi Academy Trust,multi-academy trust,,company:08735454,4638,company:08735454,ST BART'S MULTI ACADEMY TRUST
+2496,RNIB Specialist Learning Trust,multi-academy trust,,company:08478985,4372,company:08478985,RNIB SPECIALIST LEARNING TRUST
+2497,Diocese of Brentwood Multi Academy Trust,multi-academy trust,,company:08610377,2893,company:08610377,DIOCESE OF BRENTWOOD MULTI ACADEMY TRUST
+2498,Plymouth School of Creative Arts,single-academy trust,,,,company:07953395,PLYMOUTH SCHOOL OF CREATIVE ARTS
+2499,"Harrow Alternative Provision Academy Trust, The",single-academy trust,,,,company:07949213,THE HARROW ALTERNATIVE PROVISION ACADEMY TRUST
+2500,Theale Green School Trust,single-academy trust,,,,company:08644023,THEALE GREEN SCHOOL TRUST
+2501,University of Chichester (Multi) Academy Trust,multi-academy trust,,company:08595545,5153,company:08595545,UNIVERSITY OF CHICHESTER (MULTI) ACADEMY TRUST
+2502,Solent Academies Trust,multi-academy trust,,company:08374351,4559,company:08374351,SOLENT ACADEMIES TRUST
+2503,Collective Spirit Oldham,single-academy trust,,,,company:08178309,COLLECTIVE SPIRIT OLDHAM
+2504,Holyport College,single-academy trust,,,,company:07930340,HOLYPORT COLLEGE
+2505,The Heights Primary School,single-academy trust,,,,company:08334593,THE HEIGHTS PRIMARY SCHOOL
+2506,Horizons Specialist Academy Trust,multi-academy trust,,company:08608287,3483,company:08608287,HORIZONS SPECIALIST ACADEMY TRUST
+2507,Beckfoot Trust,multi-academy trust,,company:08155088,2270,company:08155088,BECKFOOT TRUST
+2508,Hartlepool Aspire Trust,multi-academy trust,,company:08604037,3329,company:08604037,HARTLEPOOL ASPIRE TRUST
+2509,"Southfield Grange Trust, The",multi-academy trust,,company:07754077,4593,company:07754077,THE SOUTHFIELD GRANGE TRUST
+2510,Dauntsey Academy Primary School,single-academy trust,,,,company:08602255,DAUNTSEY ACADEMY PRIMARY SCHOOL
+2511,Odyssey Educational Trust,multi-academy trust,,company:08612100,16096,company:08612100,ODYSSEY EDUCATIONAL TRUST
+2512,Koinonia Academies Trust,multi-academy trust,,company:08563153,3668,company:08563153,KOINONIA ACADEMIES TRUST
+2513,Stone with Woodford C of E Primary School,single-academy trust,,,,company:08576916,STONE WITH WOODFORD C OF E PRIMARY SCHOOL
+2514,"Ferrers School, The",single-academy trust,,,,company:08621334,THE FERRERS SCHOOL
+2515,"Green School Trust, The",multi-academy trust + umbrella trust,,company:08608665,3240,company:08608665,THE GREEN SCHOOL TRUST
+2516,London Diocesan Board for Schools,multi-academy trust + umbrella trust,yes,,,company:00198131,LONDON DIOCESAN BOARD FOR SCHOOLS(THE)
+2517,Ursula Taylor Church of England School,single-academy trust,,,,company:08606536,URSULA TAYLOR CHURCH OF ENGLAND SCHOOL
+2518,West Thurrock Academy,single-academy trust,,,,company:08259069,WEST THURROCK ACADEMY
+2519,Wingfield Academy,single-academy trust,,,,company:08550403,WINGFIELD ACADEMY
+2520,Woking High School Academy Trust,single-academy trust,,,,company:08586085,WOKING HIGH SCHOOL ACADEMY TRUST
+2521,Yardleys School,single-academy trust,,,,company:08496504,YARDLEYS SCHOOL
+2522,"Heyfordian School Trust, The",single-academy trust,,,,company:07926597,THE HEYFORDIAN SCHOOL TRUST
+2523,Bury College Education Trust,multi-academy trust,,company:08769073,2507,company:08769073,BURY COLLEGE EDUCATION TRUST
+2524,Durham Free School Limited,single-academy trust,,,,company:07959449,DURHAM FREE SCHOOL LTD
+2525,OUR Co-operative Academies Trust,multi-academy trust,,company:08670427,4111,company:08670427,OUR CO-OPERATIVE ACADEMIES TRUST
+2526,"Hallam Schools' Partnership Academy Trust, The",multi-academy trust,,company:08665067,3294,company:08665067,THE HALLAM SCHOOLS' PARTNERSHIP ACADEMY TRUST
+2527,Lumen Learning Trust,multi-academy trust,,company:08670599,3805,company:08670599,LUMEN LEARNING TRUST
+2528,Downview Trust,multi-academy trust,,company:08603388,2953,company:08603388,DOWNVIEW TRUST
+2529,Westfield Academy,single-academy trust,,,,company:08526440,WESTFIELD ACADEMY
+2530,Gateway Academy,single-academy trust,,,,company:08556180,GATEWAY ACADEMY
+2531,Acorn Trust,multi-academy trust,,company:08638158,2072,company:08638158,ACORN TRUST
+2532,Wardle Academy,multi-academy trust,,company:08368756,5486,company:08368756,WARDLE ACADEMY
+2533,South Northamptonshire Church of England Multi Academy Trust,multi-academy trust,,company:08569207,4579,company:08569207,SOUTH NORTHAMPTONSHIRE CHURCH OF ENGLAND MULTI ACADEMY TRUST
+2534,Fareham Academy,single-academy trust,,,,company:08549807,FAREHAM ACADEMY
+2535,Harden Primary School,single-academy trust,,,,company:08610504,HARDEN PRIMARY SCHOOL
+2536,Three Ways School,single-academy trust,,,,company:08488749,THREE WAYS SCHOOL
+2537,Alexandra Junior School,single-academy trust,,,,company:08621035,ALEXANDRA JUNIOR SCHOOL
+2538,St. Mary's Catholic School Trust,multi-academy trust,,company:08599141,4750,company:08599141,ST. MARY'S CATHOLIC SCHOOL TRUST
+2539,Highfield Infants' School,single-academy trust,,,,company:08632733,HIGHFIELD INFANTS' SCHOOL
+2540,Holmes Chapel Primary School,single-academy trust,,,,company:08587865,HOLMES CHAPEL PRIMARY SCHOOL
+2541,"Horsell Village School, The",single-academy trust,,,,company:08622047,THE HORSELL VILLAGE SCHOOL
+2542,Raglan Primary School,single-academy trust,,,,company:08628905,RAGLAN PRIMARY SCHOOL
+2543,"Oaktree School Academy Trust, The",single-academy trust,,,,company:08638766,THE OAKTREE SCHOOL ACADEMY TRUST
+2544,Hollingworth Academy Trust,single-academy trust,,,,company:08314692,HOLLINGWORTH ACADEMY TRUST
+2545,Torre Church of England Academy,single-academy trust,,,,company:08594520,TORRE CHURCH OF ENGLAND ACADEMY
+2546,Cloughwood Academy Trust,multi-academy trust,,company:08604799,2727,company:08604799,CLOUGHWOOD ACADEMY TRUST
+2547,Old Dalby Church of England Primary School,single-academy trust,,,,company:08564471,OLD DALBY CHURCH OF ENGLAND PRIMARY SCHOOL
+2548,Over Hall Academies Limited,single-academy trust,,,,company:09476660,OVER HALL ACADEMIES LIMITED
+2549,Milford-on-Sea Church of England Primary School Academy Trust,single-academy trust,,,,company:08612061,MILFORD-ON-SEA CHURCH OF ENGLAND PRIMARY SCHOOL ACADEMY TRUST
+2550,Hastings High School,single-academy trust,,,,company:08617343,HASTINGS HIGH SCHOOL
+2551,Eggbuckland Community College Academy Trust,multi-academy trust,,company:08603078,5595,company:08603078,EGGBUCKLAND COMMUNITY COLLEGE ACADEMY TRUST
+2552,Alsager Multi Academy Trust,multi-academy trust,,company:08597784,2122,company:08597784,ALSAGER MULTI ACADEMY TRUST
+2553,White Woods Primary Academy Trust,multi-academy trust,,company:08589470,5318,company:08589470,WHITE WOODS PRIMARY ACADEMY TRUST
+2554,Darrington Church of England Primary School,single-academy trust + umbrella trust,,,,company:08638398,DARRINGTON CHURCH OF ENGLAND PRIMARY SCHOOL
+2555,IQRA Academy Education Trust,single-academy trust,,,,company:08623229,IQRA ACADEMY EDUCATION TRUST
+2556,MVW Academy,single-academy trust,,,,company:08634384,MVW ACADEMY
+2557,"Newman Catholic Collegiate, The",multi-academy trust,,company:08550110,3991,company:08550110,THE NEWMAN CATHOLIC COLLEGIATE
+2558,Surrey Heath Education Trust,multi-academy trust,,company:08621310,4876,company:08621310,SURREY HEATH EDUCATION TRUST
+2559,Alleyne's Academy,single-academy trust,,,,company:08611863,ALLEYNE'S ACADEMY
+2560,Blackpool Multi Academy Trust,multi-academy trust,,company:08597962,2350,company:08597962,BLACKPOOL MULTI ACADEMY TRUST
+2561,Heartwood Church of England Academy Trust,multi-academy trust,,company:08627834,3371,company:08627834,HEARTWOOD CHURCH OF ENGLAND ACADEMY TRUST
+2562,"St John Bosco Catholic Academy, The",multi-academy trust,,company:08608177,4703,company:08608177,THE ST JOHN BOSCO CATHOLIC ACADEMY
+2563,Cawston Grange Primary School,single-academy trust,,,,company:08599777,CAWSTON GRANGE PRIMARY SCHOOL
+2564,Kingsway Community Trust,multi-academy trust,,company:08339302,3652,company:08339302,KINGSWAY COMMUNITY TRUST
+2565,Haltwhistle Community Campus,multi-academy trust,,company:08624157,3295,company:08624157,HALTWHISTLE COMMUNITY CAMPUS
+2566,Holland Park School,single-academy trust,,,,company:08588099,HOLLAND PARK SCHOOL
+2567,Henley-In-Arden Church of England Primary School,single-academy trust,,,,company:08644320,HENLEY-IN-ARDEN CHURCH OF ENGLAND PRIMARY SCHOOL
+2568,Jubilee Park Academy Trust,single-academy trust,,,,company:08591050,JUBILEE PARK ACADEMY TRUST
+2569,Ocker Hill Academy Trust,single-academy trust,,,,company:08593820,OCKER HILL ACADEMY TRUST
+2570,Park Road Sale Primary School,single-academy trust,,,,company:08623343,PARK ROAD SALE PRIMARY SCHOOL
+2571,Madeley High School Academy Trust,single-academy trust,,,,company:08621160,MADELEY HIGH SCHOOL ACADEMY TRUST
+2572,West Midlands Construction UTC,single-academy trust,,,,company:07898669,WEST MIDLANDS CONSTRUCTION UTC
+2573,William Temple Multi Academy Trust,multi-academy trust,,company:08813173,5345,company:08813173,WILLIAM TEMPLE MULTI ACADEMY TRUST
+2574,"Diocese of Chelmsford Vine Schools Trust, The",multi-academy trust,,company:08709542,4955,company:08709542,THE DIOCESE OF CHELMSFORD VINE SCHOOLS TRUST
+2575,The Diocese of Chelmsford Sower Schools Trust,multi-academy trust,,,,company:08709656,THE DIOCESE OF CHELMSFORD SOWER SCHOOLS TRUST
+2576,Chesterton Academy Trust,multi-academy trust,,company:08786812,2650,company:08786812,CHESTERTON ACADEMY TRUST
+2577,Whitefield Academy Trust,multi-academy trust,,company:08878604,5320,company:08878604,WHITEFIELD ACADEMY TRUST
+2578,Langdale Free School,single-academy trust,,,,company:07649550,LANGDALE FREE SCHOOL
+2579,Westside Academy Trust,single-academy trust,,,,company:05888220,WESTSIDE ACADEMY TRUST
+2580,St Anthony's Free School,single-academy trust,,,,company:08232396,ST ANTHONY'S FREE SCHOOL
+2581,Peaslake Free School Limited,single-academy trust,,,,company:07925067,PEASLAKE FREE SCHOOL LIMITED
+2582,Bradford Girls' Grammar School Trust,single-academy trust,,,,company:07951118,BRADFORD GIRLS' GRAMMAR SCHOOL TRUST
+2583,Kensington Aldridge Academy,single-academy trust,,,,company:07702460,KENSINGTON ALDRIDGE ACADEMY
+2584,Macintyre Academies,multi-academy trust,,company:08334745,3817,company:08334745,MACINTYRE ACADEMIES
+2585,South Bank Academies,multi-academy trust,,company:08589525,5148,company:08589525,SOUTH BANK ACADEMIES
+2586,Clifton All Saints Academy,single-academy trust,,,,company:08702006,CLIFTON ALL SAINTS ACADEMY
+2587,Appleton Primary School,single-academy trust,,,,company:08682513,APPLETON PRIMARY SCHOOL
+2588,Hall Orchard Barrow CE Primary School,single-academy trust,,,,company:08674696,HALL ORCHARD BARROW CE PRIMARY SCHOOL
+2589,Blue Bell Hill Academy Trust,multi-academy trust,,company:08554393,2358,company:08554393,BLUE BELL HILL ACADEMY TRUST
+2590,St Barnabas Church of England Multi Academy Trust,multi-academy trust + umbrella trust,,company:08669464,4636,company:08669464,ST BARNABAS CHURCH OF ENGLAND MULTI ACADEMY TRUST
+2591,Bricknell Primary School,single-academy trust,,,,company:08682863,BRICKNELL PRIMARY SCHOOL
+2592,Broadfields Academy Trust,single-academy trust,,,,company:08640614,BROADFIELDS ACADEMY TRUST
+2593,Countess Anne Church of England School,single-academy trust,,,,company:08658210,COUNTESS ANNE CHURCH OF ENGLAND SCHOOL
+2594,"Specialist Education Trust, The",multi-academy trust,,company:08610537,4608,company:08610537,THE SPECIALIST EDUCATION TRUST
+2595,Hoyland Common Primary School,single-academy trust,,,,company:08654591,HOYLAND COMMON PRIMARY SCHOOL
+2596,Hurst Primary School,single-academy trust,,,,company:08657975,HURST PRIMARY SCHOOL
+2597,Longhill Primary School,single-academy trust,,,,company:08684289,LONGHILL PRIMARY SCHOOL
+2598,Maybury Primary School,single-academy trust,,,,company:08682547,MAYBURY PRIMARY SCHOOL
+2599,Neasden Primary School,single-academy trust,,,,company:08682479,NEASDEN PRIMARY SCHOOL
+2600,"Futures Trust, The",multi-academy trust,,company:08678162,15732,company:08678162,THE FUTURES TRUST
+2601,Ralph Sadleir School,multi-academy trust,,company:08663956,4301,company:08663956,RALPH SADLEIR SCHOOL
+2602,Stanton Under Bardon Community Primary School,single-academy trust,,,,company:08423592,STANTON UNDER BARDON COMMUNITY PRIMARY SCHOOL
+2603,Thornton Community Primary School,single-academy trust,,,,company:08430135,THORNTON PRIMARY SCHOOL
+2604,Thrybergh Academy & Sports College,single-academy trust,,,,company:08290708,THRYBERGH ACADEMY & SPORTS COLLEGE
+2605,Connaught Academy Trust,single-academy trust,,,,company:08576427,CONNAUGHT ACADEMY TRUST
+2606,Highfield Junior School,single-academy trust,,,,company:08657831,HIGHFIELD JUNIOR SCHOOL
+2607,Astwood Bank First School,single-academy trust,,,,company:08637890,ASTWOOD BANK FIRST SCHOOL
+2608,Cheam Park Farm Infants School,single-academy trust,,,,company:08661374,CHEAM PARK FARM INFANTS SCHOOL
+2609,Regency High School,single-academy trust,,,,company:08658515,REGENCY HIGH SCHOOL
+2610,Robin Hood Academy,single-academy trust,,,,,
+2611,UTC Cambridge,single-academy trust,,,,company:07911604,UTC CAMBRIDGE
+2612,Educate Together Academy Trust,multi-academy trust,,company:08859774,3009,company:08859774,EDUCATE TOGETHER ACADEMY TRUST
+2613,Beecroft Academy,single-academy trust,,,,company:08699391,BEECROFT ACADEMY
+2614,Friars Academy,single-academy trust,,,,company:08722556,FRIARS ACADEMY
+2615,Cholsey Primary Academy Trust,single-academy trust,,,,company:08722647,CHOLSEY PRIMARY ACADEMY TRUST
+2616,Glebe Academy,single-academy trust,,,,company:08732018,GLEBE ACADEMY
+2617,Millbrook Primary School,single-academy trust,,,,company:08713217,MILLBROOK PRIMARY SCHOOL
+2618,Newstead Multi Academy Trust,multi-academy trust,,company:08657945,3996,company:08657945,INSPIRATIONAL LEARNING ACADEMIES TRUST
+2619,Oak Bank School,single-academy trust,,,,company:08712137,OAK BANK SCHOOL
+2620,All Saints Catholic Collegiate,multi-academy trust,,company:08709352,2112,company:08709352,ALL SAINTS CATHOLIC COLLEGIATE
+2621,Fusion Schools Trust,multi-academy trust,,company:08663011,3150,company:08663011,FUSION SCHOOLS TRUST
+2622,Peatmoor Community Primary School,single-academy trust,,,,company:08714452,PEATMOOR COMMUNITY PRIMARY SCHOOL
+2623,Priory Primary School,single-academy trust,,,,company:08684300,PRIORY PRIMARY SCHOOL
+2624,Shaw Ridge Primary School,single-academy trust,,,,company:08714241,SHAW RIDGE PRIMARY SCHOOL
+2625,South Bromsgrove High Academy Trust,single-academy trust,,,,company:08565135,SOUTH BROMSGROVE HIGH ACADEMY TRUST
+2626,Simon Balle Academies Trust,multi-academy trust,,company:08661539,4528,company:08661539,SIMON BALLE ACADEMIES TRUST
+2627,St Aidan's Catholic Primary Academy,single-academy trust,,,,company:08731777,ST AIDAN'S CATHOLIC PRIMARY ACADEMY
+2628,"Chafford School Academy Trust, the",single-academy trust,,,,company:08615792,THE CHAFFORD SCHOOL ACADEMY TRUST
+2629,Westlea Primary School,single-academy trust,,,,company:08713214,WESTLEA PRIMARY SCHOOL
+2630,Preston Primary School Academy Trust,single-academy trust,,,,company:08727883,PRESTON PRIMARY ACADEMY TRUST
+2631,Penny Bridge Church of England Primary School Limited,single-academy trust,,,,company:08701329,PENNY BRIDGE CHURCH OF ENGLAND PRIMARY SCHOOL LIMITED
+2632,Cornelius Vermuyden School,single-academy trust,,,,company:08667123,CORNELIUS VERMUYDEN SCHOOL
+2633,Matchborough First School Academy,single-academy trust,,,,company:08741704,MATCHBOROUGH FIRST SCHOOL ACADEMY
+2634,"Primary First Trust, The",multi-academy trust,,company:08738750,4245,company:08738750,THE PRIMARY FIRST TRUST
+2635,Beaver Road Academy Trust,multi-academy trust,,company:08698831,2268,company:08698831,BEAVER ROAD ACADEMY TRUST
+2636,Kirby Muxloe Primary School,single-academy trust,,,,company:08702056,KIRBY MUXLOE PRIMARY SCHOOL
+2637,Skelton Primary School,single-academy trust,,,,company:08693259,SKELTON PRIMARY SCHOOL
+2638,Ace Learning,multi-academy trust,,company:08681270,2064,company:08681270,ACE LEARNING
+2639,Cleves Cross Learning Trust,multi-academy trust,,company:08718104,2719,company:08718104,CLEVES CROSS LEARNING TRUST
+2640,"Halifax Academy, The",single-academy trust,,,,company:08529006,THE HALIFAX ACADEMY TRUST
+2641,"Lilac Sky Schools Trust, The",multi-academy trust,,company:08289583,3743,company:08289583,THE LILAC SKY SCHOOLS TRUST
+2642,"DS Academies Trust, The",multi-academy trust,,company:08745639,2962,company:08745639,THE DIOCESE OF SHEFFIELD ACADEMIES TRUST
+2643,Diocese of Salisbury Multi Academy Trust,multi-academy trust,,company:08656655,2922,company:08656655,DIOCESE OF SALISBURY MULTI ACADEMY TRUST
+2644,The Wulfrun Academies Trust,multi-academy trust,,company:08881720,5487,company:08881720,THE WULFRUN ACADEMIES TRUST
+2645,Autism Schools Trust,multi-academy trust,,company:08335297,2207,company:08335297,AUTISM SCHOOLS TRUST
+2646,The Eveleigh Link Academy Trust,multi-academy trust,,company:08823327,4963,company:08823327,THE EVELEIGH LINK ACADEMY TRUST
+2647,Chester Diocesan Academies Trust,multi-academy trust,,company:08451787,2647,company:08451787,CHESTER DIOCESAN ACADEMIES TRUST
+2648,Floreat Education Academies Trust,multi-academy trust,,company:09007740,15755,company:09007740,FLOREAT EDUCATION ACADEMIES TRUST
+2649,Carillion Academies Trust,multi-academy trust,,company:09323071,15772,company:09323071,CARILLION ACADEMIES TRUST
+2650,Billing Brook School Academy Trust,single-academy trust,,,,company:08711161,BILLING BROOK SCHOOL ACADEMY TRUST
+2651,Cleeve Primary School,single-academy trust,,,,company:08775910,CLEEVE PRIMARY SCHOOL
+2652,Parkroyal Academy Trust,multi-academy trust,,company:08728422,4149,company:08728422,PARKROYAL ACADEMY TRUST
+2653,Sacred Heart Hillsborough Academy Trust,single-academy trust + umbrella trust,,,,company:08719689,SACRED HEART HILLSBOROUGH ACADEMY TRUST
+2654,"St Mary's Primary School, A Catholic Voluntary Academy",single-academy trust + umbrella trust,,,,company:08722529,"ST MARY'S PRIMARY SCHOOL, A CATHOLIC VOLUNTARY ACADEMY"
+2655,"St Ann's Catholic Primary School, a Voluntary Academy",single-academy trust + umbrella trust,,,,company:08722710,"ST ANN'S CATHOLIC PRIMARY SCHOOL, A VOLUNTARY ACADEMY"
+2656,Bursted Wood Primary School,single-academy trust,,,,company:08603037,BURSTED WOOD PRIMARY SCHOOL
+2657,"Aspire Educational Trust, The",multi-academy trust,,company:08689696,5594,company:08689696,THE ASPIRE EDUCATIONAL TRUST
+2658,Kirkby la Thorpe Church of England Primary Academy,single-academy trust,,,,company:08597878,KIRKBY LA THORPE CHURCH OF ENGLAND PRIMARY ACADEMY
+2659,Sandhill Multi Academy Trust,multi-academy trust,,company:08745045,4460,company:08745045,SANDHILL MULTI ACADEMY TRUST
+2660,Fennwood Academy Trust,multi-academy trust,,company:08763832,3093,company:08763832,FENNWOOD ACADEMY TRUST
+2661,Perry Hall Primary School,single-academy trust,,,,company:08760817,PERRY HALL PRIMARY SCHOOL
+2662,Nexus Education Schools Trust,multi-academy trust,,company:08753719,16040,company:08753719,NEXUS EDUCATION SCHOOLS TRUST
+2663,Manor Oak Primary School,single-academy trust,,,,company:08752701,MANOR OAK PRIMARY SCHOOL
+2664,Alexandra Infant School,single-academy trust,,,,company:08759430,ALEXANDRA INFANT SCHOOL
+2665,"Ann Harris Academy Trust, The",multi-academy trust,,company:08741949,2135,company:08741949,THE ANN HARRIS ACADEMY TRUST
+2666,St Giles Church of England Academy,single-academy trust,,,,company:08781513,ST GILES CHURCH OF ENGLAND ACADEMY
+2667,"Huish Academy Trust, The",single-academy trust,,,,company:08756412,THE HUISH ACADEMY TRUST
+2668,"Adelaide Academy Trust, The",multi-academy trust,,company:08725920,2076,company:08725920,THE ADELAIDE ACADEMY TRUST
+2669,Oakwood Learning Community Trust,multi-academy trust,,company:08775996,4073,company:08775996,INSPIRE TRUST
+2670,Bentley Heath Church of England Primary School,single-academy trust,,,,company:08769758,BENTLEY HEATH CHURCH OF ENGLAND PRIMARY SCHOOL
+2671,Holy Trinity CE Primary Academy (Handsworth),single-academy trust,,,,company:08612065,HOLY TRINITY CE PRIMARY ACADEMY (HANDSWORTH)
+2672,Mordiford Church of England Primary School,single-academy trust,,,,company:08738224,MORDIFORD CHURCH OF ENGLAND PRIMARY SCHOOL
+2673,St Piran's Cross Church of England Multi Academy Trust,multi-academy trust + umbrella trust,,company:08739625,4791,company:08739625,ST PIRAN'S CROSS CHURCH OF ENGLAND MULTI ACADEMY TRUST
+2674,Robert Wilkinson Academy Trust,single-academy trust,,,,company:08766799,ROBERT WILKINSON ACADEMY TRUST
+2675,Bishop Luffa School,single-academy trust,,,,company:08749379,BISHOP LUFFA SCHOOL
+2676,Robert Bakewell Primary School,single-academy trust,,,,company:08217604,ROBERT BAKEWELL PRIMARY SCHOOL
+2677,Whittlesea Learning Trust,multi-academy trust,,company:08795983,5328,company:08795983,WHITTLESEA LEARNING TRUST
+2678,ConcertEd Multi Academy Trust,multi-academy trust,,company:08718062,2765,company:08718062,THE BOLTON MULTI ACADEMY TRUST
+2679,"Quinta Trust, The",multi-academy trust,,company:08787650,4292,company:08787650,THE QUINTA TRUST
+2680,Leigh Trust,multi-academy trust,,company:08779660,3727,company:08779660,LEIGH TRUST
+2681,Sunnyside Academy,single-academy trust,,,,company:08803924,SUNNYSIDE ACADEMY
+2682,Rose Wood Academy,single-academy trust,,,,company:08803916,ROSE WOOD ACADEMY
+2683,Viewley Hill Academy,single-academy trust,,,,company:08803858,VIEWLEY HILL ACADEMY
+2684,John Donne Primary School,single-academy trust,,,,company:08791046,COMMUNITAS EDUCATION TRUST
+2685,Beaufort Primary School,single-academy trust,,,,company:08749901,BEAUFORT PRIMARY SCHOOL
+2686,Northampton School for Girls,single-academy trust,,,,company:08591532,NORTHAMPTON SCHOOL FOR GIRLS
+2687,Mitton Manor Primary Academy,single-academy trust,,,,company:08792831,MITTON MANOR PRIMARY ACADEMY
+2688,AN Daras Multi Academy Trust,multi-academy trust,,company:08156955,3698,company:08156955,AN DARAS MULTI ACADEMY TRUST
+2689,Atwood Primary Academy,single-academy trust,,,,company:08795464,ATWOOD PRIMARY ACADEMY
+2690,Twickenham Primary School,single-academy trust,,,,company:08601624,TWICKENHAM PRIMARY SCHOOL
+2691,Kent Catholic Schools' Partnership,multi-academy trust,,company:08176019,3594,company:08176019,KENT CATHOLIC SCHOOLS' PARTNERSHIP
+2692,Mercia Primary Academy Trust,multi-academy trust,,company:08748904,3900,company:08748904,MERCIA PRIMARY ACADEMY TRUST
+2693,John Paul II Multi-academy,multi-academy trust,,company:08706247,3566,company:08706247,JOHN PAUL II MULTI-ACADEMY
+2694,Marden Primary Academy,single-academy trust,,,,company:08802427,MARDEN PRIMARY ACADEMY
+2695,Stars Trust,single-academy trust,,,,company:08810960,STARS TRUST
+2696,Severndale Specialist Academy,single-academy trust,,,,company:08738846,SEVERNDALE SPECIALIST ACADEMY
+2697,Sherwood Park Primary School,single-academy trust,,,,company:08792911,SHERWOOD PARK PRIMARY SCHOOL
+2698,Castlecombe Primary School,single-academy trust,,,,company:08754658,CASTLECOMBE PRIMARY SCHOOL
+2699,Pride Multi Academy Trust,multi-academy trust + umbrella trust,,company:08582084,15888,company:08582084,PRIDE MULTI ACADEMY TRUST
+2700,Barnsbury Primary School,single-academy trust,,,,company:08798425,BARNSBURY PRIMARY SCHOOL AND NURSERY
+2701,Hemlington Hall Academy,single-academy trust,,,,company:08803871,HEMLINGTON HALL ACADEMY
+2702,Greater Manchester Sustainable Engineering UTC Limited,single-academy trust,,,,company:07652401,GREATER MANCHESTER SUSTAINABLE ENGINEERING UTC LIMITED
+2703,Diocese Of Southwell And Nottingham Multi-Academy Trust,multi-academy trust,,company:08738949,2925,company:08738949,DIOCESE OF SOUTHWELL AND NOTTINGHAM MULTI-ACADEMY TRUST
+2704,Wickersley Partnership Trust,multi-academy trust,,company:08833508,5329,company:08833508,WICKERSLEY PARTNERSHIP TRUST
+2705,Cidari Education Limited,multi-academy trust,,company:08822760,2695,company:08822760,CIDARI EDUCATION LIMITED
+2706,Ebor Academy Trust,multi-academy trust,,company:08806335,3001,company:08806335,EBOR ACADEMY TRUST
+2707,King's College London Maths School Trust,single-academy trust,,,,company:08475184,KING'S COLLEGE LONDON MATHS SCHOOL TRUST
+2708,Harlow UTC,single-academy trust,,,,company:07653629,HARLOW UTC
+2709,Aspire Multi - Academy Trust,multi-academy trust,,company:08840094,2194,company:08840094,ASPIRE MULTI - ACADEMY TRUST
+2710,"Duchy Academy Trust, The",multi-academy trust,,company:08842867,2963,company:08842867,THE DUCHY ACADEMY TRUST
+2711,The Cavendish High Academy,single-academy trust,,,,company:08789220,THE CAVENDISH HIGH ACADEMY
+2712,John Mason Academy Trust,single-academy trust,,,,company:08786136,JOHN MASON ACADEMY TRUST
+2713,Aim High Academy Trust,multi-academy trust,,company:08842629,2082,company:08842629,AIM HIGH ACADEMY TRUST
+2714,Richmond Hill Primary Academy Limited,single-academy trust,,,,company:08820308,RICHMOND HILL PRIMARY ACADEMY LIMITED
+2715,Spring Cottage Academy,single-academy trust,,,,company:08683500,SPRING COTTAGE ACADEMY
+2716,St. Catherine's Catholic Primary School (Hallam),single-academy trust + umbrella trust,,,,company:08721728,ST. CATHERINE'S CATHOLIC PRIMARY SCHOOL (HALLAM)
+2717,St. Chad's Church Of England Primary School,single-academy trust,,,,company:08441646,ST. CHAD’S CHURCH OF ENGLAND PRIMARY SCHOOL
+2718,"St Joseph's Primary School Dinnington, A Catholic Voluntary Academy",single-academy trust + umbrella trust,,,,company:08809624,"ST JOSEPH'S PRIMARY SCHOOL DINNINGTON, A CATHOLIC VOLUNTARY ACADEMY"
+2719,The Brent Primary School,single-academy trust,,,,company:08833097,THE BRENT PRIMARY SCHOOL
+2720,The Gateway Primary Academy,single-academy trust,,,,company:08830753,THE GATEWAY PRIMARY ACADEMY
+2721,"Hermitage School, The",single-academy trust,,,,company:08811135,THE HERMITAGE SCHOOL
+2722,"Skinners' School Academy Trust, The",single-academy trust,,,,company:08813021,THE SKINNERS' SCHOOL ACADEMY TRUST
+2723,Energy Coast UTC,single-academy trust,,,,company:07912940,ENERGY COAST UTC
+2724,Salisbury Sixth Form College,single-academy trust,,,,company:08257461,SALISBURY SIXTH FORM COLLEGE
+2725,KESKOWETHYANS Multi Academy Trust,multi-academy trust + umbrella trust,,company:08872161,3603,company:08872161,KESKOWETHYANS MULTI ACADEMY TRUST
+2726,"Quantock Academy, The",multi-academy trust,,company:08767576,4273,company:08767576,THE QUANTOCK ACADEMY
+2727,Shirley Manor Primary Academy,single-academy trust,,,,company:08842936,SHIRLEY MANOR PRIMARY ACADEMY
+2728,Wistaston Academy Trust,single-academy trust,,,,company:08882544,WISTASTON ACADEMY TRUST
+2729,Esher Learning Trust,multi-academy trust,,company:08812257,3053,company:08812257,ESHER LEARNING TRUST
+2730,North West Academies Trust Limited,multi-academy trust,,company:08852553,4029,company:08852553,NORTH WEST ACADEMIES TRUST LIMITED
+2731,Truro & Penwith Academy Trust,multi-academy trust,,company:08880841,5119,company:08880841,TRURO & PENWITH ACADEMY TRUST
+2732,King's Cross Academy Trust,single-academy trust,,,,company:08803983,KING'S CROSS ACADEMY TRUST
+2733,Island Community School,single-academy trust,,,,company:08265245,ISLAND COMMUNITY SCHOOL
+2734,"Salterns Academy Trust, The",multi-academy trust,,company:08921490,5647,company:08921490,THE SALTERNS ACADEMY TRUST
+2735,The Aquinas Catholic Academy Trust,multi-academy trust,,company:08901256,4929,company:08901256,THE AQUINAS CATHOLIC ACADEMY TRUST
+2736,Netheravon All Saints Academy Trust,single-academy trust,,,,company:08929419,NETHERAVON ALL SAINTS ACADEMY TRUST
+2737,Barnwell Academy Trust,multi-academy trust,,company:08929065,2239,company:08929065,BARNWELL ACADEMY TRUST
+2738,Bradfields Academy,multi-academy trust,,company:08899707,2400,company:08899707,BRADFIELDS ACADEMY
+2739,Burnage Academy for Boys,single-academy trust,,,,company:08921898,BURNAGE ACADEMY FOR BOYS
+2740,Chipstead Valley Academy Trust,multi-academy trust,,company:08891864,2666,company:08891864,CHIPSTEAD VALLEY ACADEMY TRUST
+2741,Cottesbrooke Infant and Nursery School,single-academy trust,,,,company:08936173,COTTESBROOKE INFANT AND NURSERY SCHOOL
+2742,The Crabtree Academy Trust,multi-academy trust,,company:08782792,4951,company:08782792,THE CRABTREE ACADEMY TRUST
+2743,Crossacres Primary Academy,single-academy trust,,,,company:08899140,CROSSACRES PRIMARY ACADEMY
+2744,Days Lane Primary School,single-academy trust,,,,company:08916979,DAYS LANE PRIMARY SCHOOL
+2745,Castle Trust,multi-academy trust,,company:08850163,5670,company:08850163,CASTLE TRUST
+2746,Durrington Multi Academy Trust,multi-academy trust,,company:08895870,2969,company:08895870,DURRINGTON MULTI ACADEMY TRUST
+2747,Easterside Academy,single-academy trust + umbrella trust,,,,company:08906809,EASTERSIDE ACADEMY
+2748,The Discovery Alliance Umbrella Trust,single-academy trust + umbrella trust,yes,,,company:08809385,THE DISCOVERY ALLIANCE UMBRELLA TRUST
+2749,Fairchildes Academy Community Trust,multi-academy trust,,company:08934482,3073,company:08934482,FAIRCHILDES ACADEMY COMMUNITY TRUST
+2750,Giffards Primary School,single-academy trust + umbrella trust,,,,company:08920008,GIFFARDS PRIMARY SCHOOL
+2751,The Inspirational Learning Trust,single-academy trust + umbrella trust,yes,,,company:08474688,THE INSPIRATIONAL LEARNING TRUST
+2752,Great Missenden Trust,multi-academy trust,,company:08927321,3235,company:08927321,GREAT MISSENDEN TRUST
+2753,Green Lane Primary Academy Limited,single-academy trust,,,,company:08919795,GREEN LANE PRIMARY ACADEMY LIMITED
+2754,Harlands Educational Trust,single-academy trust,,,,company:08876009,HARLANDS EDUCATIONAL TRUST
+2755,"Hermitage Trust, The",multi-academy trust,,company:08872698,3398,company:08872698,THE HERMITAGE TRUST
+2756,Hotwells Primary School Trust,single-academy trust,,,,company:08920557,HOTWELLS PRIMARY SCHOOL TRUST
+2757,LWS Academy Trust,multi-academy trust,,company:08915981,3808,company:08915981,LWS ACADEMY TRUST
+2758,Marston Green Infant Trust,single-academy trust,,,,company:08886004,MARSTON GREEN INFANT TRUST
+2759,Middleton Primary School,single-academy trust,,,,company:08922305,MIDDLETON PRIMARY SCHOOL
+2760,Pear Tree Alliance,multi-academy trust,,company:08916147,4163,company:08916147,PEAR TREE ALLIANCE
+2761,The Rainbow Multi Academy Trust,multi-academy trust,,company:08909269,5013,company:08909269,THE RAINBOW MULTI ACADEMY TRUST
+2762,King Alfred Trust,multi-academy trust,,company:08853971,3614,company:08853971,KING ALFRED TRUST
+2763,Ruislip High School,single-academy trust,,,,company:08919697,RUISLIP HIGH SCHOOL
+2764,St. Oswald's Catholic Academy Trust,multi-academy trust,,company:08924383,4776,company:08924383,ST. OSWALD'S CATHOLIC ACADEMY TRUST
+2765,Herts & Essex Multi Academy Trust,single-academy trust,,,,company:08704162,HERTS & ESSEX MULTI ACADEMY TRUST
+2766,Tredworth Infant School,single-academy trust,,,,company:08895977,TREDWORTH INFANT SCHOOL
+2767,Tytherington School,single-academy trust,,,,company:08920320,TYTHERINGTON SCHOOL
+2768,Silvertrees Academy Trust,single-academy trust,,,,company:08590916,SILVERTREES ACADEMY TRUST
+2769,Wednesbury Oak Academy Trust,single-academy trust,,,,company:08749821,WEDNESBURY OAK ACADEMY TRUST
+2770,Woodfield School,single-academy trust,,,,company:08905350,WOODFIELD SCHOOL
+2771,Wolverhampton Girls' High School,single-academy trust,,,,company:08918836,WOLVERHAMPTON GIRLS' HIGH SCHOOL
+2772,Christ the King Catholic Collegiate,multi-academy trust,,company:08933913,2681,company:08933913,CHRIST THE KING CATHOLIC COLLEGIATE
+2773,Oaks Academy Trust,multi-academy trust,,company:08924656,4070,company:08924656,OAKS ACADEMY TRUST
+2774,West Nottinghamshire Educational Trust,single-academy trust,,,,company:08337041,WEST NOTTINGHAMSHIRE EDUCATIONAL TRUST
+2775,Peterborough Diocese Education Trust,multi-academy trust,,company:08509710,4192,company:08509710,PETERBOROUGH DIOCESE EDUCATION TRUST
+2776,Adventure Learning Academy Trust,multi-academy trust,,company:08614382,2081,company:08614382,ADVENTURE LEARNING ACADEMY TRUST
+2777,Derby Diocesan Academy Trust,multi-academy trust,,company:08980079,2879,company:08980079,DERBY DIOCESAN ACADEMY TRUST
+2778,St Cuthbert's Roman Catholic Academy Trust,multi-academy trust,,company:09023802,4668,company:09023802,ST CUTHBERT'S ROMAN CATHOLIC ACADEMY TRUST
+2779,Olive Academies,multi-academy trust,,company:08747464,5605,company:08747464,OLIVE ACADEMIES
+2780,Michaela Community School,single-academy trust,,,,company:07645701,MICHAELA COMMUNITY SCHOOL
+2781,The University of Birmingham School,single-academy trust,,,,company:07960887,THE UNIVERSITY OF BIRMINGHAM SCHOOL
+2782,"McAuley Catholic High School, The",single-academy trust + umbrella trust,,,,company:08936511,THE MCAULEY CATHOLIC HIGH SCHOOL
+2783,Our Lady of Doncaster Umbrella Trust,single-academy trust + umbrella trust,yes,,,company:08927324,OUR LADY OF DONCASTER UMBRELLA TRUST
+2784,The Snaith School Academy Trust,single-academy trust,,,,company:08920524,THE SNAITH SCHOOL ACADEMY TRUST
+2785,The English Martyrs Educational Trust,multi-academy trust,,company:08962417,4962,company:08962417,THE HOLY FAMILY EDUCATION TRUST
+2786,Fairfield High School,single-academy trust,,,,company:08936256,FAIRFIELD HIGH SCHOOL
+2787,Kader Academy Trust,single-academy trust,,,,company:08927009,KADER ACADEMY TRUST
+2788,The Sandon Trust,single-academy trust,,,,company:08922806,THE SANDON TRUST
+2789,Wheatley Area Learning Trust,multi-academy trust,,,,company:08979902,WHEATLEY AREA LEARNING TRUST
+2790,New Haw Community School,multi-academy trust,,company:08718489,3981,company:08718489,NEW HAW COMMUNITY SCHOOL
+2791,Witton Park Academy Trust,single-academy trust,,,,company:08941338,WITTON PARK ACADEMY TRUST
+2792,Marylebone School Ltd,single-academy trust,,,,company:08339142,MARYLEBONE SCHOOL LTD
+2793,Beaconsfield High School,single-academy trust,,,,company:08679235,BEACONSFIELD HIGH SCHOOL
+2794,"Smallwood Academy Trust, The",multi-academy trust,,company:09118770,4556,company:09118770,THE SMALLWOOD ACADEMY TRUST
+2795,Congleton Primary Academy Trust Limited,multi-academy trust,,company:09024278,2767,company:09024278,CONGLETON PRIMARY ACADEMY TRUST LIMITED
+2796,Shaftesbury Academy Trust,multi-academy trust,,company:09040388,4493,company:09040388,SOUTHERN ACADEMY TRUST
+2797,TIMU Academy Trust,multi-academy trust,,company:09022463,5075,company:09022463,TIMU ACADEMY TRUST
+2798,Christopher Pickering Primary School,single-academy trust,,,,company:09349525,CHRISTOPHER PICKERING PRIMARY SCHOOL
+2799,Ganton School,single-academy trust,,,,company:09349673,GANTON SCHOOL
+2800,St Nicholas Primary School,single-academy trust,,,,company:09437420,ST NICHOLAS PRIMARY SCHOOL
+2801,Parallel Learning Trust,multi-academy trust,,company:08605705,4132,company:08605705,PARALLEL LEARNING TRUST
+2802,Loughborough Church of England Primary School,single-academy trust,,,,company:09023805,LOUGHBOROUGH CHURCH OF ENGLAND PRIMARY SCHOOL
+2803,William Law CE Primary School,single-academy trust,,,,company:09060417,WILLIAM LAW CE PRIMARY SCHOOL
+2804,Ironstone Academy Trust,multi-academy trust,,company:09040348,3538,company:09040348,IRONSTONE ACADEMY TRUST
+2805,Nunthorpe Primary Academy,single-academy trust,,,,company:09040156,NUNTHORPE PRIMARY ACADEMY
+2806,St Paul's Church of England Academy Trust,single-academy trust,,,,company:09102276,ST PAUL'S CHURCH OF ENGLAND ACADEMY TRUST
+2807,Idsall School,single-academy trust,,,,company:08976748,IDSALL SCHOOL
+2808,Smith's Wood Primary Academy Limited,single-academy trust,,,,company:09065312,SMITH'S WOOD PRIMARY ACADEMY LIMITED
+2809,All Saints' Academies Trust,multi-academy trust,,company:08998917,2109,company:08998917,ALL SAINTS' ACADEMIES TRUST
+2810,The Kirkstead Education Trust,multi-academy trust,,company:08977173,4986,company:08977173,THE KIRKSTEAD EDUCATION TRUST
+2811,Ryhope Infant School Academy,single-academy trust,,,,company:09161532,RYHOPE INFANT SCHOOL ACADEMY
+2812,Pyrford Church of England Primary School,single-academy trust,,,,company:08765738,PYRFORD CHURCH OF ENGLAND PRIMARY SCHOOL
+2813,Townfield Primary School,single-academy trust,,,,company:09119526,TOWNFIELD PRIMARY SCHOOL
+2814,Bengeworth CE Academy,single-academy trust,,,,company:08943457,BENGEWORTH CE ACADEMY
+2815,The Black Pear Trust Academies,multi-academy trust,,company:08922754,4936,company:08922754,THE BLACK PEAR TRUST
+2816,Chapeltown Academy Limited,single-academy trust,,,,company:08264865,CHAPELTOWN ACADEMY LIMITED
+2817,Heathrow Aviation Engineering UTC,single-academy trust,,,,company:07510578,HEATHROW AVIATION ENGINEERING UTC
+2818,East London UTC Limited,single-academy trust,,,,company:07649596,EAST LONDON UTC LIMITED
+2819,Lincoln UTC,single-academy trust,,,,company:07898536,LINCOLN UTC
+2820,Evendons Primary School Trust,single-academy trust,,,,company:08991357,EVENDONS PRIMARY SCHOOL TRUST
+2821,West Herts Community Free School Trust,multi-academy trust,,company:08324782,5265,company:08324782,WEST HERTS COMMUNITY FREE SCHOOL TRUST
+2822,WMG Academy for Young Engineers,single-academy trust,,,,company:07937014,WMG ACADEMY FOR YOUNG ENGINEERS
+2823,"St Mary's Church of England School, Norwood Green",single-academy trust,,,,company:08333406,"ST MARY'S CHURCH OF ENGLAND SCHOOL, NORWOOD GREEN"
+2824,XP School (Doncaster) Limited,single-academy trust,,,,company:08344767,XP SCHOOL (DONCASTER) LIMITED
+2825,Trinity London Academy Trust,single-academy trust,,,,company:07847013,TRINITY LONDON ACADEMY TRUST
+2826,Paxton Academy Ltd,single-academy trust,,,,company:07626303,PAXTON ACADEMY LTD
+2827,Tottenham U.T.C.,single-academy trust,,,,company:08291601,TOTTENHAM U.T.C.
+2828,Aspire Academy Trust (Harlow),single-academy trust,,,,company:08337776,ASPIRE ACADEMY TRUST (HARLOW)
+2829,Exeter Mathematics School,single-academy trust,,,,company:08515877,EXETER MATHEMATICS SCHOOL
+2830,Swindon UTC,single-academy trust,,,,company:07941864,UTC SWINDON
+2831,Discovery Learning Limited,single-academy trust,,,,company:07650604,DISCOVERY LEARNING LIMITED
+2832,Kingston Maurward Studio School Limited,single-academy trust,,,,company:08305242,KINGSTON MAURWARD STUDIO SCHOOL LIMITED
+2833,Brentwood Community Academies Trust,multi-academy trust,,company:09030028,2425,company:09030028,BRENTWOOD COMMUNITY ACADEMIES TRUST
+2834,Nottingham University Academy Of Science And Technology,single-academy trust,,,,company:08240435,NOTTINGHAM UNIVERSITY ACADEMY OF SCIENCE AND TECHNOLOGY
+2835,"Shaw Education Trust, The",multi-academy trust,,company:09067175,4499,company:09067175,THE SHAW EDUCATION TRUST
+2836,The Watford UTC,single-academy trust,,,,company:08599329,THE WATFORD UTC
+2837,"SASH School Trust, The",single-academy trust,,,,company:07956692,SASH EDUCATION TRUST
+2838,Akaal Education Trust,single-academy trust,,,,company:08334743,AKAAL EDUCATION TRUST
+2839,London Community Learning Trust,single-academy trust,,,,company:08336324,LONDON COMMUNITY LEARNING TRUST
+2840,Jubilee Primary School,single-academy trust,,,,company:08221258,JUBILEE PRIMARY SCHOOL
+2841,Big Creative Academy,single-academy trust,,,,company:08333424,BIG CREATIVE ACADEMY
+2842,"Aspire Academy Free School Trust, The",single-academy trust,,,,company:08330636,ASPIRE FREE SCHOOL ACADEMY TRUST
+2843,Crawley Free School Trust,multi-academy trust,,company:08339290,2815,company:08339290,CRAWLEY FREE SCHOOL TRUST
+2844,Blandford Education Trust,multi-academy trust,,company:09050439,2351,company:09050439,BLANDFORD EDUCATION TRUST
+2845,Barnes Academy Trust,multi-academy trust,,company:09083904,2231,company:09083904,BARNES ACADEMY TRUST
+2846,Bicester Learning Academy,multi-academy trust,,company:09053713,2305,company:09053713,BICESTER LEARNING ACADEMY
+2847,Grove Wood Academy Trust,multi-academy trust,,company:09068218,3266,company:09068218,GROVE WOOD ACADEMY TRUST
+2848,Heathland Whitefriars Federation,multi-academy trust,,company:09066965,3377,company:09066965,HEATHLAND WHITEFRIARS FEDERATION
+2849,Holy Family Academy Trust,single-academy trust + umbrella trust,,,,company:08954620,HOLY FAMILY ACADEMY TRUST
+2850,Lindley Church of England Infant School,single-academy trust,,,,company:09058698,LINDLEY CHURCH OF ENGLAND INFANT SCHOOL
+2851,Our Lady of Lourdes Catholic Multi-Academy Company,multi-academy trust,,company:09064485,4115,company:09064485,OUR LADY OF LOURDES CATHOLIC MULTI-ACADEMY COMPANY
+2852,Blessed Christopher Wharton Catholic Academy Trust,multi-academy trust,,company:09066969,2353,company:09066969,BLESSED CHRISTOPHER WHARTON CATHOLIC ACADEMY TRUST
+2853,Tudor Court Primary Academy Trust,multi-academy trust,,company:09071607,5126,company:09071607,TUDOR COURT PRIMARY ACADEMY TRUST
+2854,Innovate Multi Academy Trust,multi-academy trust,,company:09071405,3527,company:09071405,INNOVATE MULTI ACADEMY TRUST
+2855,Woodhouse Academy,single-academy trust,,,,company:09055607,WOODHOUSE ACADEMY
+2856,Francis Askew Primary School,single-academy trust,,,,company:08684162,FRANCIS ASKEW PRIMARY SCHOOL
+2857,"Eddie Davies Educational Trust, The",single-academy trust,,,,company:08318962,THE EDDIE DAVIES EDUCATIONAL TRUST
+2858,Norfolk UTC,single-academy trust,,,,company:07911472,NORFOLK UTC
+2859,East London Arts and Music,single-academy trust,,,,company:08246407,EAST LONDON ARTS AND MUSIC
+2860,Community Inclusive Trust,multi-academy trust,,company:09071623,2758,company:09071623,COMMUNITY INCLUSIVE TRUST
+2861,"LIPA Primary School, The",single-academy trust,,,,company:08314083,THE LIPA PRIMARY SCHOOL
+2862,Sevak Education Trust Ltd,multi-academy trust,,company:08267703,4487,company:08267703,SEVAK EDUCATION TRUST LTD
+2863,Holy Trinity School Academy Trust,single-academy trust,,,,company:07953354,HOLY TRINITY SCHOOL ACADEMY TRUST
+2864,Chetwynde School Limited,single-academy trust,,,,company:08963816,CHETWYNDE SCHOOL LIMITED
+2865,Manchester Creative Studio,single-academy trust,,,,company:08339878,MANCHESTER CREATIVE STUDIO
+2866,Steiner Academy Bristol,single-academy trust,,,,company:08300393,STEINER ACADEMY BRISTOL
+2867,Apollo Schools Trust,multi-academy trust,,company:08641815,2137,company:08641815,APOLLO SCHOOLS TRUST
+2868,UTC Oxfordshire Trust,single-academy trust,,,,company:08296556,UTC OXFORDSHIRE TRUST
+2869,"Blessed Edward Bamber Catholic Multi Academy Trust, The",multi-academy trust,,company:09111449,2355,company:09111449,THE BLESSED EDWARD BAMBER CATHOLIC MULTI ACADEMY TRUST
+2870,Bromley Educational Trust,multi-academy trust,,company:09028122,2465,company:09028122,BROMLEY EDUCATIONAL TRUST
+2871,Catch22 Multi Academies Trust Limited,multi-academy trust,,company:08299181,2577,company:08299181,CATCH22 MULTI ACADEMIES TRUST LIMITED
+2872,CUL Academy Trust Limited,single-academy trust,,,,company:08337957,CUL ACADEMY TRUST LIMITED
+2873,"Westminster Family School, The",single-academy trust,,,,company:08333607,THE WESTMINSTER FAMILY SCHOOL
+2874,Tower Hamlets Enterprise Academy Ltd,single-academy trust,,,,company:08632527,TOWER HAMLETS ENTERPRISE ACADEMY LTD
+2875,Fulham Boys School Limited,single-academy trust,,,,company:07650064,FULHAM BOYS SCHOOL LIMITED
+2876,Community Links Academy Trust,single-academy trust,,,,company:08341194,COMMUNITY LINKS ACADEMY TRUST
+2877,"Pope Francis Catholic Multi Academy Company, The",multi-academy trust,,company:09113542,4227,company:09113542,THE POPE FRANCIS CATHOLIC MULTI ACADEMY COMPANY
+2878,Carwarden House Community School,single-academy trust,,,,company:09050751,CARWARDEN HOUSE COMMUNITY SCHOOL
+2879,Market Harborough Church of England Academy Trust,single-academy trust,,,,company:09123741,MARKET HARBOROUGH CHURCH OF ENGLAND ACADEMY TRUST
+2880,"Mossley Academy Trust, The",multi-academy trust,,company:09104491,3940,company:09104491,THE MOSSLEY ACADEMY TRUST
+2881,North View Academy,single-academy trust,,,,company:09077521,NORTH VIEW ACADEMY
+2882,North West London Jewish Day School,single-academy trust,,,,company:09104225,NORTH WEST LONDON JEWISH DAY SCHOOL
+2883,St Peter and St Paul Catholic Primary Academy,single-academy trust,,,,company:08938098,ST PETER AND ST PAUL CATHOLIC PRIMARY ACADEMY
+2884,Holy Trinity Church Of England Academy (South Shields) Trust,multi-academy trust,,company:09098446,3464,company:09098446,HOLY TRINITY CHURCH OF ENGLAND ACADEMY (SOUTH SHIELDS) TRUST
+2885,Cherry Tree Academy Trust Marham,multi-academy trust,,company:09106277,2643,company:09106277,CHERRY TREE ACADEMY TRUST MARHAM
+2886,PolyMAT,multi-academy trust,,company:09078530,4220,company:09078530,POLYMAT
+2887,WAC Arts College,single-academy trust,,,,company:07949464,WAC ARTS COLLEGE
+2888,QEGS Blackburn Academy Trust,single-academy trust,,,,company:08331789,QEGS BLACKBURN ACADEMY TRUST
+2889,Rise Park Academy Trust,multi-academy trust,,company:09051179,4368,company:09051179,RISE PARK ACADEMY TRUST
+2890,Craven Educational Trust,multi-academy trust,,company:09023653,2813,company:09023653,CRAVEN EDUCATIONAL TRUST
+2891,Castleman Academy Trust,multi-academy trust,,company:09101036,2573,company:09101036,CASTLEMAN ACADEMY TRUST
+2892,Burton and South Derbyshire Education Trust,multi-academy trust,,company:09142556,2504,company:09142556,BURTON AND SOUTH DERBYSHIRE EDUCATION TRUST
+2893,Education And Leadership Trust,multi-academy trust,,company:08913502,3010,company:08913502,EDUCATION AND LEADERSHIP TRUST
+2894,Lion Education Trust,multi-academy trust,,company:09161091,3759,company:09161091,LION EDUCATION TRUST
+2895,The Archbishop Lanfranc Academy - Coloma Trust,single-academy trust,,,,company:09187505,THE ARCHBISHOP LANFRANC ACADEMY - COLOMA TRUST
+2896,Takely Education Trust,multi-academy trust,,company:09451372,5606,company:09451372,TAKELY EDUCATION TRUST
+2897,Rochester Diocesan Multi-Academy Education Trust,multi-academy trust,,company:08270657,4384,company:08270657,ROCHESTER DIOCESAN MULTI-ACADEMY EDUCATION TRUST
+2898,Rushey Mead Educational Trust,multi-academy trust,,company:09079258,15900,company:09079258,RUSHEY MEAD EDUCATIONAL TRUST
+2899,"Rivers C of E Multi Academy Trust, The",multi-academy trust,,company:09199371,4369,company:09199371,THE RIVERS C OF E MULTI ACADEMY TRUST
+2900,North Chadderton School,single-academy trust,,,,company:09150568,NORTH CHADDERTON SCHOOL
+2901,Pinewood School Academy Trust,single-academy trust,,,,company:09141878,PINEWOOD SCHOOL ACADEMY TRUST
+2902,Calthorpe Teaching Academy Trust,multi-academy trust,,company:09064864,2522,company:09064864,CALTHORPE TEACHING ACADEMY TRUST
+2903,Learning in Harmony Multi Academy Trust,multi-academy trust,,company:09148738,3714,company:09148738,LEARNING IN HARMONY MULTI ACADEMY TRUST
+2904,Grenestede Academy Trust,multi-academy trust,,company:09081030,3257,company:09081030,GRENESTEDE ACADEMY TRUST
+2905,Northgate High School Trust,single-academy trust,,,,company:09119498,NORTHGATE HIGH SCHOOL TRUST
+2906,Hillstone Primary School,single-academy trust,,,,company:09108745,HILLSTONE PRIMARY SCHOOL
+2907,QC School Limited,single-academy trust,,,,company:09166463,QC SCHOOL LIMITED
+2908,Gatley Academy Trust,single-academy trust,,,,company:09142319,EDUCATION LEARNING TRUST
+2909,Lawrence Sheriff School Academy Trust,single-academy trust,,,,company:08963659,LAWRENCE SHERIFF SCHOOL ACADEMY TRUST
+2910,"Stour Federation, The",multi-academy trust,,company:09174628,4851,company:09174628,THE STOUR FEDERATION
+2911,Waterton Academy Trust,multi-academy trust,,company:09124782,5228,company:09124782,WATERTON ACADEMY TRUST
+2912,Cromwell Academy,single-academy trust,,,,company:09021722,CROMWELL ACADEMY
+2913,Hampton Academies Trust,multi-academy trust,,company:09129775,3299,company:09129775,HAMPTON ACADEMIES TRUST
+2914,"Odyssey Academy Trust, The",multi-academy trust,,company:09139888,4079,company:09139888,THE ODYSSEY ACADEMY TRUST
+2915,Pear Tree Mead Academy,single-academy trust,,,,company:09141452,PEAR TREE MEAD ACADEMY
+2916,Lanesend Primary,single-academy trust,,,,company:09154494,LANESEND PRIMARY
+2917,Ryburn Valley High School,single-academy trust,,,,company:09040380,RYBURN VALLEY HIGH SCHOOL
+2918,Creative Learning Multi Academy Trust,multi-academy trust,,company:09227333,2819,company:09227333,CREATIVE LEARNING MULTI ACADEMY TRUST
+2919,Invictus Education Trust,multi-academy trust,,company:09284368,5519,company:09284368,INVICTUS EDUCATION TRUST
+2920,Northwick Park Trust,multi-academy trust,,company:09154404,4048,company:09154404,NORTHWICK PARK TRUST
+2921,Rainbow Education Multi-Academy Trust,multi-academy trust,,company:09265723,5489,company:09265723,RAINBOW EDUCATION MULTI-ACADEMY TRUST
+2922,The Diocese of Liverpool Academies Trust (Merseyside),multi-academy trust,,company:09235635,4956,company:09235635,THE DIOCESE OF LIVERPOOL ACADEMIES TRUST (MERSEYSIDE)
+2923,UTC@harbourside,single-academy trust,,,,company:08291429,UTC@HARBOURSIDE
+2924,Stone Lodge Academy Trust,single-academy trust,,,,company:09396402,STONE LODGE ACADEMY TRUST
+2925,Saint Nicholas Owen Catholic Multi Academy Company,multi-academy trust,,company:09174154,4441,company:09174154,SAINT NICHOLAS OWEN CATHOLIC MULTI ACADEMY COMPANY
+2926,"Shropshire Gateway Educational Trust, The",multi-academy trust,,company:09115941,4519,company:09115941,THE SHROPSHIRE GATEWAY EDUCATIONAL TRUST
+2927,"Rutland Learning Trust, The",multi-academy trust,,company:09199785,4422,company:09199785,THE RUTLAND LEARNING TRUST
+2928,Nicholas Postgate Academy Trust,multi-academy trust,,company:09203984,4002,company:09203984,NICHOLAS POSTGATE ACADEMY TRUST
+2929,The Howard Academy Trust,multi-academy trust,,company:09175427,16042,company:09175427,THE HOWARD ACADEMY TRUST
+2930,"Westbrook Trust, The",multi-academy trust,,company:09223515,5286,company:09223515,THE WESTBROOK TRUST
+2931,Blessed Peter Snow Catholic Academy Trust,multi-academy trust,,company:09068195,2356,company:09068195,BLESSED PETER SNOW CATHOLIC ACADEMY TRUST
+2932,"Inspire Learning Federation, The",multi-academy trust,,company:09202445,3533,company:09202445,THE INSPIRE LEARNING FEDERATION
+2933,Torfield and Saxon Mount Academy Trust,multi-academy trust,,company:09172115,5085,company:09172115,TORFIELD AND SAXON MOUNT ACADEMY TRUST
+2934,St Vincent's Catholic Primary School,single-academy trust,,,,company:08934887,ST VINCENT'S CATHOLIC PRIMARY SCHOOL
+2935,St Philomena's Catholic Primary School,single-academy trust,,,,company:09218084,ST PHILOMENA'S CATHOLIC PRIMARY SCHOOL
+2936,St. Giles' & St. George's Church Of England Academy,single-academy trust,,,,company:08863406,ST. GILES' & ST. GEORGE'S CHURCH OF ENGLAND ACADEMY
+2937,Hereford Integrated Behaviour Outreach Service,multi-academy trust,,company:09136556,3395,company:09136556,HEREFORD INTEGRATED BEHAVIOUR OUTREACH SERVICE
+2938,"Grange Trust, The",multi-academy trust,,company:09150608,3216,company:09150608,THE GRANGE TRUST
+2939,Minerva Learning Trust,multi-academy trust,,company:09200332,3921,company:09200332,MINERVA LEARNING TRUST
+2940,Castle View School Academy Trust,single-academy trust,,,,company:09146848,CASTLE VIEW SCHOOL ACADEMY TRUST
+2941,UTS Cambridge,single-academy trust,,,,company:08557665,UTS CAMBRIDGE
+2942,Acorn Multi Academy Trust,multi-academy trust,,company:09253218,2071,company:09253218,ACORN MULTI ACADEMY TRUST
+2943,Queen Elizabeth's School (Wimborne Minster),single-academy trust,,,,company:08696394,QUEEN ELIZABETH'S SCHOOL (WIMBORNE MINSTER)
+2944,Pond Meadow Academy Trust,single-academy trust,,,,company:09148900,POND MEADOW ACADEMY TRUST
+2945,St Mary's Catholic Primary School,single-academy trust,,,,company:09258843,ST MARY'S CATHOLIC PRIMARY SCHOOL
+2946,Children's Academy Trust Ltd,multi-academy trust,,company:09061804,2658,company:09061804,CHILDREN'S ACADEMY TRUST LTD
+2947,Willows Academy Trust,multi-academy trust,,company:09093035,5351,company:09093035,WILLOWS ACADEMY TRUST
+2948,Sparken Hill Academy Trust,single-academy trust,,,,company:09250922,SPARKEN HILL ACADEMY TRUST
+2949,Avocet Academy Trust,multi-academy trust,,company:09254238,2212,company:09254238,AVOCET ACADEMY TRUST
+2950,St Joseph's Catholic Primary School,single-academy trust,,,,company:09301212,ST JOSEPH'S CATHOLIC PRIMARY SCHOOL
+2951,"Carnovian Alliance, The",multi-academy trust,,company:09221695,5443,company:09221695,THE CORNOVIAN ALLIANCE
+2952,Immaculate Conception Academy Trust,single-academy trust + umbrella trust,,,,company:09269589,IMMACULATE CONCEPTION ACADEMY TRUST
+2953,Mildmay Junior School,single-academy trust,,,,company:09295450,MILDMAY JUNIOR SCHOOL
+2954,Amaya Trust,multi-academy trust,,company:09155473,5607,company:09155473,AMAYA TRUST
+2955,Pyrgo Priory Academy Trust,single-academy trust,,,,company:08382992,PYRGO PRIORY ACADEMY TRUST
+2956,"Banovallum School Academy Trust, The",single-academy trust,,,,company:09289718,THE BANOVALLUM SCHOOL ACADEMY TRUST
+2957,Howard Junior School,single-academy trust,,,,company:09280654,APOLLO ACADEMIES TRUST
+2958,"Engage, Enrich, Excel academies",multi-academy trust,,company:09279884,3039,company:09279884,"ENGAGE, ENRICH, EXCEL ACADEMIES"
+2959,Bridgewater High School,single-academy trust,,,,company:09286883,BRIDGEWATER HIGH SCHOOL
+2960,"Bridge Integrated Learning Space Ltd, The",multi-academy trust,,company:08343491,5461,company:08343491,THE BRIDGE INTEGRATED LEARNING SPACE LTD
+2961,Green Meadow Primary School,single-academy trust,,,,company:09333191,GREEN MEADOW PRIMARY SCHOOL
+2962,Midfield Primary School,single-academy trust,,,,company:09333163,MIDFIELD PRIMARY SCHOOL
+2963,Sefton Education Trust,multi-academy trust,,company:08307770,5520,company:08307770,SEFTON EDUCATION TRUST
+2964,Stanwix School,multi-academy trust,,company:09341344,5446,company:09341344,STANWIX SCHOOL
+2965,AD Astra Academy Trust,multi-academy trust,,company:09308398,5445,company:09308398,AD ASTRA ACADEMY TRUST
+2966,Townlands C of E Primary Academy,single-academy trust,,,,company:09326643,TOWNLANDS C OF E PRIMARY ACADEMY
+2967,Brambleside Academy Trust,single-academy trust,,,,company:09212934,BRAMBLESIDE ACADEMY TRUST
+2968,St Luke Academies Trust,multi-academy trust,,company:09436283,5521,company:09436283,ST LUKE ACADEMIES TRUST
+2969,"Keys Federation, The",multi-academy trust,,company:09306360,5444,company:09306360,THE KEYS FEDERATION
+2970,Somerset Road Education Trust,multi-academy trust,,company:09343767,5447,company:09343767,SOMERSET ROAD EDUCATION TRUST
+2971,Northwood Park Educational Trust,multi-academy trust,,company:09341839,16099,company:09341839,NORTHWOOD PARK EDUCATIONAL TRUST
+2972,"Diocese of Chichester Academy Trust, The",multi-academy trust,,company:09201845,5488,company:09201845,DIOCESE OF CHICHESTER ACADEMY TRUST
+2973,Lumen Christi Catholic Multi Academy Company,multi-academy trust,,company:09471525,5609,company:09471525,LUMEN CHRISTI CATHOLIC MULTI ACADEMY COMPANY
+2974,Derby Diocesan Academies Trust 2,multi-academy trust,,company:09442311,5593,company:09442311,DERBY DIOCESAN ACADEMY TRUST 2
+2975,"Learning Partnership Trust, The",multi-academy trust,,company:09380027,5490,company:09380027,THE LEARNING PARTNERSHIP TRUST
+2976,Hinckley Academy and John Cleveland Sixth Form Centre,single-academy trust,,,,company:09318755,HINCKLEY ACADEMY AND JOHN CLEVELAND SIXTH FORM CENTRE
+2977,Greenacre School Trust,multi-academy trust,,company:08102025,5610,company:08102025,GREENACRE SCHOOL TRUST
+2978,Little Acorn Trust,multi-academy trust,,company:09207180,5471,company:09207180,LITTLE ACORN TRUST
+2979,Hungerford Primary Academy,single-academy trust,,,,company:09361618,HUNGERFORD PRIMARY ACADEMY
+2980,"Good Shepherd Multi Academy Trust, The",multi-academy trust,,company:09341374,5476,company:09341374,THE GOOD SHEPHERD MULTI ACADEMY TRUST
+2981,King Edward's Stourbridge Academy Trust,multi-academy trust,,company:09361342,5523,company:09361342,KING EDWARD'S AND HALESOWEN COLLEGES' ACADEMY TRUST
+2982,St Thomas More Catholic Comprehensive School,single-academy trust,,,,company:09350239,ST THOMAS MORE CATHOLIC COMPREHENSIVE SCHOOL
+2983,GSSC Academy Trust,single-academy trust,,,,company:09319299,GSSC ACADEMY TRUST
+2984,Radcliffe Academy,multi-academy trust,,company:09334026,5473,company:09334026,RADCLIFFE ACADEMY
+2985,"Ridings Trust, The",multi-academy trust,,company:09290889,5477,company:09290889,THE RIDINGS TRUST
+2986,Esher Church School,single-academy trust,,,,company:09362801,ESHER CHURCH SCHOOL
+2987,"Lime Academy Trust, The",multi-academy trust,,company:09297519,5470,company:09297519,THE LIME ACADEMY TRUST
+2988,"Minerva Learning Trust (Dorset) Limited, The",multi-academy trust,,company:08561222,16098,company:08561222,THE MINERVA LEARNING TRUST (DORSET)
+2989,"Holy Spirit Catholic Multi Academy, The",multi-academy trust,,company:09432692,5524,company:09432692,THE HOLY SPIRIT CATHOLIC MULTI ACADEMY COMPANY
+2990,South Devon UTC,single-academy trust,,,,company:08293776,SOUTH DEVON UTC
+2991,Godinton Academy Trust,single-academy trust,,,,company:09404783,GODINTON ACADEMY TRUST
+2992,TEACH Poole,multi-academy trust,,company:09484306,5611,company:09484306,TEACH POOLE
+2993,Wimborne Academy Trust,multi-academy trust,,company:09362004,5526,company:09362004,WIMBORNE ACADEMY TRUST
+2994,Ashton West End Primary School,single-academy trust,,,,company:09388819,ASHTON WEST END PRIMARY ACADEMY
+2995,"Sir Donald Bailey Academy, The",single-academy trust,,,,company:09443602,THE FORGE TRUST
+2996,Castle Hill Academy,single-academy trust,,,,company:09332834,CASTLE HILL ACADEMY
+2997,Castledon School Academy Trust,single-academy trust,,,,company:09425197,CASTLEDON SCHOOL ACADEMY TRUST
+2998,Viking Academy Trust,multi-academy trust,,company:09449979,5531,company:09449979,VIKING ACADEMY TRUST
+2999,Pope John XXIII Catholic Multi Academy Company,multi-academy trust,,company:09441910,5532,company:09441910,POPE JOHN XXIII CATHOLIC MULTI ACADEMY COMPANY
+3000,The Moorlands Primary Federation,multi-academy trust,,company:09378112,15774,company:09378112,THE MOORLANDS PRIMARY FEDERATION
+3001,St Martin's Multi Academy Trust,multi-academy trust,,company:09443906,5533,company:09443906,ST MARTIN'S MULTI ACADEMY TRUST
+3002,West Stafford Multi-Academy Trust,multi-academy trust,,company:09422746,5612,company:09422746,WEST STAFFORD MULTI-ACADEMY TRUST
+3003,"Levels Academy Trust, The",multi-academy trust,,company:09437439,5602,company:09437439,THE LEVELS ACADEMY TRUST
+3004,Willow Tree Academy,multi-academy trust,,company:09440025,5613,company:09440025,WILLOW TREE ACADEMY
+3005,Isebrook SEN Cognition & Learning College,single-academy trust,,,,company:09392862,ISEBROOK SEN COGNITION & LEARNING COLLEGE
+3006,The Silk Academy Trust,multi-academy trust,,company:09427476,5536,company:09427476,THE SILK ACADEMY TRUST
+3007,Piper Hill Learning Trust,multi-academy trust,,company:09392787,5537,company:09392787,PIPER HILL LEARNING TRUST
+3008,Saint Cecilia's Church of England School,single-academy trust,,,,company:09413691,SAINT CECILIA'S CHURCH OF ENGLAND SCHOOL
+3009,Health Futures UTC Ltd,single-academy trust,,,,company:08257814,HEALTH FUTURES UTC LTD
+3010,Pax Christi Catholic Partnership,multi-academy trust,,company:09378390,5539,company:09378390,PAX CHRISTI CATHOLIC PARTNERSHIP
+3011,Ipswich Primary Academies Trust,multi-academy trust,,company:09434926,5540,company:09434926,IPSWICH PRIMARY ACADEMIES TRUST
+3012,Future Generation Trust,multi-academy trust,,company:09440033,5541,company:09440033,FUTURE GENERATION TRUST
+3013,Building Futures Enterprise Academy Trust,multi-academy trust,,company:09408861,5542,company:09408861,BUILDING FUTURES ENTERPRISE ACADEMY TRUST
+3014,"Fitzwimarc School Academy Trust, The",single-academy trust,,,,company:09434988,THE FITZWIMARC SCHOOL ACADEMY TRUST
+3015,Windsor Learning Partnership,multi-academy trust,,company:09409109,5544,company:09409109,WINDSOR LEARNING PARTNERSHIP
+3016,Windhill Academy Trust,single-academy trust,,,,company:09433068,WINDHILL ACADEMY TRUST
+3017,Leaders in Learning Multi Academy Trust,multi-academy trust,,company:09482529,16008,company:09482529,LEADERS IN LEARNING MULTI ACADEMY TRUST
+3018,Manor Multi Academy Trust,multi-academy trust,,company:09323792,16011,company:09323792,MANOR MULTI ACADEMY TRUST
+3019,Kingston Educational Trust (North Kingston Secondary School),single-academy trust,,,,company:08334023,KINGSTON EDUCATIONAL TRUST
+3020,Trinity Academy Newcastle,multi-academy trust,,company:08449062,16041,company:08449062,TRINITY ACADEMY NEWCASTLE
+3021,Premier Learning Trust Limited,multi-academy trust,,company:10065284,16090,company:10065284,PREMIER LEARNING TRUST LIMITED
+3022,Yorkshire and Humberside Co-operative Academies Trust,multi-academy trust,,company:09332738,5614,company:09332738,YORKSHIRE AND HUMBERSIDE CO-OPERATIVE ACADEMIES TRUST
+3023,The Temple Learning Foundation,single-academy trust,,,,company:08816454,THE TEMPLE LEARNING FOUNDATION
+3024,Beddington Park Academy Trust,single-academy trust,,,,company:09498825,BEDDINGTON PARK ACADEMY TRUST
+3025,University of Brighton Academies Trust,multi-academy trust,,company:09466013,5615,company:09466013,UNIVERSITY OF BRIGHTON ACADEMIES TRUST
+3026,Fair Field Junior School,multi-academy trust,,company:09434766,5616,company:09434766,FAIR FIELD JUNIOR SCHOOL
+3027,"Irthlingborough And Finedon Learning Trust, The",multi-academy trust,,company:09470229,5617,company:09470229,THE IRTHLINGBOROUGH AND FINEDON LEARNING TRUST
+3028,Holy Innocents Catholic Primary School,single-academy trust,,,,company:09483921,HOLY INNOCENTS CATHOLIC PRIMARY SCHOOL
+3029,Huntington Primary Academy,single-academy trust,,,,company:09468412,HUNTINGTON PRIMARY ACADEMY
+3030,Prestolee Multi Academy Trust,multi-academy trust,,company:09481323,5618,company:09481323,PRESTOLEE MULTI ACADEMY TRUST
+3031,"Shire Multi Academy Trust, The",multi-academy trust,,company:09454169,5619,company:09454169,THE SHIRE MULTI ACADEMY TRUST
+3032,St Catherine of SIENA Multi Academy Company,multi-academy trust,,company:09497062,5620,company:09497062,ST CATHERINE OF SIENA MULTI ACADEMY COMPANY
+3033,Our Lady Of Grace Catholic Academy Trust,multi-academy trust,,company:09435396,5621,company:09435396,OUR LADY OF GRACE CATHOLIC ACADEMY TRUST
+3034,Arete Learning Trust,multi-academy trust,,company:09471240,5622,company:09471240,ARETÉ LEARNING TRUST
+3035,The Cardinal Vaughan Memorial School,single-academy trust,,,,company:09482572,THE CARDINAL VAUGHAN MEMORIAL SCHOOL
+3036,Withernsea Primary Academy Trust,single-academy trust,,,,company:09474500,WITHERNSEA PRIMARY ACADEMY TRUST
+3037,East Cheshire Youth Achievement Free School Ltd,single-academy trust,,,,company:08827502,EAST CHESHIRE YOUTH ACHIEVEMENT FREE SCHOOL LTD
+3038,Knowledge School Trust,multi-academy trust,,company:09027131,15756,company:09027131,KNOWLEDGE SCHOOL TRUST
+3039,Bolton UTC,single-academy trust,,,,company:08292380,BOLTON UTC
+3040,Channeling Positivity,single-academy trust,,,,company:09017575,CHANNELING POSITIVITY
+3041,Excell3 Independent Schools Ltd,multi-academy trust,,company:07654452,15751,company:07654452,EXCELL3 INDEPENDENT SCHOOLS LTD
+3042,Grove House School,single-academy trust,,,,company:08953180,GROVE HOUSE SCHOOL
+3043,"Ongar Academy Trust, The",single-academy trust,,,,company:09000501,THE ONGAR ACADEMY TRUST
+3044,Parkwood Hall Co-operative Academy Trust,single-academy trust,,,,company:09494940,PARKWOOD HALL CO-OPERATIVE ACADEMY TRUST
+3045,South Wiltshire UTC Limited,single-academy trust,,,,company:08282488,SOUTH WILTSHIRE UTC LIMITED
+3046,St. James And Emmanuel Academy Trust Ltd,multi-academy trust,,company:08652284,15753,company:08652284,ST. JAMES AND EMMANUEL ACADEMY TRUST LTD
+3047,Every Child Matters Academy Trust,multi-academy trust,,company:09700223,15872,company:09700223,EVERY CHILD MATTERS ACADEMY TRUST
+3048,The Challenger Multi Academy Trust,multi-academy trust,,company:09270040,15771,company:09270040,THE CHALLENGER MULTI ACADEMY TRUST
+3049,drb Ignite Multi Academy Trust,multi-academy trust,,company:09284055,15873,company:09284055,DRB IGNITE MULTI ACADEMY TRUST
+3050,Salopia Catholic Schools Trust,multi-academy trust,,company:09646093,5709,company:09646093,SALOPIA CATHOLIC SCHOOLS TRUST
+3051,"Romero Catholic Academy, The",multi-academy trust,,company:09702162,15711,company:09702162,THE ROMERO CATHOLIC ACADEMY
+3052,Hoe Valley School,single-academy trust,,,,company:08833418,HOE VALLEY SCHOOL
+3053,Creative Industries UTC,single-academy trust,,,,company:07893811,CREATIVE INDUSTRIES UTC
+3054,Activate Learning Education Trust,multi-academy trust,,company:08707909,15710,company:08707909,ACTIVATE LEARNING EDUCATION TRUST
+3055,St Edmundsbury and Ipswich Diocesan Multi-Academy Trust,multi-academy trust,,company:09499496,15712,company:09499496,ST EDMUNDSBURY AND IPSWICH DIOCESAN MULTI-ACADEMY TRUST
+3056,Inspire Education Trust,multi-academy trust,,company:09728614,15799,company:09728614,INSPIRE EDUCATION TRUST
+3057,St Philip Howard Catholic Academy Trust,single-academy trust,,,,company:09686896,ST PHILIP HOWARD CATHOLIC ACADEMY TRUST
+3058,Haileybury Academy Trust,single-academy trust,,,,company:09659808,HAILEYBURY ACADEMY TRUST
+3059,Forest Bridge School Ltd,single-academy trust,,,,company:08872579,FOREST BRIDGE SCHOOL LTD
+3060,The Edge Academy Trust,single-academy trust,,,,company:08829472,THE EDGE ACADEMY TRUST
+3061,Medway UTC Ltd,single-academy trust,,,,company:07911362,MEDWAY UTC LTD
+3062,TCAT Multi Academy Trust,multi-academy trust,,company:09709935,15796,company:09709935,TCAT MULTI ACADEMY TRUST
+3063,The Small Schools Multi Academy Trust,multi-academy trust,,company:09613632,15715,company:09613632,THE SMALL SCHOOLS MULTI ACADEMY TRUST
+3064,Ocean Learning Trust,multi-academy trust,,company:09628750,5708,company:09628750,OCEAN LEARNING TRUST
+3065,West Oxford Schools Trust,multi-academy trust,,company:09591931,15720,company:09591931,WEST OXFORD SCHOOLS TRUST
+3066,Wynyard Church of England Primary School,single-academy trust,,,,company:09012630,WYNYARD CHURCH OF ENGLAND PRIMARY SCHOOL
+3067,Akaal Academy Trust Derby Limited,single-academy trust,,,,company:08628019,AKAAL ACADEMY TRUST DERBY LIMITED
+3068,Plymouth Studio School,single-academy trust,,,,company:08318068,PLYMOUTH STUDIO SCHOOL
+3069,The WREN School Academy Trust,single-academy trust,,,,company:09200220,THE WREN SCHOOL ACADEMY TRUST
+3070,GEMS Learning Trust,multi-academy trust,,company:08346116,15754,company:08346116,GEMS LEARNING TRUST
+3071,Derby Manufacturing UTC,single-academy trust,,,,company:08289534,DERBY MANUFACTURING UTC
+3072,Humber UTC Limited,single-academy trust,,,,company:08351953,HUMBER UTC LIMITED
+3073,Mayflower Specialist School Academy Trust,multi-academy trust,,company:09610951,5704,company:09610951,MAYFLOWER SPECIALIST SCHOOL ACADEMY TRUST
+3074,Medway Anglican Schools Trust,multi-academy trust,,company:09628754,15779,company:09628754,MEDWAY ANGLICAN SCHOOLS TRUST
+3075,The Oak Academy Trust,single-academy trust,,,,company:09604912,THE OAK ACADEMY TRUST
+3076,"Sabden Multi Academy Trust, The",multi-academy trust,,company:09611796,15776,company:09611796,THE SABDEN MULTI ACADEMY TRUST
+3077,Saturn Education Trust,multi-academy trust,,company:09578698,5702,company:09578698,SATURN EDUCATION TRUST
+3078,Bridgnorth Area Schools' Trust,multi-academy trust,,company:09617166,5705,company:09617166,BRIDGNORTH AREA SCHOOLS' TRUST
+3079,The Three Saints Academy Trust,multi-academy trust,,company:09626002,15718,company:09626002,THE THREE SAINTS ACADEMY TRUST
+3080,St Joseph's Catholic Primary Voluntary Academy Retford,single-academy trust + umbrella trust,,,,company:09622777,ST JOSEPH'S CATHOLIC PRIMARY VOLUNTARY ACADEMY RETFORD
+3081,Waingels Academies Trust,single-academy trust,,,,company:09620043,WAINGELS ACADEMIES TRUST
+3082,Manor Hall Academy Trust,multi-academy trust,,company:09461655,15716,company:09461655,MANOR HALL ACADEMY TRUST
+3083,Polam Hall Educational Trust,single-academy trust,,,,company:08829554,POLAM HALL EDUCATIONAL TRUST
+3084,Cirrus Primary Academy Trust,multi-academy trust,,company:09642581,15781,company:09642581,CIRRUS PRIMARY ACADEMY TRUST
+3085,Yorkshire Collaborative Academy Trust,multi-academy trust,,company:09668526,15713,company:09668526,YORKSHIRE COLLABORATIVE ACADEMY TRUST
+3086,The Warriner Multi Academy Trust,multi-academy trust,,company:09696059,15719,company:09696059,THE WARRINER MULTI ACADEMY TRUST
+3087,Holy Trinity Catholic Multi Academy Company,multi-academy trust,,company:10013691,16045,company:10013691,HOLY TRINITY CATHOLIC MULTI ACADEMY COMPANY
+3088,Learning for Life Trust,multi-academy trust,,company:09690231,15717,company:09690231,LEARNING FOR LIFE TRUST
+3089,St Mary's Catholic Primary Schools Trust,multi-academy trust,,company:09693822,15794,company:09693822,ST MARY'S CATHOLIC PRIMARY SCHOOLS TRUST
+3090,Amadeus Primary Academies Trust,multi-academy trust,,company:09662313,15787,company:09662313,AMADEUS PRIMARY ACADEMIES TRUST
+3091,PA Community Trust,multi-academy trust,,company:09718257,15797,company:09718257,PA COMMUNITY TRUST
+3092,Sharples School A Multi Academy Trust,multi-academy trust,,company:09677469,16119,company:09677469,SHARPLES SCHOOL A MULTI ACADEMY TRUST
+3093,Ignite Education Trust,single-academy trust + umbrella trust,yes,,,company:09749664,IGNITE EDUCATION TRUST
+3094,Oaklands Primary Academy,single-academy trust + umbrella trust,,,,company:09712111,OAKLANDS PRIMARY ACADEMY
+3095,Birchwood Academy Trust,multi-academy trust,,company:09679683,15789,company:09679683,BIRCHWOOD ACADEMY TRUST
+3096,The Derwent Trust,multi-academy trust,,company:09648418,15784,company:09648418,THE DERWENT TRUST
+3097,Shavington Academy,multi-academy trust,,company:09587693,15775,company:09587693,SHAVINGTON ACADEMY
+3098,Penlee Academy Trust,multi-academy trust,,company:09683218,15791,company:09683218,PENLEE ACADEMY TRUST
+3099,Inspired Learning Multi Academy Trust,multi-academy trust,,company:09692208,15793,company:09692208,INSPIRED LEARNING MULTI ACADEMY TRUST
+3100,Harlow Inspirational Learning Trust,multi-academy trust,,company:09791050,15897,company:09791050,HARLOW INSPIRATIONAL LEARNING TRUST
+3101,Thomas's Academy,single-academy trust,,,,company:09635397,THOMAS'S ACADEMY
+3102,Hailey Hall Academy Trust,single-academy trust,,,,company:09691510,HAILEY HALL ACADEMY TRUST
+3103,Venn Academy Trust,multi-academy trust,,company:09662303,15786,company:09662303,VENN ACADEMY TRUST
+3104,King Edward VI Education Trust,multi-academy trust,,company:09635329,15780,company:09635329,KING EDWARD VI EDUCATION TRUST
+3105,St Alban Catholic Academies Trust,multi-academy trust,,company:09660515,15785,company:09660515,ST ALBAN CATHOLIC ACADEMIES TRUST
+3106,Argent Trust,multi-academy trust,,company:09646939,15782,company:09646939,ARGENT TRUST
+3107,South Newcastle Trust,multi-academy trust,,company:09679560,15863,company:09679560,SOUTH NEWCASTLE TRUST
+3108,Our Lady of Light Catholic Academy Trust,multi-academy trust,,company:09676023,15788,company:09676023,OUR LADY OF LIGHT CATHOLIC ACADEMY TRUST
+3109,Suffolk Academies Trust,multi-academy trust,,company:09702333,15795,company:09702333,SUFFOLK ACADEMIES TRUST
+3110,Sovereign Trust,multi-academy trust,,company:09666511,15966,company:09666511,THE SOVEREIGN TRUST
+3111,Lever Academy Trust,multi-academy trust,,company:09677480,15950,company:09677480,LEVER ACADEMY TRUST
+3112,Compass Academy Trust,multi-academy trust,,company:09323096,15773,company:09323096,COMPASS ACADEMY TRUST
+3113,"Russett Learning Trust, The",multi-academy trust,,company:09617195,15777,company:09617195,THE RUSSETT LEARNING TRUST
+3114,Cockermouth School Academy,single-academy trust,,,,company:09679536,COCKERMOUTH SCHOOL ACADEMY
+3115,Lincolnshire Wolds Community Trust,multi-academy trust,,company:09691946,15792,company:09691946,LINCOLNSHIRE WOLDS COMMUNITY TRUST
+3116,Elmwey Learning Trust,multi-academy trust,,company:09625982,15778,company:09625982,ELMWEY LEARNING TRUST
+3117,Highfields School,multi-academy trust,,company:09527057,15951,company:09527057,HIGHFIELDS SCHOOL
+3118,St Hilda’s Catholic Academy Trust,multi-academy trust,,company:09811711,15901,company:09811711,ST HILDA’S CATHOLIC ACADEMY TRUST
+3119,The Kite Academy Trust,multi-academy trust,,company:09785186,15864,company:09785186,THE KITE ACADEMY TRUST
+3120,The Pathway Academy Trust,multi-academy trust,,company:09782388,15865,company:09782388,THE PATHWAY ACADEMY TRUST
+3121,Elston Hall Multi Academy Trust,multi-academy trust,,company:09780473,15866,company:09780473,ELSTON HALL MULTI ACADEMY TRUST
+3122,Bournemouth Primary MAT,multi-academy trust,,company:09754024,15868,company:09754024,BOURNEMOUTH PRIMARY MAT
+3123,Newlands Girls' School,single-academy trust,,,,company:09683579,NEWLANDS GIRLS' SCHOOL
+3124,Riviera Primary Academy Trust,multi-academy trust,,company:09751294,15867,company:09751294,RIVIERA PRIMARY ACADEMY TRUST
+3125,The Crescent School Academy Trust,single-academy trust,,,,company:09771413,THE CRESCENT SCHOOL ACADEMY TRUST
+3126,Sparkle Multi-Academy Trust,multi-academy trust,,company:09741508,15870,company:09741508,SPARKLE MULTI-ACADEMY TRUST
+3127,Mid-Trent Multi Academy Trust,multi-academy trust,,company:09878928,16012,company:09878928,MID-TRENT MULTI ACADEMY TRUST
+3128,"Bournemouth, Septenary Trust",single-academy trust + umbrella trust,yes,,,company:08709369,BOURNEMOUTH SEPTENARY TRUST
+3129,Kingsleigh Primary School,single-academy trust + umbrella trust,,,,company:09872178,KINGSLEIGH PRIMARY SCHOOL
+3130,Kinson Primary School,single-academy trust + umbrella trust,,,,company:09874674,KINSON PRIMARY SCHOOL
+3131,Lent Rise School,single-academy trust,,,,company:09801986,LENT RISE SCHOOL
+3132,Moordown St John's Church of England Primary School,single-academy trust + umbrella trust,,,,company:09881224,MOORDOWN ST JOHN'S CHURCH OF ENGLAND PRIMARY SCHOOL
+3133,Muscliff Primary School,single-academy trust + umbrella trust,,,,company:09872386,MUSCLIFF PRIMARY SCHOOL
+3134,Brite Trust,multi-academy trust,,company:09795288,15899,company:09795288,BRITE TRUST
+3135,The Learning for Life Partnership,multi-academy trust,,company:09675372,15952,company:09675372,THE LEARNING FOR LIFE PARTNERSHIP
+3136,St Mark's Church of England Primary School,single-academy trust + umbrella trust,,,,company:09875389,ST MARK'S CHURCH OF ENGLAND PRIMARY SCHOOL
+3137,St Michael's Church of England Primary School,single-academy trust,,,,company:09894699,ST MICHAEL'S CHURCH OF ENGLAND PRIMARY SCHOOL
+3138,Winton Primary School,single-academy trust,,,,company:09903139,WINTON PRIMARY SCHOOL
+3139,Crewe Multi Academy Trust,multi-academy trust,,company:09379253,15964,company:09379253,CREWE MULTI ACADEMY TRUST
+3140,River Tees Multi-Academy Trust,multi-academy trust,,company:09861442,16068,company:09861442,RIVER TEES MULTI-ACADEMY TRUST
+3141,The Heath Academy Trust,multi-academy trust,,company:09809895,15953,company:09809895,THE HEATH ACADEMY TRUST
+3142,Abney Trust,multi-academy trust,,company:09912859,16015,company:09912859,ABNEY TRUST
+3143,Discover Multi Academy Trust,multi-academy trust,,company:09680241,15954,company:09680241,DISCOVER MULTI ACADEMY TRUST
+3144,The Blue Kite Academy Trust,multi-academy trust,,company:09889819,16016,company:09889819,THE BLUE KITE ACADEMY TRUST
+3145,Cascade Multi Academy Trust,multi-academy trust,,company:09913676,16003,company:09913676,CASCADE MULTI ACADEMY TRUST
+3146,The Inspire Multi Academy Trust (South West),multi-academy trust,,company:09916360,15967,company:09916360,THE INSPIRE MULTI ACADEMY TRUST (SOUTH WEST)
+3147,Thedwastre Education Trust,multi-academy trust,,company:09896672,15968,company:09896672,THEDWASTRE EDUCATION TRUST
+3148,Rivermead Inclusive Trust,multi-academy trust,,company:09853252,15969,company:09853252,RIVERMEAD INCLUSIVE TRUST
+3149,Spring Common Academy Trust,multi-academy trust,,company:09896071,15970,company:09896071,SPRING COMMON ACADEMY TRUST
+3150,All Saints Trust,multi-academy trust,,company:09887971,15971,company:09887971,ALL SAINTS' TRUST
+3151,Mulberry Academy Trust,multi-academy trust,,company:09648420,16072,company:09648420,MULBERRY ACADEMY TRUST
+3152,Burnt Ash Primary School,single-academy trust + umbrella trust,,,,company:09896945,BURNT ASH PRIMARY SCHOOL
+3153,Cockburn Multi Academy Trust,multi-academy trust,,company:09946495,16004,company:09946495,COCKBURN MULTI ACADEMY TRUST
+3154,Good Shepherd Catholic Primary & Nursery School,single-academy trust,,,,company:09918358,GOOD SHEPHERD CATHOLIC PRIMARY & NURSERY SCHOOL
+3155,Cygnus Academies Trust,multi-academy trust,,company:09950137,16005,company:09950137,CYGNUS ACADEMIES TRUST
+3156,"St Thomas More Catholic Primary, a Voluntary Academy",single-academy trust,,,,company:09888339,"ST THOMAS MORE CATHOLIC PRIMARY, A VOLUNTARY ACADEMY"
+3157,Northern Saints Catholic Education Trust,multi-academy trust,,company:09940352,16013,company:09940352,NORTHERN SAINTS CATHOLIC EDUCATION TRUST
+3158,Haybrook College Trust,multi-academy trust,,company:09606079,15958,company:09606079,HAYBROOK COLLEGE TRUST
+3159,Leading Learning Trust,multi-academy trust,,company:10028278,16108,company:10028278,LEADING LEARNING TRUST
+3160,South Bank Multi Academy Trust,multi-academy trust,,company:10067116,16073,company:10067116,SOUTH BANK MULTI ACADEMY TRUST
+3161,Link Academy Trust,multi-academy trust,,company:10049068,16074,company:10049068,LINK ACADEMY TRUST
+3162,"Royal County of Berkshire Schools Trust, The",multi-academy trust,,company:10052450,16123,company:10052450,THE ROYAL COUNTY OF BERKSHIRE SCHOOLS TRUST
+3163,Portico Academy Trust,multi-academy trust,,company:09952066,16070,company:09952066,PORTICO ACADEMY TRUST
+3164,Aston Tower Multi-Academy Trust,multi-academy trust,,company:10034419,16075,company:10034419,ASTON TOWER MULTI-ACADEMY TRUST
+3165,Plym Academy Trust,multi-academy trust,,company:10056460,16124,company:10056460,PLYM ACADEMY TRUST
+3166,Kendal Primary Multi Academy Trust,multi-academy trust,,company:09996478,16076,company:09996478,KENDAL PRIMARY MULTI ACADEMY TRUST
+3167,Chiltern Way Academy Trust,multi-academy trust,,company:10004115,16077,company:10004115,CHILTERN WAY ACADEMY TRUST
+3168,"Talentum Learning Trust, The",multi-academy trust,,company:09999238,16078,company:09999238,THE TALENTUM LEARNING TRUST
+3169,"Bolton Impact Trust, The",multi-academy trust,,company:09971348,16066,company:09971348,THE BOLTON IMPACT TRUST
+3170,Excellence in Education Trust,multi-academy trust,,company:10035934,16079,company:10035934,EXCELLENCE IN EDUCATION TRUST
+3171,Urbis Academy Trust,multi-academy trust,,company:10035844,16080,company:10035844,URBIS ACADEMY TRUST
+3172,Alexandra Academy Trust,multi-academy trust,,company:09978459,16120,company:09978459,ALEXANDRA ACADEMY TRUST
+3173,Southgate School Academy Trust,multi-academy trust,,company:10039553,16081,company:10039553,SOUTHGATE SCHOOL ACADEMY TRUST
+3174,St Aidans Catholic Primary School,single-academy trust,,,,company:10045230,ST AIDAN'S CATHOLIC PRIMARY SCHOOL
+3175,St Chads Catholic Primary School,single-academy trust,,,,company:10037192,ST CHAD'S CATHOLIC PRIMARY SCHOOL
+3176,St Thomas of Canterbury Catholic Academies Trust,multi-academy trust,,company:09980467,16084,company:09980467,ST THOMAS OF CANTERBURY CATHOLIC ACADEMIES TRUST
+3177,St. Thomas of Canterbury Catholic Multi Academy Trust,multi-academy trust,,company:10034058,16085,company:10034058,ST.THOMAS OF CANTERBURY CATHOLIC MULTI ACADEMY TRUST
+3178,"Southfield Trust, The",multi-academy trust,,company:10042321,16086,company:10042321,THE SOUTHFIELD TRUST
+3179,Five Rivers Multi Academy Trust,multi-academy trust,,company:10070417,16110,company:10070417,FIVE RIVERS MULTI ACADEMY TRUST
+3180,Comenius Trust,multi-academy trust,,company:10049139,16063,company:10049139,COMENIUS TRUST
+3181,Nexus Multi Academy Trust,multi-academy trust,,company:10075893,16125,company:10075893,NEXUS MULTI ACADEMY TRUST
+3182,Raedwald Trust,multi-academy trust,,company:08702099,16111,company:08702099,RAEDWALD TRUST
+3183,The Academy for Character and Excellence,multi-academy trust,,company:10098444,16126,company:10098444,THE ACADEMY FOR CHARACTER AND EXCELLENCE
+3184,ACE Schools Multi Academy Trust,multi-academy trust,,company:10038640,16122,company:10038640,ACE SCHOOLS MULTI ACADEMY TRUST
+3185,"Creative Learning Partnership Trust, The",multi-academy trust,,company:10226712,16165,company:10226712,THE CREATIVE LEARNING PARTNERSHIP TRUST
+3186,Ickford Learning Trust,single-academy trust,,,,company:10160645,ICKFORD LEARNING TRUST
+3187,Inspire Education Community Trust,multi-academy trust,,company:10155032,16127,company:10155032,INSPIRE EDUCATION COMMUNITY TRUST
+3188,Bolton and Farnworth Church of England Primary Multi Academy Trust,multi-academy trust,,company:10261477,16166,company:10261477,BOLTON AND FARNWORTH CHURCH OF ENGLAND PRIMARY MULTI ACADEMY TRUST
+3189,Bronte Academy Trust,multi-academy trust,,company:10201636,16146,company:10201636,BRONTE ACADEMY TRUST
+3190,Harbourside Learning Partnership,multi-academy trust,,company:10161526,16147,company:10161526,HARBOURSIDE LEARNING PARTNERSHIP
+3191,Learners' Trust,multi-academy trust,,company:10224802,16148,company:10224802,LEARNERS' TRUST
+3192,Streetsbrook Academy Trust,multi-academy trust,,company:10225404,16149,company:10225404,STREETSBROOK ACADEMY TRUST
+3193,The South East Stafford Academy Trust,multi-academy trust,,company:10178490,16151,company:10178490,THE SOUTH EAST STAFFORD ACADEMY TRUST
+3194,Inspiration Academy Trust,multi-academy trust,,company:10174100,16152,company:10174100,INSPIRATION ACADEMY TRUST
+3195,Salisbury Plain Academies,multi-academy trust,,company:10163646,16153,company:10163646,SALISBURY PLAIN ACADEMIES
+3196,BASE Academy Trust,multi-academy trust,,company:10227910,16167,company:10227910,BASE ACADEMY TRUST
+3197,"Tilian Partnership, The",multi-academy trust,,company:10259334,16168,company:10259334,THE TILIAN PARTNERSHIP
+3198,VENN Academy Learning Trust,multi-academy trust,,company:10249712,16169,company:10249712,VENN ACADEMY LEARNING TRUST
+3199,Warrington Primary Academy Trust,multi-academy trust,,company:10181707,16170,company:10181707,WARRINGTON PRIMARY ACADEMY TRUST
+3200,"Consortium Multi-Academy Trust, The",multi-academy trust,,company:10255142,16171,company:10255142,THE CONSORTIUM MULTI-ACADEMY TRUST
+3201,Whinless Down Academy Trust,multi-academy trust,,company:10253931,16172,company:10253931,WHINLESS DOWN ACADEMY TRUST
+3202,Richmond West Schools Trust,multi-academy trust,,company:10081995,16241,company:10081995,THE RICHMOND WEST SCHOOLS TRUST

--- a/lists/edubase-umbrella-trusts/trusts.csv
+++ b/lists/edubase-umbrella-trusts/trusts.csv
@@ -1,0 +1,20 @@
+name,is-umbrella
+Askel Veur (Diocese of Truro Academies Umbrella Trust),yes
+"Bournemouth, Septenary Trust",yes
+Canterbury Diocesan Umbrella Trust,yes
+Hallam: De La Salle Academy Trust,yes
+Hamwic Trust,yes
+Ignite Education Trust,yes
+London Diocesan Board for Schools,yes
+"Marian Catholic Academy Trust, The",yes
+North East Essex Education Partnership,yes
+Our Lady of Doncaster Umbrella Trust,yes
+Our Lady Seat of Wisdom,yes
+Our Lady's,yes
+Portsmouth and Winchester Diocesan Academy Umbrella Trust,yes
+The Consortium of Community Trusts,yes
+The Discovery Alliance Umbrella Trust,yes
+The Holy Spirit Umbrella Trust,yes
+The Inspirational Learning Trust,yes
+The South Leicestershire Learning Partnership,yes
+Wakefield Diocesan Umbrella Trust,yes


### PR DESCRIPTION
Update school trust data with all school trusts listed in edubase.

Manually matched trusts to companies house companies, where they were not already matched in edubase.

Manually identified which trusts are umbrella trusts when a school had two trusts listed.

Makefile steps to match a school with its school-trust and school-umbrella-trust keys.

Add updated alpha data for school-eng and school-trust register.