### PR TITLE
School organisation type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,18 @@ lists/religious-ethos/ethos.tsv:  cache/establishmentdetails
 	@mkdir -p lists/religious-ethos
 	./bin/religious-ethos.sh > $@
 
-data/alpha/school-eng/schools.tsv: mix.deps data/discovery/school-eng/schools.tsv
+data/alpha/school-eng/schools.tsv: data/discovery/school-eng/schools.tsv
 	@mkdir -p data/alpha/school-eng
 	[[ -e $@ ]] || \
 	csvgrep -tc school-authority -m "919" < data/discovery/school-eng/schools.tsv \
 	| sed 's/school-authority,/school-authority-eng,/' \
+	| csvformat -T > schools.tsv \
+	&& ruby ./bin/school-organisation.rb > school-organisations.tsv \
+	&& csvjoin --left -tc school-eng,school-eng2 schools.tsv school-organisations.tsv \
+	| csvcut -c school-eng,name,address,school-authority-eng,minimum-age,maximum-age,headteacher,religious-characters,religious-ethos,dioceses,organisation,school-phases,school-admissions-policy,school-gender,school-tags,start-date,end-date \
 	| csvformat -T \
 	> $@
+	rm -f schools.tsv school-organisations.tsv
 
 data/alpha/la-maintained-school-eng/la-maintained-schools.tsv: data/alpha/school-eng/schools.tsv
 	@mkdir -p data/alpha/la-maintained-school-eng

--- a/bin/school-organisation.rb
+++ b/bin/school-organisation.rb
@@ -1,0 +1,33 @@
+require 'morph'
+
+def load file, type
+  Morph.from_tsv IO.read(file), type
+end
+
+def type_codes file, types
+  type_names = IO.readlines(file).map(&:strip)
+  types.select {|t| type_names.include?(t.name)}.map(&:school_type)
+end
+
+schools = load('./schools.tsv', :school) ; nil
+
+types = load('./data/alpha/school-type/school-types.tsv', :type) ; nil
+
+la_types = type_codes('./lists/la-maintained-types/types.txt', types)
+academy_types = type_codes('./lists/academy-types/types.txt', types)
+
+schools.each do |school|
+  type = school.school_type
+  school.organisation = if la_types.include? type
+                          "la-maintained-school:#{school.school_eng}"
+                        elsif academy_types.include? type
+                          "academy-school:#{school.school_eng}"
+                        else
+                          "school-type:#{type}"
+                        end
+end
+
+puts ['school-eng2','organisation'].join("\t")
+schools.each do |school|
+  puts [school.school_eng, school.organisation].join("\t")
+end

--- a/data/alpha/school-eng/schools.tsv
+++ b/data/alpha/school-eng/schools.tsv
@@ -1,882 +1,882 @@
-school-eng	name	address	school-authority-eng	minimum-age	maximum-age	headteacher	religious-characters	religious-ethos	dioceses	school-type	school-phases	school-admissions-policy	school-gender	school-tags	start-date	end-date
-102256	Purcell School	9B1AK1J	919	8	19	Mr Stephen Yeo				11			M		1962-10-11	
-117065	Weston Way Nursery School	2X6MXMZY	919	3	5	Ms Jane Millett				15	NUR		M			
-117066	Arlesdene Nursery School and Pre-School	4D4TEC	919	2	5	Mrs Catherine Croft				15	NUR		M			
-117067	Greenfield Nursery School	4D4SBT	919	2	4	Mrs Deborah Harrison				15	NUR		M			
-117068	Batford Nursery School	2X6MTFQ8	919	2	5	Mrs Sue Mansfield				15	NUR		M			
-117069	Birchwood Nursery School	2X6MTB00	919	2	5	Mrs Kathryn Evans				15	NUR		M			
-117070	Heath Lane Nursery School	9AQJZND	919	3	5	Mrs Pauline Kirtley				15	NUR		M			
-117071	York Road Nursery School	2X6MXJA5	919	3	5	Mrs Helen Griffiths				15	NUR		M			
-117072	Rye Park Nursery School	4D5GWB	919	2	5	Mrs Helen Ackerman				15	NUR		M			
-117073	Nevells Road Nursery School	9C3H97E	919	3	5	Mrs M J Tyler				15	NUR		M			2001-12-31
-117074	Muriel Green Nursery School	2X6MHB38	919	3	5	Mrs B Snijder				15	NUR		M			2001-01-01
-117075	London Colney Nursery School	2X6MTBMX	919	3	5	Ms Barbara Fitton				15	NUR		M			2015-03-31
-117076	Kingswood Nursery School	2X6MYGEW	919	2	5	Mrs Bernice Jackson				15	NUR		M			
-117077	Oxhey Early Years Centre	2X6MYCMV	919	3	5	Mrs Rachel Fagan				15	NUR		M			
-117078	Tenterfield Nursery School	2X6MTG52	919	3	5	Mrs Megan Wilcox				15	NUR		M			
-117079	Ludwick Nursery School	2X6MTH2N	919	2	5	Mrs Karen James				15	NUR		M			
-117080	Peartree Way Nursery School	9C3QP0K	919	2	5	Mrs Deborah Willcox				15	NUR		M			
-117081	Wall Hall Nursery School	9B1AK8C	919	3	5	Ms Cynthia Willey				15	NUR		M			2003-12-31
-117082	Lea Valley Education Support Centre	9ACAQBC	919	5	16	Mrs A Brown				14			M		1995-09-01	2009-08-31
-117083	Abbots Langley School	5T8FR7NZ	919	3	11	Mr Roger Billing				1	PRI		M			
-117084	Ashwell Primary School	9C3H2ZH	919	3	11	Mrs Lisa Hall				1	PRI		M			
-117085	Northgate Primary School	2X6MTK10	919	3	11	Mrs Deirdre Glasgow				1	PRI		M			2012-07-31
-117086	Bovingdon Junior School	2X6MV9QV	919	7	11	  				1	PRI		M			1998-09-01
-117087	Jenyns First School and Nursery	9B09NDE	919	3	9	Mrs Sandra Morris				1	PRI		M			
-117088	Bushey Heath Primary School	9B1AJWD	919	3	11	Ms Penny Barefoot				1	PRI		M			
-117089	Highwood Primary School	9B1AK0C	919	3	11	 Della Allen				1	PRI		M			
-117090	Merry Hill Infant School and Nursery	9B1AJY1	919	3	7	Mrs Melissa Regnier				1	PRI		M			
-117091	Holdbrook Primary School	4D50QJ	919	3	11	Mr Nick Heald				1	PRI		M			
-117092	Four Swannes Primary School	4D50QH	919	3	11	Mrs G E Jones				1	PRI		M			
-117093	Chorleywood Primary School	5T8FR9MQ	919	3	11	Mrs Rebecca Roberts				1	PRI		M			
-117094	Beechfield School	9A2MXPG	919	3	11	Mr James Roach				1	PRI		M			
-117095	New Briars Primary and Nursery School	2X6MTBHG	919	3	11	Miss Helen Turner				1	PRI		M			2007-08-31
-117096	Shepherd Primary	5T8FR93G	919	3	11	Mrs Claire Foad				1	PRI		M			
-117097	Hobletts Manor Junior School	5T8FVQCE	919	7	11	Mrs Sally Short				1	PRI		M			
-117098	The Russell School	5T8FR999	919	3	11	Mrs Claire Pitt				1	PRI		M			
-117099	Cowley Hill School	9B1AJ1X	919	3	11	 Jon Hood				1	PRI		M			
-117100	Flamstead Village School	2X6MTE37	919	3	11	Ms Sarah Jones				1	PRI		M			
-117101	Gaddesden Row JMI School	9A2N6TH	919	4	11	Mr Nick Read				1	PRI		M			
-117102	Sauncey Wood Primary School	5T8GM330	919	4	11	Mr Steven Lloyd				1	PRI		M			
-117103	Manland Primary School	2X6MTFDJ	919	4	11	Miss Melanie Smith				1	PRI		M			
-117104	Gascoyne Cecil Junior School	2X6MTB4W	919	7	11	Mr D Petherick				1	PRI		M			1999-09-01
-117105	Green Lanes Primary School	2X6MTBHN	919	5	11	 Michele Johnson				1	PRI		M			
-117106	George Street Primary School	5T8JQF7A	919	3	11	Mrs Heather Freeman				1	PRI		M			
-117107	Boxmoor Primary School	5T8JQEZ2	919	4	11	Mrs Vicky Campos				1	PRI		M			
-117108	Two Waters Primary School	2X6MV9Y3	919	3	11	Mr Tim Gately				1	PRI		M			
-117109	Tudor Primary School	2X6MVAE8	919	3	11	Mr Rob Weightman				1	PRI		M			
-117110	South Hill Primary School	9A2N6DJ	919	5	11	Mr David Smith				1	PRI		M			
-117111	Abel Smith School	9B09VV9	919	2	11	Mrs Gillian Langan				1	PRI		M			
-117112	Hexton Junior Mixed and Infant School	9C3H2AA	919	4	11	Mrs Joanne Webb				1	PRI		M			
-117113	Highbury Infant School and Nursery	2X6MXHN8	919	3	7	Mrs Helen Avey				1	PRI		M			
-117114	Strathmore Infant and Nursery School	5T8GM5Z2	919	3	7	Mrs Bernadette Holmes				1	PRI		M			
-117115	Highover Junior Mixed and Infant School	2X6MXGR1	919	3	11	Mrs Lisa Hayes				1	PRI		M			
-117116	Wilshere-Dacre Junior School	9C3H8GG	919	7	11	Mrs Susan Sheffield				1	PRI		M			2014-02-28
-117117	Hunsdon Junior Mixed and Infant School	9B09WAB	919	4	11	Mr Jonathan Millward				1	PRI		M			
-117118	Kimpton Primary School	2X6MXHA3	919	3	11	Mrs Tracy Clements				1	PRI		M			
-117119	Breachwood Green Junior Mixed and Infant School	9C3H4CS	919	4	11	Mrs Rosemarie Bethel				1	PRI		M			
-117120	Knebworth Primary and Nursery School	9C3H3W0	919	3	11	 Michael John				1	PRI		M			
-117121	Wilbury Junior School	2X6MXM4C	919	7	11	Miss Ellie Shaw				1	PRI		M			
-117122	Grange Junior School	2X6MXMAX	919	7	11	Miss Zoe Mathie				1	PRI		M			
-117123	Hillshott Infant School and Nursery	2X6MXKC1	919	3	7	Mrs Lucy Leighton				1	PRI		M			
-117124	Westbury Primary and Nursery School	9C3H9JV	919	3	11	Mrs Anna Marshall				1	PRI		M			2009-08-31
-117125	Hertford Heath Primary and Nursery School	9B09MHA	919	3	11	Mrs Janice Smith				1	PRI		M			
-117126	Little Hadham Primary School	9B09XQM	919	4	11	Mrs Elizabeth Stockley				1	PRI		M			
-117127	Markyate Village School and Nursery	5T8JQERT	919	4	11	Miss Sally Esom				1	PRI		M			
-117128	Pirton School	5T8GM5Z6	919	4	11	Mrs Joanne Webb				1	PRI		M			
-117129	Reed First School	2X6MXNM0	919	3	9	Mrs Jackie Harvey				1	PRI		M			
-117130	Yorke Mead Primary School	5T8FRBSD	919	3	11	Ms Lucille Pollard				1	PRI		M			
-117131	Harvey Road Primary School	5T8FR9S8	919	3	11	Mr Nick Rowlands				1	PRI		M			
-117132	Little Green Junior School	5T8FR9SA	919	7	11	Mrs Janice Tearle				1	PRI		M			
-117133	Malvern Way Infant and Nursery School	5T8FR9SP	919	3	7	Mrs Emma Cole				1	PRI		M			
-117134	Tannery Drift School	2X6MXNAM	919	3	9	Mrs Anna Greetham				1	PRI		M			
-117135	Bernards Heath Infant and Nursery School	2X6MTANG	919	3	7	Mrs Hannah Rimmer				1	PRI		M			
-117136	Camp Primary and Nursery School	5T8JAKCQ	919	3	11	Mrs Sharon Barton				1	PRI		M			
-117137	Fleetville Junior School	5T8JAG03	919	7	11	Mr J Loukes				1	PRI		M		1997-02-26	2012-05-31
-117138	Fleetville Infant and Nursery School	2X6MTAHR	919	3	7	Mrs Androulla Peek				1	PRI		M		1996-06-05	2012-05-31
-117139	Garden Fields Junior Mixed and Infant School	5T8JAKZZ	919	5	11	Mr Chris Jukes				1	PRI		M			
-117140	St Peter's School	2X6MT9N0	919	3	11	Mrs Gillie Young				1	PRI		M			
-117141	Aboyne Lodge Junior Mixed and Infant School	2X6MTDHF	919	3	11	Mrs Amanda Abley				1	PRI		M			
-117142	Mandeville Primary School	2X6MT9TB	919	3	11	Ms Amanda Godfrey				1	PRI		M			2012-12-31
-117143	Bernards Heath Junior School	5T8JAQW9	919	7	11	Mrs Sian Kilpatrick				1	PRI		M			
-117144	St Paul's Walden Primary School	2X6MXHA2	919	4	11	 Louise Cerqua				1	PRI		M			
-117145	Colney Heath Junior Mixed Infant and Nursery School	2X6MTEC1	919	4	11	Mr Pete Rose				1	PRI		M			
-117146	London Colney Primary & Nursery School	2X6MTBMW	919	3	11	Mrs Sarah Joyce				1	PRI		M			
-117147	Sandon Junior Mixed and Infant School	2X6MXNX1	919	4	11	Mrs Margaret Gilbert				1	PRI		M			
-117148	Sandridge School	2X6MTEVR	919	4	11	Miss Lisa Roberts				1	PRI		M			
-117149	Fawbert and Barnard Infants' School	9B09WDC	919	3	7	Ms Angela Euesden				1	PRI		M			
-117150	Shenley Primary School	9B1AHCZ	919	3	11	Ms Katy Longley				1	PRI		M			
-117151	Letchmore Infants' and Nursery School	9C3QN7X	919	3	7	Mrs Roma Marshall				1	PRI		M			
-117152	Fairlands Primary School and Nursery	9C3QN1A	919	3	11	Mr Robert Staples				1	PRI		M			
-117153	Therfield First School	2X6MXNSQ	919	5	9	Mrs Tara McGovern				1	PRI		M			
-117154	Walkern Primary School	2X6MXFT3	919	4	11	Mr Jonty Hall				1	PRI		M			
-117155	The Orchard Primary School	2X6MYG70	919	3	11	Mr Paul Sutton				1	PRI		M			
-117156	Central Primary School	5T8FR0MP	919	3	11	Mr John Mynott				1	PRI		M			
-117157	Bushey and Oxhey Infant School	5T8FR2HA	919	5	7	Mrs Mary Ann Cooper				1	PRI		M			
-117158	Chater Junior School	2X6MYDFF	919	7	11	Mr P McEntee				1	PRI		M			
-117159	Chater Infant School	2X6MYDDS	919	3	7	 Amrit Bal-Richards				1	PRI		M			
-117160	Field Junior School	2X6MYE01	919	7	11	Mrs Julie Henley-Washford				1	PRI		M			
-117161	Watford Field School (Infant & Nursery)	5T8FR161	919	3	7	Mrs Angela Butcher				1	PRI		M			
-117162	Parkgate Junior School	2X6MYFQH	919	7	11	Mrs Sarah Pipe				1	PRI		M			
-117163	Parkgate Infants' and Nursery School	2X6MYFQM	919	3	7	Miss A E Lawrence				1	PRI		M			
-117164	Garston Infants' School	9A2MY3R	919	5	7	Mrs J Sexton				1	PRI		M			2005-08-31
-117165	Knutsford School	2X6MYFQJ	919	3	11	Miss Eileen Anderson				1	PRI		M			
-117166	St Meryl School	2X6MYCWQ	919	3	11	Mrs Michele Geddes				1	PRI		M			
-117167	Cassiobury Junior School	5T8FR15R	919	7	11	Miss Jenny Sherry				1	PRI		M			
-117168	Kingsway Junior School	2X6MYGF8	919	7	11	Mr Darren Armoogum				1	PRI		M			
-117169	Warren Dell Primary School	5T8FR6C3	919	2	11	Mrs Jenny Morley				1	PRI		M			
-117170	Oxhey Wood Primary School	5T8FRCN0	919	3	11	Mrs Jenny Morley				1	PRI		M			
-117171	Watton-at-Stone Primary and Nursery School	9B09WXE	919	2	11	Mrs Zoe Hussain				1	PRI		M			
-117172	Peartree Primary School	2X6MTH0Y	919	5	11	Miss Clare Herbert				1	PRI		M			
-117173	Blackthorn Junior School	2X6MTH0W	919	7	11	Mrs S Jennings				1	PRI		M			2001-12-31
-117174	Templewood Primary School	5T8JHBRH	919	3	11	Miss Angharad Morris				1	PRI		M			
-117175	Holwell Primary School	2X6MTH11	919	5	11	Mr Joe McIntyre				1	PRI		M			
-117176	Widford School	9B09WXS	919	4	11	Mrs Diane Penn				1	PRI		M			
-117177	Wymondley Junior Mixed and Infant School	2X6MXGZ4	919	4	11	Mrs Alison Emmerson				1	PRI		M			
-117178	Tanners Wood Junior Mixed and Infant School	2X6MYKRX	919	3	11	Mrs Parv Qureshi				1	PRI		M			
-117179	Havers Infant School		919	3	7	Mrs J J Evans				1	PRI		M			2005-12-31
-117180	Hurst Drive Primary School	4D4SBR	919	4	11	Mr Chris O'Connor				1	PRI		M			
-117181	Woodlands Primary School	9B1AJ1Y	919	3	11	Mrs PJ Woods				1	PRI		M			
-117182	Summerswood Primary School	9B1AHM6	919	3	11	Miss Sarah Kneller				1	PRI		M			
-117183	Kenilworth Primary School	9B1AHNW	919	3	11	Ms S Jayasuriya				1	PRI		M			
-117184	Meryfield Primary School	9B1AJ14	919	3	11	Mrs Rosemarie Alexander				1	PRI		M			
-117185	Salisbury Infants' School	5T8JHBZT	919	5	7	Mrs M Rimell				1	PRI		M			1999-09-01
-117186	Icknield Infant and Nursery School	2X6MXM4M	919	3	7	Mrs J Egan				1	PRI		M			
-117187	Bowmansgreen Primary School	5T8JAMAR	919	4	11	Ms Anna Lippa				1	PRI		M			
-117188	Margaret Wix Primary School	5T8JAM3C	919	3	11	Mr Damien Johnston				1	PRI		M			
-117189	Broom Barns Community Primary School	9C3QMW8	919	4	11	Mrs Jayne Currant				1	PRI		M			
-117190	Lea Farm Junior School	9A2MY3R	919	7	11	Mrs J M Graham				1	PRI		M			2005-08-31
-117191	Alban Wood Junior School	5T8FR162	919	7	11	Mr K Sampey				1	PRI		M			2005-08-31
-117192	Little Furze Junior Mixed and Infant School	5T8FR6C5	919	3	11	Mr D G Dougans				1	PRI		M			2004-12-16
-117193	Greenfields Primary School	2X6MYCZB	919	3	11	Mrs Helen Cook				1	PRI		M			
-117194	Woodhall Primary School	5T8FR714	919	3	11	Mrs E Lesley Spence				1	PRI		M			
-117195	Saffron Green Primary School	9B1AHQY	919	3	11	Mrs Linda Storey				1	PRI		M			
-117196	Hazelgrove Primary School	2X6MTBHG	919	4	11	Mr J S Dunford				1	PRI		M			2004-08-31
-117197	Hobletts Manor Infants' School	9A2N6M9	919	3	7	Mrs Wendy Hull				1	PRI		M			
-117198	Chaulden Junior School	2X6MZR56	919	7	11	Ms Pam Stocks				1	PRI		M			2013-04-30
-117199	Roebuck Junior School	9C3QNHH	919	7	11	Mr R K Jones				1	PRI		M			2001-04-18
-117200	Bedwell Primary School	9C3QP13	919	4	11	Mrs J E Moore				1	PRI		M			
-117201	Flamstead End Junior School	4D4PHZ	919	7	11	Mr Don Round				1	PRI		M			2003-08-31
-117202	Chaulden Infants' and Nursery	9A2N7AH	919	3	7	Mrs Jacqueline Susan Hood				1	PRI		M			
-117203	Haslewood Junior School	4D5EGC	919	7	11	Mr J Schmitt				1	PRI		M			2002-12-31
-117204	Roebuck Infant School	9C3QNHH	919	3	7	Mrs M A Dodds				1	PRI		M			2001-04-18
-117205	Peartree Spring Junior School	5T8FDF2Q	919	7	11	Mrs Teresa Skeggs				1	PRI		M			2014-08-31
-117206	Peartree Spring Primary School	9ADG70Z	919	4	11	Mrs Teresa Skeggs				1	PRI		M			
-117207	Longmeadow Junior School	5T8FDGYV	919	7	11	Mr T Longhurst				1	PRI		M			2005-08-31
-117208	Longmeadow Infant and Nursery School	5T8FDGYV	919	3	7	Mrs J Wilson				1	PRI		M			2005-08-31
-117209	Bandley Hill Junior School	9C3QPDF	919	7	11	  				1	PRI		M			1998-03-20
-117210	Bandley Hill Infants' School	9C3QPDF	919	5	7	  				1	PRI		M			1998-03-20
-117211	Roundwood Primary School	5T8JAR3E	919	3	11	Mrs Suzanne Webb				1	PRI		M			
-117212	Wheatfields Junior Mixed School	5T8JAQYW	919	7	11	Mr Lyndon Evans				1	PRI		M			
-117213	Thumbswood Infant School	2X6MTH0X	919	5	7	Mr P J Steven				1	PRI		M			2001-12-31
-117214	Chambersbury Primary School	2X6MVA2W	919	3	11	Mr Desmond Taylor				1	PRI		M			
-117215	Broadfield Junior School	5T8JQEN7	919	7	11	Mr Matthew Heasman				1	PRI		M			2007-12-31
-117216	Broadfield Infants' School	2X6MV4MW	919	3	7	Mrs Jane Prior				1	PRI		M			2007-12-31
-117217	Windermere Primary School	2X6MTAYM	919	5	11	Mrs Davina Raftery				1	PRI		M			
-117218	Anstey First School	9B1RAP4	919	2	9	Mrs Amy Myers				1	PRI		M			
-117219	Monksmead School	9B1AHNH	919	2	11	Mrs Cathy Elsley				1	PRI		M			
-117220	Howe Dell Primary School	9AE9DVC	919	3	11	Mrs Debra Massey				1	PRI		M			
-117221	Almond Hill Junior School	5T8FDH6F	919	7	11	Mrs Judith Lovelock				1	PRI		M			
-117222	Oakwood Primary School	2X6MTEAJ	919	4	11	Ms Zoe Buckley				1	PRI		M			
-117223	Northfields Infants and Nursery School	2X6MXMBX	919	3	7	Miss Claire Logan				1	PRI		M			
-117224	Purwell Primary School	5T8GM5YV	919	3	11	Mr Richard Cano				1	PRI		M			
-117225	Killigrew Junior School	5T8JAQST	919	7	11	Mrs Tracy Mylotte				1	PRI		M			2008-08-31
-117226	Camps Hill Community Primary School	9C3QPE3	919	2	11	Mrs Emma Flawn				1	PRI		M			
-117227	Harwood Hill Junior Mixed Infant and Nursery School	5T8JHBHC	919	3	11	Miss Yvette Page				1	PRI		M			
-117228	Fair Field Junior School	9B1AHFC	919	7	11	Mr Matt Johnson				5	PRI		M			2015-03-31
-117229	Creswick Primary and Nursery School	9AE9DWC	919	4	11	Mrs Fay Brett				1	PRI		M			
-117230	Thorley Hill Primary School	2X6MTKB4	919	3	11	Mrs Kim Perez				1	PRI		M			
-117231	Micklem Primary School	2X6MTSD9	919	3	11	Miss Elizabeth Ormonde				1	PRI		M			
-117232	Mayfield Infants' School and Nursery	4D5476	919	3	7	Mrs Brenda Mitchell				1	PRI		M			2010-08-31
-117233	Brookland Junior School	4D559A	919	7	11	Mr Gavin Douglas				1	PRI		M			
-117234	The Reddings Primary School	2X6MVA2V	919	3	11	Miss Tracy Prickett				1	PRI		M			
-117235	How Wood Primary and Nursery School	5T8JAQT4	919	3	11	Mrs Cynthia Rowe				1	PRI		M			
-117236	Redbourn Infants' and Nursery School	9AQQSA1	919	3	7	Mrs Jane C Byrne				1	PRI		M			
-117237	Lodge Farm Junior Mixed School	9C3QPF8	919	7	11	Mrs L Stinchcombe				1	PRI		M			2000-04-30
-117238	Lodge Farm Infants' School	9C3QPF8	919	3	7	Mrs C Rodbard				1	PRI		M			2000-04-30
-117239	Rossgate Primary School	2X6MTSE6	919	3	11	Mrs Margaret Priggs				1	PRI		M			2008-08-31
-117240	Skyswood Primary & Nursery School	2X6MTEVX	919	3	11	Mr Robert Bridle				1	PRI		M			
-117241	Martindale Primary and Nursery School	2X6MTSDA	919	3	11	Mrs Jill Litchfield				1	PRI		M			2008-08-31
-117242	Bushey Manor Junior School	9B1AK1Q	919	7	11	Miss Kate Fiddler				1	PRI		M			
-117243	Goffs Oak Primary & Nursery School	4D4RPT	919	3	11	Ms Michelle Matthews				1	PRI		M			
-117244	Summercroft Junior School	9B09V9Y	919	7	11	Mr Michael Smith				1	PRI		M			2005-12-31
-117245	Eastbury Farm Primary School	5T8FRA25	919	3	11	Mrs Baljit Ahluwalia				1	PRI		M			
-117246	Burydale Junior School	9C3QNZ0	919	7	11	Miss L Hodgson				1	PRI		M			2005-08-31
-117247	Shephall Green Infant and Nursery School	5T8FDGVQ	919	3	7	Ms Lee Rieksts				1	PRI		M			2005-08-31
-117248	Bedmond Village Primary and Nursery School	5T8FR7WQ	919	3	11	Mrs Emma Woollon				1	PRI		M			
-117249	Gade Valley Primary School	2X6MZ9HS	919	3	11	Mr Daniel Barron				1	PRI		M			
-117250	Cunningham Hill Junior School	5T8JAKE5	919	7	11	Ms J Elbourne-Cload				1	PRI		M			
-117251	Pin Green Primary School and Nursery	9C3QNNT	919	4	11	Ms Carole Sangster				1	PRI		M			2005-08-31
-117252	Homerswood Primary and Nursery School	5T8JHBMF	919	3	11	Mrs Debbie Shirley				1	PRI		M			
-117253	Whitehill Junior School	2X6MXHN9	919	7	11	Mr Steve Mills				1	PRI		M			
-117254	Westfield Primary School and Nursery	5T8JQF0C	919	3	11	Mrs Suzanne Stace				1	PRI		M			
-117255	Downfield Primary School	4D50X6	919	2	11	Miss Sarah Goldsmith				1	PRI		M			
-117256	Pixies Hill Primary School	2X6MTSD7	919	4	11	Mr Martin Smith				1	PRI		M			
-117257	Rowans Primary School	2X6MTGAS	919	3	11	Mrs Joanne Reed				1	PRI		M			
-117258	The Grove Junior School	2X6MTEXS	919	7	11	Ms Maggie Clifford				1	PRI		M			
-117259	Pixmore Junior School	2X6MXJY8	919	7	11	Mrs Alex Evans				1	PRI		M			
-117260	Swing Gate Infant School and Nursery	2X6MVB3M	919	3	7	Mrs Francesca Gallagher				1	PRI		M			
-117261	Oaklands Primary School	2X6MTFVS	919	5	11	Mrs Julie Petitt				1	PRI		M			
-117262	Flamstead End Infant and Nursery School	4D4PHY	919	3	7	Mrs S A Killey				1	PRI		M			2003-08-31
-117263	Hollybush Primary School	9B09VVZ	919	3	11	Mr Alan Brown				1	PRI		M			
-117264	Oughtonhead Junior School	5T8GM5Z3	919	7	11	Mrs A Kibby				1	PRI		M			2001-09-01
-117265	Oughtonhead Infants' School	5T8GM5Z3	919	3	7	Mrs D Hallett				1	PRI		M			2001-09-01
-117266	Maple Cross Junior Mixed Infant and Nursery School	5T8FR8QR	919	4	11	Mr Duncan Roberts				1	PRI		M			
-117267	Killigrew Infant and Nursery School	5T8JAQST	919	3	7	Miss Tracy Mylotte				1	PRI		M			2008-08-31
-117268	Wheatfields Infants' and Nursery School	9AQQQ70	919	3	7	Mrs Jane Whitehurst				1	PRI		M			
-117269	Moss Bury Primary School and Nursery	9C3QP1W	919	3	11	Mr Gareth Linwood				1	PRI		M			
-117270	Westfield Community Primary School	4D5C6Q	919	5	11	Mrs Diane Ashmore				1	PRI		M			
-117271	Priors Wood Primary School	2X6MXAJ9	919	3	11	Mrs Rebecca Collins				1	PRI		M			
-117272	Brookland Infant and Nursery School	4D5THA	919	3	7	Mrs Alison Atkinson				1	PRI		M			
-117273	Summercroft Infant and Nursery School	9B09V9Y	919	3	7	Miss C Evans				1	PRI		M			2005-12-31
-117274	Goldfield Infants' and Nursery School	5T8JQEW6	919	3	7	Mrs Debbie Stevens				1	PRI		M			
-117275	Tower Primary School	9B09WW3	919	2	11	Mrs Joanne Lyness				1	PRI		M			
-117276	Greenway Primary and Nursery School	2X6MVBEG	919	3	11	Mrs Katharine Ellwood				1	PRI		M			
-117277	Thorn Grove Primary School	2X6MTM1G	919	3	11	Mr Pete Luck				1	PRI		M			
-117278	Icknield Walk First School	2X6MXNF3	919	3	9	Mrs Jane Sherwood				1	PRI		M			
-117279	Cunningham Hill Infant School	9AQQSA0	919	5	7	Mrs Charlotte Cooper				1	PRI		M			
-117280	Reedings Junior School	9B09WC0	919	7	11	Mrs Laura Webber				1	PRI		M			
-117281	The Grove Infant and Nursery School	2X6MTF03	919	3	7	Ms Anna Archer				1	PRI		M			
-117282	The Hammond Primary School	5T8JQEQF	919	5	11	Ms Gail Porterfield				1	PRI		M			2011-07-31
-117283	Kings Langley Primary School	5T8JQEXY	919	3	11	Mrs Paula Harris				1	PRI		M			
-117284	Forres Primary School	4D5JF9	919	5	11	Mrs Susan Camp				1	PRI		M			
-117285	Martins Wood Primary School	2X6MX9VD	919	2	11	Mr Tom Evans				1	PRI		M			
-117286	Dundale Primary School and Nursery	2X6MZ9Y6	919	3	11	Mr Simon King				1	PRI		M			
-117287	Crabtree Junior School	2X6MTFQN	919	7	11	Mr Ian Pattrick				1	PRI		M			2014-03-31
-117288	Redbourn Junior School	2X6MTDTD	919	7	11	Mr Nathan Hairon				1	PRI		M			
-117289	Arnett Hills Junior Mixed and Infant School	5T8FR8CN	919	4	11	Miss T Ali				1	PRI		M			
-117290	Holywell Primary School	5T8FR0E4	919	3	11	Mr Coert Van Straaten				1	PRI		M			
-117291	The Firs Junior School	2X6MTKCB	919	7	11	Mrs M C Thurley				1	PRI		M			2005-12-31
-117292	Trotts Hill Primary and Nursery School	9C3QNTR	919	4	11	Miss Colette Pidgeon				1	PRI		M			
-117293	Cassiobury Infant and Nursery School	9CPSB9K	919	3	7	Mrs Emma Edwards				1	PRI		M			
-117294	Panshanger Primary School	2X6MTGAT	919	3	11	Mrs Sarah Holt				1	PRI		M			
-117295	Bovingdon Infants' School	2X6MZ9CG	919	5	7	  				1	PRI		M			1998-09-01
-117296	Bournehall Primary School	9B1AJVS	919	4	11	Mrs Jill Litchfield				1	PRI		M			
-117297	Mill Mead Primary School	9B09W4W	919	3	11	Mrs Sue Nesbitt-Larking				1	PRI		M			
-117298	Maple Primary School	5T8JAQW1	919	4	11	Mr Timothy Bowen				1	PRI		M			
-117299	Round Diamond Primary School	9APZHJM	919	3	11	Mrs Zoe Phillips				1	PRI		M			
-117300	Hartsbourne Primary School	9B1AK05	919	4	11	Mrs Valerie Hudson				1	PRI		M			
-117301	Beech Hyde Primary School and Nursery	5T8JAR6K	919	3	11	Miss Hazel Millard				1	PRI		M			
-117302	Andrews Lane Primary School	4D4Q89	919	3	11	Mrs Emma Devally				1	PRI		M			
-117303	Newberries Primary School	9B1AHFF	919	4	11	Ms Ness Peters				1	PRI		M			
-117304	Rickmansworth Park Junior Mixed and Infant School	5T8FR92K	919	5	11	Mrs Peta Dyke				1	PRI		M			
-117305	Mandeville Primary School	2X6MT9TB	919	3	11	Miss Kara Hales				1	PRI		M			
-117306	Giles Junior School	5T8FDH1E	919	7	11	Mrs Heather Davies				1	PRI		M			
-117307	The Cranbourne Primary School	4D5MF5	919	4	11	Mrs Rachel Semark				1	PRI		M			2016-08-31
-117308	Bromet Primary School	2X6MYCN6	919	5	11	Mrs Maria Pace				1	PRI		M			
-117309	Millfield First and Nursery School	2X6MXNXS	919	3	9	Mrs Kathy Willett				1	PRI		M			
-117310	Hillmead Primary School	9B09Q1V	919	3	11	Mrs S L Keefe				1	PRI		M			
-117311	Nascot Wood Junior School	5T8FR16E	919	7	11	Mrs Christina Singh				1	PRI		M			
-117312	Crabtree Infants' School	2X6MTFQ9	919	5	7	Mrs Jane Whitehurst				1	PRI		M			2014-03-31
-117313	The Ryde School	5T8JHC95	919	3	11	Mrs Sue Thompson				1	PRI		M			
-117314	William Ransom Primary School	5T8GM5Z0	919	4	11	Mrs Mary Driver				1	PRI		M			
-117315	Prae Wood Primary School	2X6MTD7F	919	3	11	Mrs Jackie Stephenson				1	PRI		M			
-117316	The Giles Infant and Nursery School	9C3QP5S	919	3	7	Mrs Rouane Mendel				1	PRI		M			
-117317	Kingsway Infants' School	5T8FR163	919	5	7	Mrs Caroline Tristram-Walmsley				1	PRI		M			
-117318	Alban Wood Infant and Nursery School	2X6MYGZD	919	3	7	Mrs Y Davis				1	PRI		M			2005-08-31
-117319	Kingshill Infant School	5T8HG06K	919	3	7	Mrs Catherine Reemer				1	PRI		M			
-117320	Laurance Haines School	5T8FR3MT	919	3	11	Mr James Roach				1	PRI		M			2016-10-31
-117321	Woodside Primary School	4D4KHF	919	4	11	Dr Keith Richmond				1	PRI		M			
-117322	Woolenwick Junior School	9C3QMJX	919	7	11	Mr Mike Crabtree				1	PRI		M			
-117323	Woolenwick Infant and Nursery School	5T8FDH83	919	3	7	Ms Usha Dhorajiwala				1	PRI		M			
-117324	Leavesden JMI School	2X6MYGZE	919	3	11	Mrs Victoria Lyon				1	PRI		M			
-117325	Springmead Primary School	5T8JHB1W	919	3	11	Miss Jennifer Moles				1	PRI		M			
-117326	Longlands Primary School and Nursery	4D56ZK	919	3	11	Ms Lee-Ann Britten				1	PRI		M			
-117327	The Lea Primary School and Nursery	5T8JAMXC	919	3	11	Mrs Sharon Swinson				1	PRI		M			
-117328	Wheatcroft Primary School	2X6MXBM8	919	3	11	Mr Alisdair Skinner				1	PRI		M			
-117329	Mary Exton Primary School	5T8GM5YW	919	5	11	Mrs Lisa Hayes				1	PRI		M			
-117330	Lordship Farm Primary School	9C3H4EB	919	3	11	Mr Ben Parry				1	PRI		M			
-117331	Studlands Rise First School	2X6MXNSX	919	3	9	Miss Alison Doke				1	PRI		M			
-117332	Roman Way First School	2X6MXNAN	919	3	9	Mrs Emma Edwards				1	PRI		M			
-117333	Lime Walk Primary School	2X6MVAGM	919	3	11	Mr Robert Hutchings				1	PRI		M			
-117334	Fairfields Primary School and Nursery	4D4Q88	919	3	11	Mr Giovanni Gaidoni				1	PRI		M			
-117335	Aycliffe Drive Primary School	2X6MV52E	919	3	11	Mrs Maria Green				1	PRI		M			
-117336	Holtsmere End Junior School	2X6MV5B1	919	7	11	Mrs Emma McGuigan				1	PRI		M			
-117337	Samuel Lucas Junior Mixed and Infant School	9ADWWZ9	919	4	11	Mrs Tracy Thomas				1	PRI		M			
-117338	Roselands Primary School	4D5CE2	919	5	11	Mrs J Carson				1	PRI		M			2016-08-31
-117339	Cherry Tree Primary School	5T8FR0ZN	919	3	11	Ms Jessie Bruce				1	PRI		M			
-117340	Coates Way JMI and Nursery School	9A2MY90	919	3	11	Mr Steven Wells				1	PRI		M			
-117341	Grove Road Primary School	2X6MV8D9	919	3	11	Miss Sharon Sanderson				1	PRI		M			
-117342	High Beeches Primary School	5T8JAR5S	919	5	11	Ms Sara Lawrence				1	PRI		M			
-117343	Barncroft Primary School	5T8JQH12	919	3	11	Mr Geoff Allen				1	PRI		M			2008-08-31
-117344	Jupiter Drive Junior Mixed and Infant School	2X6MV4WB	919	5	11	Mrs Margie Knight				1	PRI		M			2008-08-31
-117345	Stonehill School	2X6MXMC2	919	3	11	Mrs Elaine Close				1	PRI		M			
-117346	Richard Whittington Primary School	2X6MTKGY	919	3	11	Mr A K Kern				1	PRI		M			
-117347	Mount Pleasant Lane Junior Mixed and Infant School and Nursery	5T8JAMHS	919	3	11	Mr John Dibdin				1	PRI		M			
-117348	Watchlytes Junior Mixed Infant and Nursery School	2X6MTGVX	919	3	11	Mr Andrew Farrugia				1	PRI		M			
-117349	Brockswood Primary School	9A2N4RC	919	3	11	Mrs Gayle Voigt				1	PRI		M			
-117350	Lannock Primary School	9C3H64A	919	3	11	Mrs Carol Pratt				1	PRI		M			2009-08-31
-117351	Ryelands Primary School	4D5QYQ	919	5	11	Miss Fay Holness				1	PRI		M			2007-08-31
-117352	Ashtree Primary School and Nursery	9C3QPDM	919	3	11	 Elizabeth Lewis				1	PRI		M			
-117353	Sheredes Primary School	4D5BFS	919	3	11	Mrs Mary Childs				1	PRI		M			
-117354	Radburn Primary School	2X6MXKK5	919	3	11	Mrs Wendy Dellar				1	PRI		M			2012-08-31
-117355	Applecroft School	2X6MTHMA	919	3	11	Mrs Vicky Parsey				1	PRI		M			2012-02-29
-117356	Ley Park Primary School	4D59VX	919	3	11	Mr Julian Thomas				1	PRI		M			2008-08-31
-117357	Five Oaks Primary and Nursery School	2X6MTBF0	919	3	11	Mr A Boxer				1	PRI		M			2004-08-31
-117358	Wood End School	2X6MTFBZ	919	4	11	Mr Richard Boulton				1	PRI		M			
-117359	Eastbrook Primary School	2X6MV58T	919	5	11	Mr Geoff Allen				1	PRI		M			2008-08-31
-117360	Meriden Primary School	5T8FR15X	919	3	11	Mrs R Mattison				1	PRI		M			2005-08-31
-117361	Bengeo Primary School	9B09W62	919	3	11	Mrs Julie Starkiss				1	PRI		M			
-117362	Stream Woods Junior Mixed Infant and Nursery School	5T8JHCD2	919	3	11	Mrs Beverley Garwood				1	PRI		M			2007-08-31
-117363	Morgans Primary School & Nursery	9B09KZQ	919	3	11	Mrs Alis Rocca				1	PRI		M			
-117364	The Leys Primary and Nursery School	2X6MX9R5	919	3	11	Ms Leigh Humphries				1	PRI		M			
-117365	Belswains Primary School	2X6MVAEA	919	3	11	Mr Michael Fearnhead				1	PRI		M			
-117366	Bonneygrove Primary School	4D4MDG	919	3	11	Mrs Anne Gorolini				1	PRI		M			
-117367	Burleigh Primary School	4D4WFP	919	4	11	Mr Nick Norman				1	PRI		M			
-117368	Hobbs Hill Wood Primary School	2X6MVA3W	919	3	11	Mr Richard Haynes				1	PRI		M			
-117369	Cranborne Primary School	9AE03PB	919	3	11	Mr Charles Alan Cocker				1	PRI		M			
-117370	Ladbrooke Junior Mixed and Infant School	9B1AKBC	919	3	11	Miss T Webster				1	PRI		M			
-117371	Oakmere Primary School	9B1AJKB	919	3	11	Mrs Elizabeth Haynes				1	PRI		M			
-117372	Sunny Bank Junior School	9AE03NR	919	7	11	Mr K Hooper				1	PRI		M			1999-08-31
-117373	Sunny Bank Infants' School	9AE03NR	919	3	7	Mr  Hooper				1	PRI		M			1999-08-31
-117374	Nascot Wood Infant and Nursery School	5T8FR0J2	919	3	7	Ms Pam Scragg				1	PRI		M			
-117375	The Pines Junior Mixed and Infant School	2X6MXBM9	919	4	11	Mr M J K Marshall				1	PRI		M			2003-08-31
-117376	Hartsfield Junior Mixed and Infant School	9C3H4K7	919	4	11	Mrs Philippa Smith				1	PRI		M			
-117377	Holtsmere End Infant and Nursery School	2X6MV5B2	919	3	7	Mrs Nicola O'Connell				1	PRI		M			
-117378	Commonswood Primary & Nursery School	2X6MTH6E	919	4	11	Mrs Gillian Seymour				1	PRI		M			
-117379	Millbrook School	4D4TB6	919	4	11	Mrs Ruth Bamlett				1	PRI		M			
-117380	Manor Fields Primary School	2X6MTKPQ	919	3	11	Ms Tina Jarman				1	PRI		M			
-117381	Bellgate Primary School	5T8JQF4Y	919	4	11	Mr Andy Whelan				1	PRI		M			2008-08-31
-117382	Aldbury Church of England Primary School	2X6MV8DA	919	4	11	Mrs Natasha Chiswell	C22		CE32	3	PRI		M			
-117383	St John's Church of England Infant and Nursery School	9B1AHEP	919	3	7	Mrs Alice Aharon	C22		CE32	3	PRI		M			
-117384	St Mary's Infants' School	9APZMWE	919	5	7	 Claire Gunn	C22		CE32	3	PRI		M			
-117385	St Mary's Junior Mixed School	2X6MXMZZ	919	7	11	Mrs Patricia Jenkins	C22		CE32	3	PRI		M			
-117386	Barley Church of England Voluntary Controlled First School	2X6MXNGE	919	5	9	 Margaret Davies-Mckeon	C22		CE32	3	PRI		M			
-117387	Bayford Church of England Voluntary Controlled Primary School	2X6MXBTA	919	3	11	Mr Jonathan Preston	C22		CE32	3	PRI		M			
-117388	Tonwell St Mary's Church of England Primary School	2X6MXAD5	919	3	11	Mrs Sarah Bridgman	C22		CE32	3	PRI		M			
-117389	Benington Church of England Primary School	9B09TXM	919	4	11	Mrs J Stevens	C22		CE32	3	PRI		M			
-117390	Layston Church of England First School	9B09N7S	919	5	9	Mrs Myra Bloomfield	C22		CE32	3	PRI		M			
-117391	Ashfield Junior School	9B1AJY4	919	7	11	Mrs Carolyn Dalziel				3	PRI		M			
-117392	Codicote Church of England Primary School	2X6MXHA4	919	3	11	Mrs Liz Pollard	C22		CE32	3	PRI		M			
-117393	Essendon CofE (VC) Primary School	2X6MTHWN	919	3	11	Mrs Charlotte Tudway	C22		CE32	3	PRI		M			
-117394	Furneux Pelham Church of England School	9B1RA9H	919	4	11	Mrs Brigid Dyson	C22		CE32	3	PRI		M			
-117395	Graveley Primary School	2X6MXGZ5	919	4	11	Mrs Lisa Massey	C22		CE32	3	PRI		M			
-117396	Ponsbourne St Mary's Church of England Primary School	2X6MXBT5	919	4	11	Mrs Dorothy Marlow	C22		CE32	3	PRI		M			
-117397	Hertford St Andrew CofE Primary School	9B09VSP	919	3	11	Mrs Lyn Stark	C22		CE32	3	PRI		M			
-117398	High Wych Church of England Primary School	9B1RA9Z	919	3	11	Mrs Mandy West	C22		CE32	3	PRI		M			
-117399	St Paul's Voluntary Controlled Church of England Infants' School	4D5EGC	919	5	7	Mrs Ca Eames	C22		CE32	3	PRI		M			2002-12-31
-117400	Wormley Primary School	4D59VX	919	3	11	Mrs Tracy Gaiteri	C22		CE32	3	PRI		M			
-117401	Ickleford Primary School	9C3H9EJ	919	4	11	Mrs S Dury	C22		CE32	3	PRI		M			
-117402	Little Munden Church of England Voluntary Controlled Primary School	9B1N3BC	919	3	11	Mrs Marina Breeze	C22		CE32	3	PRI		M			
-117403	Preston Primary School	9C3H4EC	919	4	11	Miss Vicky Lunniss	C22		CE32	3	PRI		M			
-117404	Sarratt Church of England Primary School	5T8FRA17	919	4	11	Mrs Pippa Bremner	C22		CE32	3	PRI		M			
-117405	Spellbrook Primary School	9B09PAV	919	3	11	Mrs Gill Vise	C22		CE32	3	PRI		M			
-117406	Roger De Clare First CofE School	9B09WFN	919	3	9	Mrs L Woods	C22		CE32	3	PRI		M			
-117407	St Andrew's Church of England Voluntary Controlled Primary School	9B09WH6	919	3	11	Mrs Shirley Arnold	C22		CE32	3	PRI		M			
-117408	Thundridge Church of England Primary School	2X6MXADA	919	3	11	 Paula Greatrex	C22		CE32	3	PRI		M			
-117409	St Mary's Voluntary Controlled Church of England Junior School	2X6MXA4K	919	7	11	Mr Andy Cosslett	C22		CE32	3	PRI		M			
-117410	St Catherine's Church of England Primary School	9B09WT8	919	3	11	 Hazel Wing	C22		CE32	3	PRI		M			
-117411	Musley Infant School	2X6MXADK	919	5	7	Mrs P A Staras	C22		CE32	3	PRI		M			2003-08-31
-117412	Wareside Church of England Primary School	9B09XT0	919	2	11	Mrs Wendy-May Foster	C22		CE32	3	PRI		M			
-117413	Weston Primary School	9C3H8X2	919	3	11	Mr Geoff Holmes	C22		CE32	3	PRI		M			
-117414	Potten End CofE Primary School	5T8JQEX2	919	3	11	Mr Andrew Morris	C22		CE32	3	PRI		M			
-117415	Dewhurst St Mary CofE Primary School	4D5QVQ	919	5	11	Mrs Susan Wilcox	C22		CE32	3	PRI		M			
-117416	Leverstock Green Church of England Primary School	2X6MV4PH	919	3	11	Mrs Victoria Burgess	C22		CE32	3	PRI		M			
-117417	St Paul's Church of England Primary School, Langleybury	9A1STCM	919	3	11	Mrs Sarah Winter	C22		CE32	2	PRI		M			
-117418	Nash Mills Church of England Primary School	5T8JQ82D	919	3	11	 Rosemary Washford Mower	C22		CE32	2	PRI		M			
-117419	Albury Church of England Voluntary Aided Primary School	2X6MXA42	919	2	11	Mr James Howard	C22		CE32	2	PRI		M			
-117420	Ardeley St Lawrence Church of England Voluntary Aided Primary School	9B1RA8S	919	3	11	Mrs Jenny Dingley	C22		CE32	2	PRI		M			
-117421	Aston St Mary's Church of England Aided Primary School	9B09TW7	919	4	11	Mrs Julie Winwood	C22		CE32	2	PRI		M			
-117422	Barkway VA Church of England First School	9C3H55T	919	5	9	 Sharon Brown	C22		CE32	2	PRI		M			
-117423	Victoria Church of England Infant and Nursery School	5T8JQ7K1	919	3	7	Mrs Zoe Kernohan-Neely	C22		CE32	2	PRI		M			
-117424	St Mary's CofE Primary School, Northchurch	5T8JQGB2	919	3	11	Miss Vanessa Hunt	C22		CE32	2	PRI		M			
-117425	St Joseph's Catholic Primary School	9B09V4B	919	3	11	Mr Peter Coldwell	C67		RC01	2	PRI		M			
-117426	St Michael's Church of England Primary School	2X6MTKB7	919	3	11	Mrs Lisa Dale	C22		CE32	2	PRI		M			
-117427	St Clement's Church of England Voluntary Aided Junior School	4D55NA	919	7	11	Miss Sam Sweetman	C22		CE32	2	PRI		M			2010-08-31
-117428	Holy Trinity Church of England Primary School	4D4TAK	919	4	11	Miss Sarah Chaloner	C22		CE32	2	PRI		M			
-117429	St Joseph's Catholic Primary School	4D51HB	919	3	11	Mr Tony Gorton	C67		RC01	2	PRI		M			
-117430	All Saints Church of England Voluntary Aided Primary School, Datchworth	9B09VQ6	919	5	11	Mr S Whiteland	C22		CE32	2	PRI		M			
-117431	St Nicholas Elstree Church of England VA Primary School	9B1AHZ8	919	3	11	 Kate Johnston-Grant	C22		CE32	2	PRI		M			
-117432	St John the Baptist Voluntary Aided Church of England Primary School	9B09VQM	919	4	11	Miss Lydia Hunt	C22		CE32	2	PRI		M			
-117433	Great Gaddesden Church of England Primary School	9A2N3ZG	919	4	11	Mrs Nikki Comer	C22		CE32	2	PRI		M			
-117434	St Nicholas CofE VA Primary School	5T8JAR4F	919	4	11	Ms Rizelle Crouch	C22		CE32	2	PRI		M			
-117435	St John's Voluntary Aided Church of England Primary School, Lemsford	5T8JHC7Q	919	4	11	Mrs Mandy Evans	C22		CE32	2	PRI		M			
-117436	St Joseph's Catholic Primary School	9B09KVV	919	3	11	Mr Ian Kendal	C67		RC01	2	PRI		M			
-117437	Broxbourne CofE Primary School	4D5AD2	919	3	11	Mr Paul Miller	C22		CE32	2	PRI		M			
-117438	St Augustine Roman Catholic Primary School	4D5FRY	919	3	11	Mrs Gillian Napier	C67		RC01	2	PRI		M			
-117439	Hormead Church of England (VA) First School	9B1N45D	919	3	9	Mr Philip Asher	C22		CE32	2	PRI		M			
-117440	St Ippolyts Church of England Aided Primary School	2X6MXGZ6	919	5	11	 Rachel Peddie	C22		CE32	2	PRI		M			
-117441	St Paul's Church of England Voluntary Aided Primary School, Chipperfield	2X6MYKF6	919	3	11	Miss Caroline Moore	C22		CE32	2	PRI		M			
-117442	Norton St Nicholas CofE (VA) Primary School	2X6MXJXW	919	3	11	Mr Stephen Cowdery	C22		CE32	2	PRI		M			
-117443	Little Gaddesden Church of England Voluntary Aided Primary School	2X6MVAPK	919	4	11	Mrs Charis Geoghegan	C22		CE32	2	PRI		M			
-117444	St Andrew's CofE Primary School and Nursery	9B09WAV	919	3	11	Mrs Judy King	C22		CE32	2	PRI		M			
-117445	Offley Endowed Primary School	9C3HAY7	919	4	11	Mrs Anne Peck	C22		CE32	2	PRI		M			
-117446	Cockernhoe Endowed CofE Primary School	9C3H7Z4	919	3	11	Mr Simon Philby	C22		CE32	2	PRI		M			
-117447	St Mary's Church of England Primary School, Rickmansworth	5T8FR94D	919	3	11	Mr Aaron Wanford	C22		CE32	2	PRI		M			
-117448	St Peter's Church of England Voluntary Aided Primary School	2X6MYHQ6	919	4	11	Ms Philippa Golding	C22		CE32	2	PRI		M			
-117449	The Abbey Church of England Voluntary Aided Primary School, St Albans	5T8JAEJ1	919	4	11	Miss Emma Fenn	C22		CE32	2	PRI		M			
-117450	St Alban and St Stephen Roman Catholic Infant and Nursery School	5T8JAH43	919	3	7	Mrs Bernadette Dempsey	C67		RC01	2	PRI		M			
-117451	St Michael's Church of England Voluntary Aided Primary School, St Albans	9A1REK6	919	5	11	Mrs Alison Rafferty	C22		CE32	2	PRI		M			
-117452	Park Street Church of England Voluntary Aided Primary School	5T8JAHE1	919	3	11	Mrs Tina Facer	C22		CE32	2	PRI		M			
-117453	Puller Memorial, Church of England, Voluntary Aided Primary School	9B1RB29	919	3	11	Mrs Tracy Keddie	C22		CE32	2	PRI		M			
-117454	St Thomas of Canterbury Roman Catholic Primary School	9B09WFA	919	3	11	Mrs Michelle Keating	C67		RC01	2	PRI		M			
-117455	Stapleford Primary School		919	2	11	Mr James Shillito	C22		CE32	2	PRI		M			
-117456	St Nicholas CofE (VA) Primary School and Nursery	9C3QNK2	919	3	11	Mrs Sarah Stevens	C22		CE32	2	PRI		M			
-117457	Tewin Cowper Church of England Voluntary Aided Primary School	2X6MTFVR	919	4	11	Mrs Alison Simpson	C22		CE32	2	PRI		M			
-117458	Bishop Wood Church of England Junior School, Tring	2X6MV8D8	919	7	11	Mrs L Hardman	C22		CE32	2	PRI		M			
-117459	Long Marston VA Church of England Primary School	5T8JQGSM	919	5	11	Mrs Clare South	C22		CE32	2	PRI		M			
-117460	St John's CofE Primary School	5T8JHAGW	919	3	11	Mr R A Price	C22		CE32	2	PRI		M			
-117461	St Michael's Woolmer Green CofE VA Primary School	5T8JHCKE	919	4	11	Mr Brendan Mallon	C22		CE32	2	PRI		M			
-117462	St Helen's Church of England Primary School	2X6MTEJG	919	4	11	Mr Jamie Brown	C22		CE32	2	PRI		M			
-117463	St Bartholomew's Church of England Voluntary Aided Primary School, Wigginton	5T8JQEXV	919	4	11	Mrs Sally Roycroft	C22		CE32	2	PRI		M			
-117464	Our Lady Roman Catholic Primary School	5T8JHBYW	919	4	11	 Catherine Corr	C67		RC01	2	PRI		M			
-117465	St Joseph Catholic Primary School	5T8FR5R8	919	3	11	Mrs Linda Payne	C67		RC01	2	PRI		M			
-117466	St Teresa Roman Catholic Primary School	9B1AHH8	919	3	11	Ms Teresa McBride	C67		RC01	2	PRI		M			
-117467	St Andrew's Church of England Voluntary Aided Primary School, Hitchin	5T8GM5Z1	919	4	11	Ms Deborah Fenn	C22		CE32	2	PRI		M			
-117468	St Cuthbert Mayne Catholic Junior School	5T8JQ7VV	919	7	11	Mrs Bernadette Quinn	C67		RC01	2	PRI		M			
-117469	St Philip Howard Catholic Primary School	2X6MTBE4	919	4	11	Mrs Mairead Waugh	C67		RC01	2	PRI		M			
-117470	St Adrian Roman Catholic Primary School	5T8JAQT5	919	3	11	Mrs Yvonne Hawkes	C67		RC01	2	PRI		M			
-117471	Saint Albert the Great Catholic Primary School	5T8JQE5F	919	3	11	Mrs Kathryn Little	C67		RC01	2	PRI		M			
-117472	All Saints Church of England Primary School and Nursery, Bishop's Stortford	2X6MTM1E	919	3	11	Miss Heidi Otranen	C22		CE32	2	PRI		M			
-117473	Christ Church CofE (VA) Primary School and Nursery, Ware	2X6MXAE3	919	3	11	Mrs Ania Vaughan	C22		CE32	2	PRI		M			
-117474	St Margaret Clitherow Roman Catholic Primary School	9C3QNHJ	919	3	11	Mr Jonathan White	C67		RC01	2	PRI		M			
-117475	St John Catholic Primary School	5T8FR8CM	919	4	11	Mr Peter Sweeney	C67		RC01	2	PRI		M			
-117476	Our Lady Roman Catholic Primary School	9C3H984	919	5	11	Mrs Susan Brown	C67		RC01	2	PRI		M			2012-06-30
-117477	St Thomas More Roman Catholic Primary School	2X6MXKNC	919	3	11	Mrs Mary Hewitson	C67		RC01	2	PRI		M			2012-06-30
-117478	St Dominic Catholic Primary School	5T8JAR3X	919	3	11	Mrs Elizabeth O'brien	C67		RC01	2	PRI		M			
-117479	St Thomas More Roman Catholic Voluntary Aided Primary School	2X6MVBEF	919	3	11	Miss Isabel Cerasale	C67		RC01	2	PRI		M			
-117480	St John Fisher Roman Catholic Primary School	5T8JAK3D	919	4	11	Mrs Laura Flitton	C67		RC01	2	PRI		M			
-117481	The Holy Family Catholic Primary School	5T8HFFSD	919	3	11	Ms Ginnette Stevens	C67		RC01	2	PRI		M			
-117482	Countess Anne Voluntary Aided Church of England Primary School, Hatfield	5T8JH8CZ	919	5	11	Mr David Lodge	C22		CE32	2	PRI		M			2013-09-30
-117483	St Cross Catholic Primary School	4D5EF8	919	5	11	Mrs Kathryn Hall	C67		RC01	2	PRI		M			
-117484	St Rose's Catholic Infants School	2X6MTS96	919	3	7	Mrs Rebecca Tregear	C67		RC01	2	PRI		M			
-117485	Divine Saviour Roman Catholic Primary School	5T8FRBGB	919	3	11	Mr Stephen Wheatley	C67		RC01	2	PRI		M			
-117486	Holy Rood Catholic Junior School	9A95YCZ	919	7	11	Ms E Ward	C67		RC01	2	PRI		M			2006-08-31
-117487	St John Roman Catholic Primary School	9ADX0CA	919	3	11	Ms Alex Hanou	C67		RC01	2	PRI		M			2012-06-30
-117488	Sacred Heart Catholic Primary School and Nursery	9B1AJXK	919	3	11	Mrs Carolyn Hatch	C67		RC01	2	PRI		M			
-117489	Saint Bernadette Catholic Primary School	5T8GM26F	919	4	11	Mrs Elisabeth Barton	C67		RC01	2	PRI		M			
-117490	Welwyn St Mary's Church of England Voluntary Aided Primary School	2X6MTG51	919	4	11	Mrs Mary Westley	C22		CE32	2	PRI		M			
-117491	Saint Alban and St Stephen Catholic Junior School	5T8JAH43	919	7	11	Mr C D Soyka	C67		RC01	2	PRI		M			
-117492	St Paul's Catholic Primary School	4D4Q8A	919	3	11	Mrs Yvonne Devereux	C67		RC01	2	PRI		M			
-117493	Sacred Heart Catholic Primary School	9B1AJXK	919	4	11	Mrs Michelle Fusi	C67		RC01	2	PRI		M			
-117494	Holy Rood RC Infants' School	9A95YCZ	919	3	7	Mrs M T Woodcock	C67		RC01	2	PRI		M			2006-08-31
-117495	St Anthony's Catholic Primary School	5T8FR0DR	919	3	11	Mrs Pauline Wilson	C67		RC01	2	PRI		M			
-117496	Pope Paul Catholic Primary School	9B1AJKK	919	4	11	Mrs Liz Heymoz	C67		RC01	2	PRI		M			
-117497	St Mary's Church of England Primary School	2X6MTHYM	919	4	11	Mrs Vicky Humbles	C22		CE32	2	PRI		M			
-117498	Saint Vincent de Paul Catholic Primary School	9B0E1TM	919	4	11	 Peter Keane	C67		RC01	2	PRI		M			
-117499	The Priory School	9C3H7F5	919	11	18	Mr Geraint Edwards				5	SEC		M			
-117500	The Hemel Hempstead School	5T8JQ7X5	919	11	18	Mr Patrick Harty				5	SEC		M			
-117501	Richard Hale School	9B09VXK	919	11	18	Mr Stephen Neate				5	SEC		B			2013-06-30
-117502	Hitchin Boys' School	2X6MXHSD	919	11	18	Mr Martin Brown				1	SEC		B			2012-12-31
-117503	Hitchin Girls' School	2X6MXHBD	919	11	18	Mrs Frances Manning				1	SEC		G			2011-08-16
-117504	Fearnhill School	9C3H9D6	919	11	18	Ms Elizabeth Ellis				5	SEC		M			
-117505	Verulam School	5T8FVP7Q	919	11	18	Mr David Kellaway				1	SEC		B			2011-07-31
-117506	Presdales School	2X6MXAZE	919	11	18	Mrs Janine Robinson				1	SEC		G			2012-03-31
-117507	Stanborough School	2X6MTHCA	919	11	18	Mr Peter J Brown				1	SEC		M			2012-01-31
-117508	Langleybury School	9A1STGM	919	11	18	  				1	SEC		M			1996-09-01
-117509	The Knights Templar School	2X6MXN06	919	11	18	Mr Andrew Pickering				1	SEC		M			2011-03-31
-117510	The Hillside School	9B1AHNG	919	13	18	Mr T E Westrip				1	SEC		M			2000-08-31
-117511	Sir John Lawes School	2X6MTFDH	919	11	18	Ms Claire Robins				5	SEC		M			2011-07-31
-117512	Adeyfield School	2X6MV4HS	919	11	18	Mr Scott Martin				1	SEC		M			
-117513	Norton School	9APZDCT	919	11	18	Ms  Roberts				1	SEC		M			2002-08-31
-117514	Beaumont School	2X6MTE5Z	919	11	18	Mrs Elizabeth Hitch				1	SEC		M			2012-06-30
-117515	Barclay School	2X6N0357	919	11	18	Ms Jacqui O'Connor				1	SEC		M			
-117516	Hawksmoor School	9AE03ZN	919	13	18	Mr P G Tompkins				1	SEC		M			2000-08-31
-117517	The Heathcote School	2X6MXG43	919	11	18	Mr Edward Joseph Gaynor				1	SEC		M			2012-08-31
-117518	Barnwell School	2X6MXG42	919	11	18	Mr A Fitzpatrick				5	SEC		M			
-117519	Simon Balle School	2X6MXBT7	919	11	18	Mrs Alison Saunders				5	SEC		M			2013-10-31
-117520	Roundwood Park School	2X6MTFB6	919	11	18	Mr Alan Henshall				5	SEC		M			2011-07-31
-117521	Lyndhurst Middle School	9B1AKC2	919	9	13	Mr M Howell				1	MDS		M			2001-08-31
-117522	Francis Combe School and Community College	9AQ026H	919	11	18	Miss Nicky Williams				1	SEC		M			2009-08-31
-117523	Longdean School	2X6MV9YH	919	11	18	Mr Rhodri Bryant				1	SEC		M			2011-07-31
-117524	St Albans Girls' School	2X6MTDMM	919	11	18	Mrs Margaret Chapman				1	SEC		G			2011-08-31
-117525	Sir Frederic Osborn School	2X6MTGFN	919	11	18	Mr Jed Whelan				1	SEC		M			
-117526	Kings Langley School	5T8JQHE1	919	11	18	Mr Gary Lewis				1	SEC		M			2012-11-30
-117527	Bishop's Hatfield Girls' School	2X6MTBBS	919	11	18	Ms Theodora Nickson				1	SEC		G			2011-12-31
-117528	The Cavendish School	2X6MTSE5	919	11	18	Mrs Sarah Lansley				1	SEC		M			
-117529	The Broxbourne School	4D5AAK	919	11	18	Mr M F Titchmarsh				5	SEC		M			2010-12-31
-117530	The Nobel School	9C3QPF9	919	11	18	Mr Martyn Henson				1	SEC		M			
-117531	Turnford School	4D547M	919	11	18	Mrs Joanne Gant				1	SEC		M			2015-08-31
-117532	Westfield Community Technology College	2X6MYE5R	919	11	18	Ms Emma Aylesbury				1	SEC		M			2013-08-31
-117533	Collenswood School	9C3QPAP	919	11	18	Dr Jenny Francis				1	SEC		M			2006-08-31
-117534	Marriotts School	9C3QRXM	919	11	18	Ms Bethany Honnor				1	SEC		M			
-117535	The Sele School	2X6MXCRP	919	11	18	Mr Nick Binder				1	SEC		M			2012-07-31
-117536	Monk's Walk School	5T8JH9XV	919	11	18	Mrs Kate Smith				5	SEC		M			2012-08-31
-117537	The Highfield School	2X6MXKNB	919	11	18	Mr Ian Morris				1	SEC		M			
-117538	Sheredes School	4D5BSY	919	11	18	Mr Ced De La Croix				1	SEC		M			2016-08-31
-117539	Meridian School	2X6MXNC2	919	13	18	Dr M Firth				1	SEC		M			2011-10-31
-117540	Freman College	2X6MXP1R	919	13	18	Ms Helen Loughran				5	SEC		M			2011-07-31
-117541	Bridgewater Primary School	5T8JQEGB	919	4	11	Mrs Caren Doodson				1	PRI		M			
-117542	The Greneway School	2X6MXNC1	919	9	13	Mrs Sai Kennedy				1	MDS		M			2011-10-31
-117543	Ralph Sadleir Middle School	9B09WFM	919	9	13	Mrs E Hinton				1	MDS		M			2013-09-30
-117544	Furzehill Middle School	9B1AHM5	919	9	13	Mr J P Fryer				1	MDS		M			2001-08-31
-117545	Roysia Middle School	2X6MXNAP	919	9	13	Mr Peter Fielden				1	MDS		M			2011-10-31
-117546	Sir John Newsom School	2X6MTH64	919	11	18	  				1	SEC		M			1998-08-31
-117547	Onslow St Audrey's School	2X6MTBBK	919	11	18	Mr Paul Meredith				1	SEC		M			2011-12-31
-117548	Sandringham School	5T8JAHHX	919	11	18	Mr Alan Gray				1	SEC		M			2011-03-31
-117549	Birchwood High School	9B09QS4	919	11	18	Mr Chris Ingate				5	SEC		M			2011-10-31
-117550	The Thomas Alleyne School	9C3QN4X	919	11	18	Mr Mark Lewis				1	SEC		M			2013-08-31
-117551	The Chauncy School	2X6MXAD9	919	11	18	Mr Dennis O'sullivan				5	SEC		M			2011-07-31
-117552	The Astley Cooper School	2X6MV56T	919	11	18	Mr Edward Gaynor				1	SEC		M			
-117553	Tring School	2X6MV863	919	11	18	Mrs Julia Wynd	C22		CE32	3	SEC		M			2012-06-30
-117554	Edwinstree Church of England Middle School	2X6MXNXN	919	9	13	Mrs J Gant	C22		CE32	3	MDS		M			
-117555	Townsend CofE School	5T8JAHPF	919	11	18	Mr A Wellbeloved	C22		CE32	2	SEC		M			
-117556	St George's School	2X6N02Y7	919	11	18	Mr Norman Hoare	C1			2	SEC		M			2012-06-30
-117557	John F Kennedy Catholic School	2X6MTSAV	919	11	18	Mr Paul Neves	C67		RC01	2	SEC		M			
-117558	Loreto College	2X6MTA14	919	11	18	Mrs Maire Lynch	C67		RC01	2	SEC		G			2012-04-30
-117559	The Thomas Coram Church of England School	5T8JQHHF	919	7	11	Mr Rob Halls	C22		CE32	2	PRI		M			
-117560	St Mary Roman Catholic Primary School	2X6MXNF8	919	3	11	Mr Robert Dunbar	C67		RC01	2	PRI		M			2012-06-30
-117561	Christ Church Church of England School	5T8FR9KA	919	3	11	Mr Duncan Gauld	C22		CE32	2	PRI		M			2013-03-31
-117562	Parkside Community Primary School	9B1AHGK	919	3	11	Mr Steven Perrin				5	PRI		M			
-117563	Hertingfordbury Cowper Primary School	9B09W9Z	919	4	11	Mrs Alison Richards	C22		CE32	2	PRI		M			
-117564	St Giles' CofE Primary School	9B1AJ33	919	4	11	Mrs Susan Ridge	C22		CE32	2	PRI		M			
-117565	Cuffley School	2X6MTNZM	919	3	11	Mrs Wendy Heyes				5	PRI		M			
-117566	The Wroxham School	9B1AJKR	919	4	11	Mrs Alison Peacock				5	PRI		M			2012-05-31
-117567	Little Heath Primary School	5T8JHCF1	919	3	11	Mrs Kim Custis				5	PRI		M			
-117568	Little Reddings Primary School	9B1AJVM	919	3	11	Mrs H M Maddox				5	PRI		M			2012-01-31
-117569	Northaw Church of England Primary School	5T8JH99K	919	3	11	Mrs Shirley Whales	C22		CE32	2	PRI		M			
-117570	Brookmans Park Primary School	2X6MTJ65	919	4	11	Mrs Aileen Davies				5	PRI		M			
-117571	St Catherine of Siena Catholic Primary School	5T8FR6JX	919	4	11	Ms P Curran	C67		RC01	2	PRI		M			2012-06-30
-117572	Rickmansworth School	2X6MYHSM	919	11	18	Dr Stephen Burton				5	SEC		M			2011-03-31
-117573	Watford Grammar School for Boys	5T8FR167	919	11	18	Mr M Post	C22			2	SEC		B			2010-08-31
-117574	Francis Bacon School	2X6MTAPX	919	11	18	Mr Matthew Gauthier				5	SEC		M			2012-08-31
-117575	Watford Grammar School for Girls	5T8FR333	919	11	18	Mrs H Hyde	C22			2	SEC		G			2010-08-31
-117576	Parmiter's School	2X6MYGZH	919	11	18	Mr Nick Daymond				2	SEC		M			2011-06-30
-117577	The Bishop's Stortford High School	2X6MTK6F	919	11	18	Mr Dale Reeve				5	SEC		B			
-117578	Ashlyns School	5T8GAB7X	919	11	18	Mr James Shapland				5	SEC		M			
-117579	Dame Alice Owen's School	9B1AJKN	919	11	18	Doctor A J Davison				2	SEC		M			2011-03-31
-117580	Bushey Meads School	9B1AK1T	919	11	18	Mr Keith Douglas				5	SEC		M			2012-01-31
-117581	Bushey Hall School	9B1AJXE	919	11	18	Mr Graham Yapp				5	SEC		M			2009-08-31
-117582	Queens' School	9AE04NH	919	11	18	Mr Terence James				5	SEC		M			2011-06-30
-117583	Mount Grace School	9AE051S	919	11	18	Mr Peter Baker				5	SEC		M			2011-07-31
-117584	Nicholas Breakspear Catholic School	2X6MTE5Y	919	11	18	Mr Phil Jakszta	C67		RC01	2	SEC		M			2012-02-29
-117585	The John Henry Newman Catholic School	9C3QMQ7	919	11	18	Mr Michael Kelly	C67		RC01	2	SEC		M			2012-02-29
-117586	Marlborough School	2X6MT9S6	919	11	18	Ms Annie Thomson				5	SEC		M			2012-03-31
-117587	Goffs School	4D4ME9	919	11	18	Mrs Alison Garner				5	SEC		M			2011-09-30
-117588	The Leventhorpe School	2X6MTJCP	919	11	18	Mr Jonathan Locke				5	SEC		M			2011-07-31
-117589	Saint Michael's Catholic High School	5T8FR6GF	919	11	18	Mr John Murphy	C67		RC01	2	SEC		M			2012-02-29
-117590	Saint Joan of Arc Catholic School	2X6MSZSZ	919	11	18	Mr Peter Sweeney	C67		RC01	2	SEC		M			2012-02-29
-117591	Chancellor's School	2X6MTHZS	919	11	18	Mr David Croston				5	SEC		M			
-117592	The Hertfordshire & Essex High School and Science College	2X6MZTDB	919	11	18	Mrs Cathy Tooze				5	SEC		G			2014-03-31
-117593	St Clement Danes School	2X6MYJWD	919	11	18	Dr Josephine Valentine				2	SEC		M			2011-06-30
-117594	St Mary's Catholic School	2X6MTJQC	919	11	18	Mr A Celano	C67		RC01	2	SEC		M			
-117595	St Mary's Church of England High School (VA)	4D5Z7N	919	11	18	Ms Stephanie Benbow	C22		CE32	2	SEC		M			2012-06-30
-117596	Cheshunt School	4D4TEG	919	11	18	Mr Andy Stainton				5	SEC		M			
-117597	The John Warner School	4D5J74	919	11	18	Mr D J Kennedy				5	SEC		M			2011-03-31
-117598	Hockerill Anglo-European College	9B09QK4	919	11	18	Mr Simon Dennis				5	SEC		M			2011-01-31
-117599	Holmshill School	9AE03ZM	919	9	13	Mr C Wright				5	MDS		M			2001-08-31
-117600	Abbot's Hill School	2X6MZSBC	919	3	16	Mrs E Thomas		C22		11			G		1941-01-01	
-117601	Edge Grove School	9AD5D5B	919	3	13	Mr Ben Evans		C1		11			M		1938-01-01	
-117602	The Aldenham Foundation	9B1AK1W	919	3	19	Mr J C Fowler	C22	C22		11			M		1910-01-01	
-117603	Berkhamsted School for Girls	2X6MVB5T	919	3	19	  		C22		11			G			1996-12-06
-117604	Berkhamsted School	9A2N5H3	919	3	19	Mr M S Steed	C4;C1	C1		11			M		1902-01-01	
-117605	Bishop's Stortford College	2X6MZT6T	919	4	18	Mr Jeremy Gladwin		C1		11			M		1907-01-01	
-117606	St Margaret's School	9B1AJXQ	919	4	18	Mrs Rose Hardy		C22		11			G		1918-01-01	
-117607	Haileybury and Imperial Service College	9B0A2RT	919	11	18	Mr J Davies	C22	C22		11			M		1920-01-01	
-117608	Aldwickbury School	2X6MTEZM	919	4	13	Mr V W Hales		C22		11			B		1950-01-01	
-117609	Queenswood School	2X6MTHW3	919	11	18	Mrs Joanna Cameron	C49	C49		11			G		1919-01-01	
-117610	Westbrook Hay Prep School	5T8FVQ4M	919	3	14	Mr K D Young		C22		11			M		1920-01-01	
-117611	Lockers Park School	2X6MTRZW	919	5	14	Mr Christopher Wilson	C22	C22		11			B		1919-01-01	
-117612	St Christopher School	2X6MSN3M	919	3	19	Mr Richard Palmer		K20a;C1c		11			M		1929-01-01	
-117613	St Francis College	2X6MXKN9	919	3	18	Mrs Bronwen Goulding	C1	C1		11			G		1947-01-01	
-117614	Princess Helena College	9C3HAE9	919	11	18	Mrs Sue Wallace-Woodroffe	C22	C1		11			G		1919-01-01	
-117615	Radlett Preparatory School	9AD5AX0	919	4	11	Mr G White				11			M		1950-01-01	
-117616	Merchant Taylors' School	5T8FRA72	919	11	18	Mr S Everson		C22		11			B		1927-01-01	
-117617	St Albans High School for Girls	2X6MTA18	919	4	18	Mrs Jenny Brown	C4	C1		11			G		1908-01-01	
-117618	Tring Park School for the Performing Arts	5T8JQE17	919	8	18	Mr Stefan Anderson				11			M		1949-01-01	
-117619	Northfield School	5T8FR0HC	919	2	19	  		C22		11			G			1997-08-19
-117620	Beechwood Park School	5T8JQ7WB	919	3	13	Mr Edward Balfour		C22;C1		11			M		1930-01-01	
-117621	Heath Mount School	9B09XVA	919	3	13	Mr Chris Gillam		C1		11			M		1921-01-01	
-117622	Sherrardswood School	5T8JHE7M	919	3	19	Dr Markus Bernhardt				11			M		1950-01-01	
-117623	Egerton-Rothesay School	2X6MVBCY	919	6	19	Mr Colin Parker	C1	C1		11			M		1956-01-01	
-117624	St Hilda's School	9B1AJV4	919	2	11	Mrs T Handford		K20a;C1c		11			M		1957-10-18	
-117625	Westwood School	9B1AK06	919	5	6	Mrs J I Hill				11			M		1957-10-21	2009-07-09
-117626	Harpenden Preparatory School	2X6MTF8X	919	5	10	Mrs E Broughton				11			M		1958-03-05	2005-07-15
-117627	St Hilda's School	9B1AJV4	919	3	11	Mr Daniel Sayers		C22		11			G		1957-10-15	
-117628	Duncombe School	9B09W8M	919	2	11	Mr J Phelan		C22		11			M		1957-11-13	
-117629	St Joseph's in the Park	9B1N3RZ	919	3	11	Mr Douglas Brown		K20a;C1c		11			M		1957-10-15	
-117630	Kingshott School	9C3H9WD	919	3	13	Mr Mark Seymour				11			M		1951-10-30	
-117631	Rudolf Steiner School	2X6MYKBT	919	3	18	 Tina Hobday				11			M		1957-10-18	
-117632	The Barn School	2X6MX9XX	919	2	8	Mrs M M Renny		C67		11			M			1998-08-18
-117633	St Edmund's College	9B09SPZ	919	3	19	Mr Paulo Duran	C67	C67		11			M		1952-01-01	
-117634	Hart House School	9AD5D5B	919	2	7	  		C67		11			M			1999-03-22
-117635	Charlotte House Preparatory School	2X6MYJ52	919	3	11	Miss P Woodcock		C1		11			G		1957-01-01	
-117636	York House School	2X6MYJ7Z	919	3	13	Mr J Gray		C1		11			M		1956-01-01	
-117637	Homewood Independent School	5T8JAQSS	919	5	6	Mrs A Zeina				11			M		1957-10-22	2006-07-07
-117638	St Columba's College	2X6MTCZY	919	4	18	Mr David Buxton	C67	C67		11			B		1957-12-06	
-117639	Francis House Preparatory School	2X6MZ9W3	919	3	11	Mrs H Stanton-Tonner				11			M		1957-10-17	2014-12-12
-117640	Stanborough Secondary School	2X6N040E	919	11	18	Mrs Loraine Dixon	C73	C73		11			M		1957-12-03	
-117641	Royal Masonic School for Girls	5T8FR936	919	4	18	Ms D Rose				11			G		1935-01-01	
-117642	St Francis College	9C3H2ZP	919	3	12	Mrs  Dorothy Macginty		C1		11			M		1947-01-01	2012-04-30
-117643	Lochinver House School	9B1AJKE	919	4	13	Mr Ben Walker		C22		11			B		1952-01-01	
-117644	Stormont School	9B1AJMG	919	4	11	Mrs Sharon Martin				11			G		1944-01-01	
-117645	St Columba's Preparatory School	5T8JAQ7V	919	5	10	Mr E F Brown		C67		11			B		1966-10-28	2005-02-02
-117646	Radlett Lodge School	2X6MYN7R	919	4	19	Miss Jo Galloway				10			M		1974-09-30	
-117647	St Albans School	5T8JAGTK	919	11	19	Mr Jonathan Gillespie	C1;C1c	C1		11			B		1980-09-30	
-117648	Haberdashers' Aske's Boys' School	9B1AHHC	919	5	18	Mr P B Hamilton				11			B		1980-09-30	
-117649	Haberdashers' Aske's School for Girls	9B1AGR6	919	4	18	Miss B A O'Connor		C1		11			G		1980-09-30	
-117650	The King's School	5T8JAREK	919	4	16	Mr C Case	C1	C1		11			M		1982-09-14	
-117651	Merchant Taylors' Prep School	5T8FR93A	919	3	13	Dr Karen McNerney	C1	C1		11			B		1922-01-01	
-117652	Radlett Nursery and Infant School	9B1AH7W	919	5	6	Mrs J Briggs				11			M		1983-06-21	2005-09-01
-117653	Berkhamsted Pre-Prep School	2X6MVB6A	919	3	7	 Karen O'connor				11			M		1985-04-29	
-117654	Bhaktivedanta Manor School	9B1AK1Z	919	4	11	Mrs Wendy Harrison	D1	D1		11			M		1985-05-16	
-117656	Haresfoot Senior School	2X6MVAY2	919	11	17	Ms L Stuart				11			M			2000-10-17
-117657	Immanuel College	9AD52PD	919	4	19	Mr Charles Dormer	F1	F1		11			M		1990-10-31	
-117658	Manor Lodge School	9B1AHEB	919	3	11	Mr Gil Dunn				11			M		1992-02-04	
-117659	Warrax House School	2X6ME1FT	919	11	16	Ms Sally Glossap				10			M		1992-02-03	2006-03-31
-117660	High Elms Manor School	5T8FRBHC	919	1	11	Mrs Sheila O'Neill				11			M		1992-05-07	
-117661	South Lodge School	5T8FNG55	919	12	17	Miss M Sales		C22		11			G			1999-12-22
-117662	Longwood School	9B1AJXV	919	3	11	Mrs Claire May		K20a;C1c		11			M		1994-07-26	
-117663	Epping House School	9B09QVD	919	7	12	  				7			M			1997-07-25
-117664	Pinewood School	2X6MZT45	919	11	16	Mr Adrian Lloyd				12			M			2014-08-31
-117665	St Elizabeth's School	9B09NGR	919	5	19	Mrs Samantha Steinke-Sanderson				8			M			
-117666	Knightsfield School	5T8JHA3Z	919	10	18	Mrs Lucille Leith				7			M			2012-07-31
-117667	Garston Manor School	5T8FR09X	919	11	16	Miss Christine deGraft-Hanson				7			M			
-117668	Boxmoor House School	9A2N551	919	11	16	Mr J R Hooper				7			B			2006-03-31
-117669	The Valley School	5T8FDH0D	919	11	16	Mrs Corina Foster				7			M			
-117670	Colnbrook School	2X6MYD37	919	4	11	Ms Kerry Harris				7			M			
-117671	St Luke's School	2X6MTDT8	919	9	16	Mr Paul Johnson				12			M			
-117672	The Collett School	2X6MTS3N	919	4	16	Mr Stephen Hoult-Allen				7			M			
-117673	Hailey Hall School	4D5CKW	919	11	16	Mrs Heather Boardman				12			B			2015-08-31
-117674	Batchwood School	2X6MTDG1	919	11	16	Mr Miraz Triggs				7			M			
-117675	The Hyde School		919	4	12	  				7			M			1995-09-01
-117676	Middleton School	2X6MXBAD	919	4	11	Mrs Donna Jolly				7			M			
-117677	Great Brookmead School	9AE059D	919	5	11	  				7			M			1995-08-31
-117678	Hilltop School	5T8FDGKZ	919	5	11	  				7			B			1996-08-31
-117679	Lonsdale School	9C3QRXM	919	3	18	Mrs Annemari Ottridge				7			M			
-117680	Lakeside School	2X6MTHMB	919	2	19	Mrs Judith Chamberlain				7			M			
-117681	Breakspeare School	2X6MYKRW	919	2	19	Ms Merja Paakkonen				7			M			
-117682	Woodfield School	2X6MV9YK	919	3	19	Mrs Gill Waceba				7			M			
-117683	Watling View School	2X6MT9W3	919	2	19	Ms Pauline B Atkins				7			M			
-117684	Amwell View School	9B1N31S	919	2	19	Mrs J S Liversage				7			M			
-117685	Heathlands School	2X6MTDHE	919	3	16	Mrs Deborah Jones-Stevens				7			M			
-117686	Falconer School	9B1AJXG	919	11	16	Mr Jonathan Kemp				7			B			
-117687	High Wick School	5T8FDH08	919	6	11	  				7			M			1996-08-31
-117688	The Edward Jenner Hospital School	9AQQR2W	919	12	16	Mr M R Ingham				7			M			1999-10-18
-117689	Woolgrove School	2X6MXKK6	919	4	12	Mrs Bridget Walton				7			M			2012-03-31
-117690	Greenside School	9C3QNZ4	919	2	19	Mr Dave Victor				7			M			
-117691	Meadow Wood School	9AE04RC	919	3	11	Ms Elizabeth Stratton				7			M			
-127416	Holy Rood Catholic Primary School	9A95YCZ	919	3	11	Mr Stephen Wheatley	C67		RC01	2	PRI		M		2006-09-01	
-127633	The Chrysalis School for Autism	9C3H328	919	5	16	Mrs Elizabeth Dun				10			M		2005-07-14	2011-03-26
-129109	Highfield Nursery School	9B09WJ3	919			  				15	NUR					1988-08-31
-129110	Burleigh Junior School	4D4WFP	919	7	11	  				1	PRI		M			1994-12-31
-129111	Belswains Junior School	2X6MVAE9	919	7	11	  				1	PRI		M			1993-12-31
-129112	Morgans Walk Junior Mixed School	9B09KZQ	919	7	11	  				1	PRI		M			1992-12-31
-129113	Mount Pleasant Lane Junior School	5T8JAMHS	919	7	11	  				1	PRI		M			1989-08-31
-129114	Leavesden Green Junior Mixed School	2X6MYGZE	919	7	11	  				1	PRI		M			1992-08-31
-129115	Hobbs Hill Wood Junior School	2X6MVA3W	919	7	11	  				1	PRI		M			1995-08-31
-129116	Belswains Infants' School	5T8GM4PH	919	4	7	  				1	PRI		M			1993-12-31
-129117	Hobbs Hill Wood Infants' School	2X6MVA3W	919	3	7	  				1	PRI		M			1995-08-31
-129118	Bengeo Junior School	9APR87M	919	7	11	  				1	PRI		M			1992-08-31
-129119	Bonneygrove Junior School	4D4MDG	919	7	11	  				1	PRI		M			1993-12-31
-129120	Broad Oaks Junior Mixed School		919			  				1	PRI					1991-08-31
-129121	Bishops Wood Infant School	5T8JHCC6	919			  				1	PRI					1991-08-31
-129122	Bellgate Junior Mixed School	5T8JQF4Y	919	7	11	  				1	PRI		M			1987-12-31
-129123	Meriden Junior School	5T8FR15X	919	7	11	  				1	PRI		M			1992-08-31
-129124	St Stephen's Infant School		919			  				1	PRI					1989-08-31
-129125	Millwards Junior Mixed School	5T8JHCD0	919	7	11	  				1	PRI		M			1992-08-31
-129126	The Downs Infant School	5T8JHCD2	919	5	7	  				1	PRI		M			1992-08-31
-129127	Bellgate Infant School	5T8JQF4Y	919	5	7	  				1	PRI		M			1987-12-31
-129128	Meriden Infant School	5T8FR15X	919	5	7	  				1	PRI		M			1992-08-31
-129129	Bonneygrove Infants' School	4D4MDG	919	4	7	  				1	PRI		M			1993-12-31
-129130	Wood End Junior Mixed School	2X6MTFBZ	919	7	11	  				1	PRI		M			1991-08-31
-129131	Chalk Dell Infant School	2X6MXBPQ	919	5	7	  				1	PRI		M			1992-12-31
-129132	Bengeo Infant School	9B09W62	919	5	7	  				1	PRI		M			1992-08-31
-129133	Grangewood Infants' School	4D5TD3	919	4	7	  				1	PRI		M			1994-12-31
-129134	Cranbourne Junior School	4D5MF5	919	7	11	  				1	PRI		M			1990-08-31
-129135	Dundale Infant School		919			  				1	PRI					1988-08-31
-129136	Cranbourne Infant School	4D5MF5	919	5	7	  				1	PRI		M			1990-08-31
-129137	Leavesden Green Infant School	2X6MYGZE	919	5	7	  				1	PRI		M			1992-08-31
-129138	Wood End Infant School	2X6MTFBZ	919	5	7	  				1	PRI		M			1991-08-31
-129139	Laurance Haines Infant School	5T8FR3MT	919			  				1	PRI					1988-08-31
-129140	Eastbrook Junior School	2X6MV58T	919	7	11	  				1	PRI		M			1991-08-31
-129141	Ley Park Junior School	4D59VX	919	7	11	  				1	PRI		M			1991-08-31
-129142	Eastbrook Infant and Nursery School	2X6MV5B0	919	5	7	  				1	PRI		M			1991-08-31
-129143	Wellfield Wood Junior School	2X6MX9R5	919	7	11	  				1	PRI		M			1993-03-31
-129144	Grove Road Junior School	2X6MV8D9	919	7	11	  				1	PRI		M			1992-12-31
-129145	Wellfield Wood Infant School	2X6MX9R5	919	5	7	  				1	PRI		M			1993-03-31
-129146	Ley Park Infant School	4D59VX	919	5	7	  				1	PRI		M			1991-08-31
-129147	Cottered VC Primary School		919	5	9	  				3	PRI		M			1992-12-31
-129148	Westmill First School		919			  				3	PRI					1989-08-31
-129149	Sir John Southworth RC Junior Mixed and Infant School		919			  				2	PRI					1990-08-31
-129150	Pope Pius XII RC Primary School		919			  				2	PRI					1990-08-31
-129151	Maragaret Dane School		919			  				1	SEC					1990-08-31
-129152	Hadham Hall School	9B1RC7K	919			  				1	SEC					1990-08-31
-129153	Hitchin School		919			  				1	SEC					1988-08-31
-129154	Durrants School		919	11	18	  				1	SEC		M			1991-08-31
-129155	Sir James Altham School		919			  				1	SEC					1989-08-31
-129156	Hatfield School	5T8JHCG0	919			  				1	SEC					1990-08-31
-129157	Thomas Alleynes School		919			  				1	SEC					1989-08-31
-129158	Bowes Lyon High School		919			  				1	SEC					1988-08-31
-129159	The Marshalwick School	5T8JAHHX	919	11	18	  				1	SEC		M			1988-08-31
-129160	The Willian School	2X6MXKK5	919	11	18	  				1	SEC		M			1991-08-31
-129161	Francis Bacon School	2X6MTAPX	919			  				1	SEC					1990-08-31
-129162	Halsey School	9A2N789	919			  				1	SEC					1988-08-31
-129163	The Mountbatten School	2X6MS6GV	919	11	18	  				1	SEC		M			1991-08-31
-129164	Wheathampstead School	2X6MTEGK	919	11	18	  				1	SEC		M			1988-08-31
-129165	Stevenage Girls' School		919			  				1	SEC					1989-08-31
-129166	The Augustus Smith School		919			  				1	SEC					1988-08-31
-129167	Bishopslea School		919			  				1	SEC					1988-08-31
-129168	Cardinal Bourne School		919			  				2	SEC					1988-08-31
-129169	Thomas Bourne CofE Middle School	2X6MVBCY	919			  				2	MDS					1988-08-31
-129170	Roasry Priory High School	9B1AJW2	919			  				11						1988-07-08
-129171	Lyndale School	2X6N02M5	919	3	17	  				11			M			1994-01-06
-129172	Sherrardswood Junior School	5T8JHE7M	919			  				11					1950-01-01	2006-08-31
-129173	Rosary Priory Preparatory School	9B1AJW2	919			  				11						1988-07-08
-129174	Pamela Gardens School	2X6MDBK5	919			  				11						1991-01-09
-129176	Marlin Montessori School	9AEAAJW	919			  				11						1991-10-20
-129177	Stanborough Secondary School	2X6N040E	919			  				11					1950-01-01	2006-08-31
-129178	Broxbournebury School	4D5TCX	919			  				7						1990-08-31
-129179	Chorleywood College		919	11	19	  				7			G			1987-07-31
-129180	Elmfield School	5T8HFFQF	919	10	16	  				7			M			1987-07-31
-129181	Hangers Wood School	5T8FR6C5	919	3	12	  				7			M			1994-09-01
-129182	Brandles School	2X6MXMZX	919	11	13	  				7			B			1990-09-30
-129183	Greenside School	9C3QNZ4	919			  				7						1989-03-31
-129184	Harperbury Hospital School	2X6MYN1B	919			  				7						1993-12-31
-129185	Springfield School	2X6N0380	919	3	19	  				7			M			1993-12-31
-129186	Home Field School	9C3QNZ4	919	3	18	  				7			M			1989-03-31
-130160	Summercroft Primary School	9B09V9Y	919	3	11	Mr Michael Smith				1	PRI		M		2006-01-01	2011-08-31
-130338	Norfolk Lodge School Ltd	9B1AJM8	919	5	10	Mrs Mary Wales				11			M		1996-03-13	2009-08-31
-130344	North Area Pupil Referral Unit	9APZQ0C	919	5	16	Mrs Julie Vernon-Hamilton				14			M		1995-09-01	
-130347	Hertford, Ware and Bishop's Stortford Area Pupil Referral Unit	9APR8VN	919	5	16	Mr Christopher Millard				14			M		1995-09-01	2009-08-31
-130348	The Park Education Support Centre	9B1AK5M	919	5	16	Mrs J Porter				14			M		1995-09-01	
-130349	South West Area Pupil Referral Unit	2X6MYG0S	919	5	16	Mrs Susan Howe				14			M		1995-09-01	
-130355	Buntingford Area Pupil Referral Unit	2X6MXNXN	919	5	18	Mr M Knowles				14			M		1996-04-01	1998-01-01
-130356	The Links Education Support Centre	5T8JAGKZ	919	5	16	Miss Tracey Healy				14			M		1995-09-01	2013-01-31
-130359	Stevenage Education Support Centre	9C3QPE6	919	11	14	Ms Anne-Marie O'sullivan				14			M		1995-09-01	
-130362	Southfield School	9CQJT5Q	919	4	11	Ms Libby Duggan				7			M		1995-09-01	
-130363	Shepherd Montessori School	5T8FR93G	919	5	5	  				11			M		1996-05-02	1996-09-18
-130720	West Herts College	5T8FR0G2	919	16	99	Ms Gill Worgan				18	16P		M			
-130721	North Hertfordshire College	2X6MXKN8	919	16	99	Mr Matt Hamnett				18	16P		M			
-130722	Hertford Regional College	9B09WV0	919	16	99	Mr Andy Forbes				18	16P		M			
-130723	Oaklands College	5T8JASBR	919	16	99	Ms Zoe Hancock				18	16P		M			
-131060	Brandles School	2X6MXMZX	919	11	16	Mr David Andrew Vickery				7			B		1993-10-25	
-131100	Dacorum Education Support Centre	2X6MV4HA	919	5	16	Ms Sara Lalis				14			M		1995-09-01	
-131188	Bovingdon Primary School	2X6MV9XY	919	3	11	Mr Martin Mangan				1	PRI		M		1998-09-01	2011-06-30
-131319	Haywood Grove School	2X6MV5B0	919	5	11	Mrs Catherine Smith				7			M		1996-02-20	
-131456	Clore Shalom School	9B1AK53	919	3	11	Mr Ian Pattrick	F1			2	PRI		M		1999-09-01	
-131503	Larwood School	2X6MX9RF	919	5	11	Mr S Trimble				12			M			2016-10-31
-131505	Featherstone Wood Primary School	9C3QPDF	919	3	11	Miss Louise Shuttleworth				1	PRI		M		1998-09-01	
-131651	Hertsmere Jewish Primary School	9B1AHEF	919	1	5	Mrs M Bazak		F1		11			M			1999-09-22
-131955	Hertsmere Jewish Primary School	9B1AHEF	919	3	11	Mr Steven Isaacs	F1			2	PRI		M		1999-09-01	
-131971	Hertswood School	9AE03ZP	919	11	18	Mrs Jan Palmer Sayer				1	SEC		M		2000-09-01	2012-08-31
-132015	St Elizabeth's College (The Congregation of the Daughters of the Cross of the Liege)	9B09NGR	919	19	25	Ms Kathy Cox	C67			32	16P		M		2006-06-20	
-132091	Lodge Farm Primary School	9C3QPF8	919	3	11	Miss Helen Turner				1	PRI		M		2000-09-01	
-132105	Birchwood Avenue Primary School	9AE9CV7	919	5	11	Mrs Joanna DI-Bella				1	PRI		M		2000-04-13	
-132118	Sunny Bank Primary School	9AE03NR	919	3	11	Mr K M Hooper				5	PRI		M		1999-09-01	2008-08-31
-133065	Grove Road Infant School	2X6MV8D9	919	5	7	  				1	PRI		M			2001-03-29
-133134	South Lodge School	5T8FNG55	919	11	17	  				11			G			1993-06-21
-133263	Roebuck Primary School and Nursery	9C3QNHH	919	3	11	Mr R Fordham				1	PRI		M		2001-04-18	
-133295	Integrated Services Programme	2X6MM9N0	919	1	16	  				11			M		2001-03-26	2001-07-26
-133323	Oughton Primary and Nursery School	5T8GM5Z3	919	3	11	Mrs Lisa Clayton				1	PRI		M		2001-09-01	
-133488	Swallow Dell Primary and Nursery School	9AE9CV8	919	2	11	Mrs Clare Hollingsworth				1	PRI		M		2002-01-01	
-133738	Redemption Academy	9C3QPNH	919	3	18	Mrs S J Neale	C1	C1		11			M		2002-07-26	2015-07-16
-133773	St Catherine's Hoddesdon CofE Primary School	4D5FST	919	4	11	Mrs Amanda Staiano			CE32	3	PRI		M		2003-01-01	
-133783	University of Hertfordshire	2X6MTBJ3	919			Professor Quintin McKellar				29			M			
-133917	Littlebury Resource Centre	4D5QVY	919	11	16	Mr D J Stacey				27			M		2000-09-01	2004-05-17
-133975	Muriel Green Nursery School	2X6MTDDH	919	3	5	Mrs Karen Ashton				15	NUR		M		2001-01-01	
-134087	St Albans Independent College	2X6MT9QA	919	14	19	Mr Assim Jemal				11			M		2003-01-20	
-134197	Flamstead End Primary and Nursery School	4D4PHY	919	3	11	Mrs S Killey				1	PRI		M		2003-09-01	2013-03-31
-134488	Littlebury Resource Centre	4D5QVY	919	11	16	  		C1		11			M		2003-08-29	2004-09-29
-134682	Windhill School	2X6MTKCB	919	3	11	Mrs Philippa Moore				1	PRI		M		2006-01-01	2015-02-28
-134684	Berrygrove Primary and Nursery School	9A95Y4M	919	3	11	Mr Christopher Kronda				1	PRI		M		2005-09-02	2012-08-31
-134685	Alban Wood Primary School and Nursery	2X6MYGZD	919	3	11	Mrs Rachel Kirk				1	PRI		M		2005-09-02	
-134716	De Havilland Primary School	2X6MTBF0	919	3	11	 Andrew Peck				1	PRI		M		2004-09-01	
-134786	Village Montessori	9A2N6TH	919	4	11	Mrs Amanda Kemp	C1			11			M		2004-09-01	2007-03-30
-134933	International Stanborough School	2X6N040E	919	11	18	Mrs Lorraine Dixon				11			M		2005-02-10	
-134985	Yavneh College	9AE03VX	919	11	18	Dr Dena Coleman	F1			2	SEC		M		2006-09-01	2011-06-30
-135083	Longmeadow Primary School	5T8FDGYV	919	3	11	Miss Anne Heywood				1	PRI		M		2005-09-01	
-135084	Shephalbury Park Primary School	9C3QNZ0	919	3	11	Ms Chelsea Atkins				1	PRI		M		2005-09-01	
-135221	Maple Grove Primary School	2X6MV58T	919	3	11	Mr Geoffrey Allen				1	PRI		M		2008-09-01	
-135222	Yewtree Primary School	5T8JQF4Y	919	3	11	Miss Faye Ewen				1	PRI		M		2008-09-01	
-135223	Oak View Primary and Nursery School	2X6MTBEZ	919	3	11	Mrs Yvonne Davis				1	PRI		M		2007-09-01	
-135224	Galley Hill Primary School and Nursery	2X6MTSE6	919	3	11	Mrs Emily Birch				1	PRI		M		2008-09-01	
-135339	Broadfield Primary School	5T8JQEN7	919	3	11	Mrs Christine Hall				1	PRI		M		2008-01-01	
-135402	Education and Youth Services (Herts)	5T8FDDY5	919	14	18	Mr Matthew Harvey				10			M		2007-09-05	2016-02-29
-135528	Killigrew Primary and Nursery School	5T8JAQST	919	3	11	Miss Tracy Mylotte				1	PRI		M		2008-09-01	
-135553	Focus School - Cheshunt Primary Campus		919	7	11	Mrs Janice Tew-Cragg	C61	C1		11			M		2008-04-22	2014-10-22
-135560	Worldshapers Academy	9AQK0HS	919	13	16	Dr Arno Steen Andreasen	C1	C1		10			M		2008-04-24	2014-07-24
-135596	Stanborough Primary School	5T8FR15Q	919	3	11	Mrs K Hanson		C73		11			M		1957-12-03	
-135876	Francis Combe Academy	9AQ026H	919	11	18	Ms Debbie Warwick				46	SEC		M		2009-09-01	
-135890	Rivers Education Support Centre	4D5GPC	919	11	16	Mrs Janet Bourne				14			M		2009-09-01	
-135938	The Bushey Academy	9B1AJXE	919	11	18	Mr Andrew Hemmings				46	SEC		M		2009-09-01	
-136024	Churchfield CofE VA Primary	4D609B	919	3	11	 Katharine Hardwick	C22		CE32	2	PRI		M		2010-09-01	
-136247	Roman Fields	9A2N551	919	11	18	Mr Trevor Orchard				14			M		2010-11-01	
-136276	Watford Grammar School for Boys	5T8FR167	919	11	18	 Ian Cooksey	C22			45	SEC		B		2010-09-01	
-136289	Watford Grammar School for Girls	5T8FR333	919	11	18	Mrs Clare Wagner	C22			45	SEC		G		2010-09-01	
-136396	The Broxbourne School	4D59W3	919	11	18	Ms Paula Humphreys				45	SEC		M		2011-01-01	
-136482	Hockerill Anglo-European College	9B09QK4	919	11	18	Mr Richard Markham				45	SEC		M		2011-02-01	
-136554	Dame Alice Owen's School	9B1AJKN	919	11	18	 Hannah Nemko				45	SEC		M		2011-04-01	
-136606	Rickmansworth School	2X6MYHSM	919	11	18	Mr Keith Douglas				45	SEC		M		2011-04-01	
-136607	The John Warner School	4D5J74	919	11	18	Mr David Kennedy				45	SEC		M		2011-04-01	
-136608	The Knights Templar School	2X6MXN06	919	11	18	Mr Tim Litchfield				45	SEC		M		2011-04-01	
-136609	Sandringham School	5T8JAHHX	919	11	18	Mr Alan Gray				45	SEC		M		2011-04-01	
-136857	Bovingdon Primary Academy	2X6MV9XY	919	3	11	Mrs Shereen Breslin				45	PRI		M		2011-07-01	
-136877	Queens' School	9AE04NH	919	11	18	Mr Jonathan Morrell				45	SEC		M		2011-07-01	
-136899	Parmiter's School	2X6MYGZH	919	11	18	Mr Nick Daymond				45	SEC		M		2011-07-01	
-136901	St Clement Danes School	2X6MYJWD	919	11	18	Dr Josephine Valentine				45	SEC		M		2011-07-01	
-136922	Yavneh College	9AE03VX	919	11	18	Mr Spencer Lewis	F1			45	SEC		M		2011-07-01	
-136973	Roundwood Park School	2X6MTFB6	919	11	18	Mr Alan Henshall				45	SEC		M		2011-08-01	
-137002	Freman College	2X6MXP1R	919	13	18	Ms Helen Loughran				45	SEC		M		2011-08-01	
-137038	Verulam School	5T8FVP7Q	919	11	18	Mr Paul Ramsey				45	SEC		B		2011-08-01	
-137090	The Chauncy School	2X6MXAD9	919	11	18	Mr Dennis O'Sullivan				45	SEC		M		2011-08-01	
-137110	Longdean School	2X6MV9YH	919	11	18	 Graham Cunningham				45	SEC		M		2011-08-01	
-137156	Leventhorpe	2X6MTJCP	919	11	18	Mr Jonathan Locke				45	SEC		M		2011-08-01	
-137224	Mount Grace School	9AE051S	919	11	18	Mr Peter Baker				45	SEC		M		2011-08-01	
-137238	Hammond Academy	5T8JQEQF	919	3	11	Mrs Laura Gregory				45	PRI		M		2011-08-01	
-137270	Sir John Lawes School	2X6MTFDH	919	11	18	 Claire Robins				45	SEC		M		2011-08-01	
-137288	Hitchin Girls' School	2X6MXHBD	919	11	18	Mrs F Manning				45	SEC		G		2011-08-17	
-137339	St Albans Girls' School	2X6MTDMM	919	11	18	Mrs Margaret Chapman				45	SEC		G		2011-09-01	
-137351	Summercroft Primary School	9B09V9Y	919	3	11	Mrs Carole Hinstridge				45	PRI		M		2011-09-01	
-137532	Goffs School	4D4ME9	919	11	18	Ms Alison Garner				45	SEC		M		2011-10-01	
-137637	Birchwood High School	9B09QS4	919	11	18	Mr Chris Ingate				45	SEC		M		2011-11-01	
-137656	Meridian School	2X6MXNC2	919	13	18	Miss Kim Horner				45	SEC		M		2011-11-01	
-137657	Roysia Middle School	2X6MXNAP	919	9	13	Miss Zoe Linington				45	MDS		M		2011-11-01	
-137658	The Greneway School	2X6MXNC1	919	9	13	Mrs Laura Rawlings				45	MDS		M		2011-11-01	
-137757	Bishop's Hatfield Girls' School	2X6MTBBS	919	11	18	 Theodora Nickson				45	SEC		G		2012-01-01	
-137792	Onslow St Audrey's School	2X6MTBBK	919	11	18	 Michael Harpham				45	SEC		M		2012-01-01	
-137847	Stanborough School	2X6MTHCA	919	11	18	Mr Peter Brown				45	SEC		M		2012-02-01	
-137861	Little Reddings Primary School	9B1AJVM	919	3	11	Miss C Simmonds				45	PRI		M		2012-02-01	
-137872	Bushey Meads School	9B1AK1T	919	11	18	 Jeremy Turner				45	SEC		M		2012-02-01	
-137895	The John Henry Newman Catholic School	9C3QMQ7	919	11	18	Mr C Mathew	C67		RC01	45	SEC		M		2012-03-01	
-137914	Saint Joan of Arc Catholic School	2X6MSZSZ	919	11	18	Mr Peter Sweeney	C67		RC01	45	SEC		M		2012-03-01	
-137922	Saint Michael's Catholic High School	5T8FR6GF	919	11	18	 Edward Conway	C67		RC01	45	SEC		M		2012-03-01	
-137938	Nicholas Breakspear Catholic School	2X6MTE5Y	919	11	18	Mr Declan Linnane	C67		RC01	45	SEC		M		2012-03-01	
-137943	Applecroft School	2X6MTHMA	919	3	11	Ms Lisa Withe				45	PRI		M		2012-03-01	
-137985	Presdales School	2X6MXAZE	919	11	18	Mr Matthew Warren				45	SEC		G		2012-04-01	
-137997	Woolgrove School, Special Needs Academy	2X6MXKK6	919	4	12	Mrs Lisa Hall				44			M		2012-04-01	
-138042	The Marlborough Science Academy	2X6MT9S6	919	11	18	Ms Annie Thomson				45	SEC		M		2012-04-01	
-138106	Loreto College	2X6MTA14	919	11	18	Mrs Marie Lynch	C67		RC01	45	SEC		G		2012-05-01	
-138201	Hatfield Community Free School	5T8JHC00	919	4	11	 Sue Attard				39	PRI		M		2012-09-01	
-138205	Fleetville Junior School	5T8JAG03	919	7	11	Mrs Androulla Peek				45	PRI		M		2012-06-01	
-138206	Fleetville Infant and Nursery School	2X6MTAHR	919	3	7	Mrs Alex Lindley				45	PRI		M		2012-06-01	
-138215	The Wroxham School	9B1AJKR	919	4	11	Mrs Alison Peacock				45	PRI		M		2012-06-01	
-138225	The Da Vinci Studio School of Science and Engineering	9C3QSD8	919	14	19	 Mark Lewis				41	SEC		M		2012-09-03	
-138231	Alban City School	5T8GN26J	919	5	11	 Janet Goddard				39	PRI		M		2012-09-01	
-138286	Beaumont School	2X6MTE5Z	919	11	18	Mrs Elizabeth Hitch				45	SEC		M		2012-07-01	
-138288	St Catherine of Siena Catholic Primary School	5T8FR6JX	919	4	11	Ms Nicola Kane	C67		RC01	45	PRI		M		2012-07-01	
-138292	St Mary Roman Catholic Primary School	2X6MXNF8	919	3	11	Mrs Julia Pearce	C67		RC01	45	PRI		M		2012-07-01	
-138316	St John Roman Catholic Primary School	9C3H55Z	919	3	11	Ms A Hanou	C67		RC01	45	PRI		M		2012-07-01	
-138322	Our Lady Catholic Primary School	9C3H984	919	5	11	Mrs S Brown	C67		RC01	45	PRI		M		2012-07-01	
-138352	Tring School	2X6MV863	919	11	18	 Susanna Collings	C22		CE32	45	SEC		M		2012-07-01	
-138354	St Thomas More Roman Catholic Primary School	2X6MXKNC	919	3	11	Mrs Jane Perry	C67		RC01	45	PRI		M		2012-07-01	
-138356	St George's School	2X6N02Y7	919	11	18	Mr Raymond McGovern	C1			45	SEC		M		2012-07-01	
-138360	St Mary's Church of England High School (VA)	4D5Z7N	919	11	18	Ms Stephanie Benbow	C22		CE32	45	SEC		M		2012-07-01	
-138389	Garden City Academy	2X6MXKK5	919	3	11	 Linda Meredith				46	PRI		M		2012-09-01	
-138484	The Sele School	2X6MXCRP	919	11	18	 Neil Dunn				45	SEC		M		2012-08-01	
-138485	Knightsfield School	5T8JHA3Z	919	10	18	 Lucille Leith				44			M		2012-08-01	
-138507	The Grove Academy	9A95Y4M	919	3	11	Mr Philip Gray				46	PRI		M		2012-09-01	
-138539	Northgate Primary School	2X6MTK10	919	3	11	Mrs Louisa Hotson				45	PRI		M		2012-08-01	
-138561	Harpenden Free School	9CSKJEK	919	4	11	Mrs Lisa Davies				39	PRI		M		2012-09-01	2016-08-31
-138582	Samuel Ryder Academy	2X6MTAPX	919	4	19	Mr Matt Gauthier				46	ALL		M		2012-09-01	
-138632	Monk's Walk School	5T8JH9XV	919	11	18	 Kate Smith				45	SEC		M		2012-09-01	
-138747	Hertswood Academy	9AE03ZP	919	11	18	 Peter Gillett				45	SEC		M		2012-09-01	
-139036	Kings Langley School	5T8JQHE1	919	11	18	Mr Gary Lewis				45	SEC		M		2012-12-01	
-139154	Hitchin Boys' School	2X6MXHSD	919	11	18	 Martin Brown				45	SEC		B		2013-01-01	
-139159	Mandeville Primary School	2X6MT9TB	919	3	11	Mrs Cathy Longhurst				45	PRI		M		2013-01-01	
-139197	Links Academy	5T8JAGKZ	919	5	16	 David Allen				42			M		2013-02-01	
-139416	The Elstree UTC	9AE09FM	919	14	19	Mr Chris Mitchell				40	SEC		M		2013-09-01	
-139507	Christ Church Chorleywood CofE School	5T8FR9KA	919	3	11	Mr Duncan Gauld	C22		CE32	45	PRI		M		2013-04-01	
-139545	Flamstead End School	4D4PHZ	919	2	11	Mrs Susan Killey				45	PRI		M		2013-04-01	
-139550	Chaulden Junior School	2X6MZR56	919	7	11	Mrs Moira White				46	PRI		M		2013-05-01	
-139662	The Reach Free School	9CQACQQ	919	11	18	Mr Richard Booth				39	SEC		M		2013-09-02	
-139835	Rhodes Farm School	2X6MTHY9	919	8	18	Mrs Karen El-Shirbini				11			M		2013-06-27	
-139873	Richard Hale School	9B09VXK	919	11	18	Mr Stephen Neate				45	SEC		B		2013-07-01	
-139902	The Da Vinci Studio School of Creative Enterprise	2X6MXKNA	919	14	19	 Mark Lewis				41	SEC		M		2013-09-02	
-140037	The Thomas Alleyne School	9C3QN4X	919	11	18	Mr Mark Lewis				46	SEC		M		2013-09-01	
-140049	Westfield Academy	2X6MYE5R	919	11	18	Mr Tim Body				45	SEC		M		2013-09-01	
-140238	Countess Anne Church of England School	5T8JH8CZ	919	5	11	 David Lodge	C22		CE32	45	PRI		M		2013-10-01	
-140249	Ralph Sadleir School	9B09WFM	919	9	13	 Dominic Spong				45	MDS		M		2013-10-01	
-140294	Simon Balle All-Through School	2X6MXBT7	919	4	18	Ms Alison Saunders				45	ALL		M		2013-11-01	
-140611	Wilshere-Dacre Junior Academy	9C3H8GG	919	7	11	Mrs Sarah Smith				46	PRI		M		2014-03-01	
-140707	Crabtree Infants' School	2X6MTFQ9	919	5	7	Mrs Sally Pattrick				45	PRI		M		2014-04-01	
-140708	Crabtree Junior School	2X6MTFQN	919	7	11	Mr Ian Pattrick				45	PRI		M		2014-04-01	
-140786	The Hertfordshire & Essex High School and Science College	2X6MZTDB	919	11	18	 Cathy Tooze				45	SEC		G		2014-04-01	
-140954	Lanchester Community Free School	9CPSCCP	919	4	11	 Helen Lockham				39	PRI		M		2014-09-01	
-140955	Jupiter Community Free School	2X6MV4WB	919	4	11	 Sue Attard				39	PRI		M		2014-09-01	
-140956	Ascot Road Community Free School	9CPSCH5	919	4	11	Mrs Helen Lockham				39	PRI		M		2014-09-01	
-141004	The Watford UTC	9CPSCN0	919	14	19	Ms Emma Loveland				40	SEC		M		2014-09-01	
-141251	Pinewood School	2X6MZT45	919	11	16	 David McGachen				44			M		2014-09-01	
-141851	Windhill21	2X6MTKCB	919	3	11	 Phillippa Moore				45	PRI		M		2015-03-01	
-141898	Fair Field Junior School	9B1AHFC	919	7	11	 Matt Johnson				45	PRI		M		2015-04-01	
-142051	Haileybury Turnford	4D547M	919	11	18	Mr Robin Newman				46	SEC		M		2015-09-01	
-142221	Watford St John's Church of England Primary School	2X6MKQRD	919	4	11	Mrs Helen Langeveld	C22;C1	C22		39	PRI		M		2016-09-07	
-142257	Hailey Hall School	4D5CKW	919	11	16	 P Flint				44			B		2015-09-01	
-142413	Garden City Montessori School	2X6MXM92	919	2	12	  				11			M		2015-09-22	
-142862	Yavneh Primary School	9B1AHNG	919	4	11	Mrs Caroline Field	F7			39	PRI		M		2016-09-01	
-143131	Robert Barclay Academy	4D5BSY	919	11	18	Mr Ced De La Croix				46	SEC		M		2016-09-01	
-143409	Roselands Primary School	4D5CE2	919	5	11	Mrs J Carson				45	PRI		M		2016-09-01	
-143410	The Cranbourne Primary School	4D5MF5	919	4	11	Mrs Rachel Semark				45	PRI		M		2016-09-01	
-143603	Laurance Haines School		919	3	11	Mr James Roach				45	PRI		M		2016-11-01	
-143604	Larwood School		919	5	11	Mr S Trimble				44			M		2016-11-01	
-143648	Harpenden Free School		919	4	11	Mrs Lisa Davies				39	PRI				2016-09-01	
+school-eng	name	address	school-authority-eng	minimum-age	maximum-age	headteacher	religious-characters	religious-ethos	dioceses	organisation	school-phases	school-admissions-policy	school-gender	school-tags	start-date	end-date
+102256	Purcell School	9B1AK1J	919	8	19	Mr Stephen Yeo				school-type:11			M		1962-10-11	
+117065	Weston Way Nursery School	2X6MXMZY	919	3	5	Ms Jane Millett				la-maintained-school:117065	NUR		M			
+117066	Arlesdene Nursery School and Pre-School	4D4TEC	919	2	5	Mrs Catherine Croft				la-maintained-school:117066	NUR		M			
+117067	Greenfield Nursery School	4D4SBT	919	2	4	Mrs Deborah Harrison				la-maintained-school:117067	NUR		M			
+117068	Batford Nursery School	2X6MTFQ8	919	2	5	Mrs Sue Mansfield				la-maintained-school:117068	NUR		M			
+117069	Birchwood Nursery School	2X6MTB00	919	2	5	Mrs Kathryn Evans				la-maintained-school:117069	NUR		M			
+117070	Heath Lane Nursery School	9AQJZND	919	3	5	Mrs Pauline Kirtley				la-maintained-school:117070	NUR		M			
+117071	York Road Nursery School	2X6MXJA5	919	3	5	Mrs Helen Griffiths				la-maintained-school:117071	NUR		M			
+117072	Rye Park Nursery School	4D5GWB	919	2	5	Mrs Helen Ackerman				la-maintained-school:117072	NUR		M			
+117073	Nevells Road Nursery School	9C3H97E	919	3	5	Mrs M J Tyler				la-maintained-school:117073	NUR		M			2001-12-31
+117074	Muriel Green Nursery School	2X6MHB38	919	3	5	Mrs B Snijder				la-maintained-school:117074	NUR		M			2001-01-01
+117075	London Colney Nursery School	2X6MTBMX	919	3	5	Ms Barbara Fitton				la-maintained-school:117075	NUR		M			2015-03-31
+117076	Kingswood Nursery School	2X6MYGEW	919	2	5	Mrs Bernice Jackson				la-maintained-school:117076	NUR		M			
+117077	Oxhey Early Years Centre	2X6MYCMV	919	3	5	Mrs Rachel Fagan				la-maintained-school:117077	NUR		M			
+117078	Tenterfield Nursery School	2X6MTG52	919	3	5	Mrs Megan Wilcox				la-maintained-school:117078	NUR		M			
+117079	Ludwick Nursery School	2X6MTH2N	919	2	5	Mrs Karen James				la-maintained-school:117079	NUR		M			
+117080	Peartree Way Nursery School	9C3QP0K	919	2	5	Mrs Deborah Willcox				la-maintained-school:117080	NUR		M			
+117081	Wall Hall Nursery School	9B1AK8C	919	3	5	Ms Cynthia Willey				la-maintained-school:117081	NUR		M			2003-12-31
+117082	Lea Valley Education Support Centre	9ACAQBC	919	5	16	Mrs A Brown				la-maintained-school:117082			M		1995-09-01	2009-08-31
+117083	Abbots Langley School	5T8FR7NZ	919	3	11	Mr Roger Billing				la-maintained-school:117083	PRI		M			
+117084	Ashwell Primary School	9C3H2ZH	919	3	11	Mrs Lisa Hall				la-maintained-school:117084	PRI		M			
+117085	Northgate Primary School	2X6MTK10	919	3	11	Mrs Deirdre Glasgow				la-maintained-school:117085	PRI		M			2012-07-31
+117086	Bovingdon Junior School	2X6MV9QV	919	7	11	  				la-maintained-school:117086	PRI		M			1998-09-01
+117087	Jenyns First School and Nursery	9B09NDE	919	3	9	Mrs Sandra Morris				la-maintained-school:117087	PRI		M			
+117088	Bushey Heath Primary School	9B1AJWD	919	3	11	Ms Penny Barefoot				la-maintained-school:117088	PRI		M			
+117089	Highwood Primary School	9B1AK0C	919	3	11	 Della Allen				la-maintained-school:117089	PRI		M			
+117090	Merry Hill Infant School and Nursery	9B1AJY1	919	3	7	Mrs Melissa Regnier				la-maintained-school:117090	PRI		M			
+117091	Holdbrook Primary School	4D50QJ	919	3	11	Mr Nick Heald				la-maintained-school:117091	PRI		M			
+117092	Four Swannes Primary School	4D50QH	919	3	11	Mrs G E Jones				la-maintained-school:117092	PRI		M			
+117093	Chorleywood Primary School	5T8FR9MQ	919	3	11	Mrs Rebecca Roberts				la-maintained-school:117093	PRI		M			
+117094	Beechfield School	9A2MXPG	919	3	11	Mr James Roach				la-maintained-school:117094	PRI		M			
+117095	New Briars Primary and Nursery School	2X6MTBHG	919	3	11	Miss Helen Turner				la-maintained-school:117095	PRI		M			2007-08-31
+117096	Shepherd Primary	5T8FR93G	919	3	11	Mrs Claire Foad				la-maintained-school:117096	PRI		M			
+117097	Hobletts Manor Junior School	5T8FVQCE	919	7	11	Mrs Sally Short				la-maintained-school:117097	PRI		M			
+117098	The Russell School	5T8FR999	919	3	11	Mrs Claire Pitt				la-maintained-school:117098	PRI		M			
+117099	Cowley Hill School	9B1AJ1X	919	3	11	 Jon Hood				la-maintained-school:117099	PRI		M			
+117100	Flamstead Village School	2X6MTE37	919	3	11	Ms Sarah Jones				la-maintained-school:117100	PRI		M			
+117101	Gaddesden Row JMI School	9A2N6TH	919	4	11	Mr Nick Read				la-maintained-school:117101	PRI		M			
+117102	Sauncey Wood Primary School	5T8GM330	919	4	11	Mr Steven Lloyd				la-maintained-school:117102	PRI		M			
+117103	Manland Primary School	2X6MTFDJ	919	4	11	Miss Melanie Smith				la-maintained-school:117103	PRI		M			
+117104	Gascoyne Cecil Junior School	2X6MTB4W	919	7	11	Mr D Petherick				la-maintained-school:117104	PRI		M			1999-09-01
+117105	Green Lanes Primary School	2X6MTBHN	919	5	11	 Michele Johnson				la-maintained-school:117105	PRI		M			
+117106	George Street Primary School	5T8JQF7A	919	3	11	Mrs Heather Freeman				la-maintained-school:117106	PRI		M			
+117107	Boxmoor Primary School	5T8JQEZ2	919	4	11	Mrs Vicky Campos				la-maintained-school:117107	PRI		M			
+117108	Two Waters Primary School	2X6MV9Y3	919	3	11	Mr Tim Gately				la-maintained-school:117108	PRI		M			
+117109	Tudor Primary School	2X6MVAE8	919	3	11	Mr Rob Weightman				la-maintained-school:117109	PRI		M			
+117110	South Hill Primary School	9A2N6DJ	919	5	11	Mr David Smith				la-maintained-school:117110	PRI		M			
+117111	Abel Smith School	9B09VV9	919	2	11	Mrs Gillian Langan				la-maintained-school:117111	PRI		M			
+117112	Hexton Junior Mixed and Infant School	9C3H2AA	919	4	11	Mrs Joanne Webb				la-maintained-school:117112	PRI		M			
+117113	Highbury Infant School and Nursery	2X6MXHN8	919	3	7	Mrs Helen Avey				la-maintained-school:117113	PRI		M			
+117114	Strathmore Infant and Nursery School	5T8GM5Z2	919	3	7	Mrs Bernadette Holmes				la-maintained-school:117114	PRI		M			
+117115	Highover Junior Mixed and Infant School	2X6MXGR1	919	3	11	Mrs Lisa Hayes				la-maintained-school:117115	PRI		M			
+117116	Wilshere-Dacre Junior School	9C3H8GG	919	7	11	Mrs Susan Sheffield				la-maintained-school:117116	PRI		M			2014-02-28
+117117	Hunsdon Junior Mixed and Infant School	9B09WAB	919	4	11	Mr Jonathan Millward				la-maintained-school:117117	PRI		M			
+117118	Kimpton Primary School	2X6MXHA3	919	3	11	Mrs Tracy Clements				la-maintained-school:117118	PRI		M			
+117119	Breachwood Green Junior Mixed and Infant School	9C3H4CS	919	4	11	Mrs Rosemarie Bethel				la-maintained-school:117119	PRI		M			
+117120	Knebworth Primary and Nursery School	9C3H3W0	919	3	11	 Michael John				la-maintained-school:117120	PRI		M			
+117121	Wilbury Junior School	2X6MXM4C	919	7	11	Miss Ellie Shaw				la-maintained-school:117121	PRI		M			
+117122	Grange Junior School	2X6MXMAX	919	7	11	Miss Zoe Mathie				la-maintained-school:117122	PRI		M			
+117123	Hillshott Infant School and Nursery	2X6MXKC1	919	3	7	Mrs Lucy Leighton				la-maintained-school:117123	PRI		M			
+117124	Westbury Primary and Nursery School	9C3H9JV	919	3	11	Mrs Anna Marshall				la-maintained-school:117124	PRI		M			2009-08-31
+117125	Hertford Heath Primary and Nursery School	9B09MHA	919	3	11	Mrs Janice Smith				la-maintained-school:117125	PRI		M			
+117126	Little Hadham Primary School	9B09XQM	919	4	11	Mrs Elizabeth Stockley				la-maintained-school:117126	PRI		M			
+117127	Markyate Village School and Nursery	5T8JQERT	919	4	11	Miss Sally Esom				la-maintained-school:117127	PRI		M			
+117128	Pirton School	5T8GM5Z6	919	4	11	Mrs Joanne Webb				la-maintained-school:117128	PRI		M			
+117129	Reed First School	2X6MXNM0	919	3	9	Mrs Jackie Harvey				la-maintained-school:117129	PRI		M			
+117130	Yorke Mead Primary School	5T8FRBSD	919	3	11	Ms Lucille Pollard				la-maintained-school:117130	PRI		M			
+117131	Harvey Road Primary School	5T8FR9S8	919	3	11	Mr Nick Rowlands				la-maintained-school:117131	PRI		M			
+117132	Little Green Junior School	5T8FR9SA	919	7	11	Mrs Janice Tearle				la-maintained-school:117132	PRI		M			
+117133	Malvern Way Infant and Nursery School	5T8FR9SP	919	3	7	Mrs Emma Cole				la-maintained-school:117133	PRI		M			
+117134	Tannery Drift School	2X6MXNAM	919	3	9	Mrs Anna Greetham				la-maintained-school:117134	PRI		M			
+117135	Bernards Heath Infant and Nursery School	2X6MTANG	919	3	7	Mrs Hannah Rimmer				la-maintained-school:117135	PRI		M			
+117136	Camp Primary and Nursery School	5T8JAKCQ	919	3	11	Mrs Sharon Barton				la-maintained-school:117136	PRI		M			
+117137	Fleetville Junior School	5T8JAG03	919	7	11	Mr J Loukes				la-maintained-school:117137	PRI		M		1997-02-26	2012-05-31
+117138	Fleetville Infant and Nursery School	2X6MTAHR	919	3	7	Mrs Androulla Peek				la-maintained-school:117138	PRI		M		1996-06-05	2012-05-31
+117139	Garden Fields Junior Mixed and Infant School	5T8JAKZZ	919	5	11	Mr Chris Jukes				la-maintained-school:117139	PRI		M			
+117140	St Peter's School	2X6MT9N0	919	3	11	Mrs Gillie Young				la-maintained-school:117140	PRI		M			
+117141	Aboyne Lodge Junior Mixed and Infant School	2X6MTDHF	919	3	11	Mrs Amanda Abley				la-maintained-school:117141	PRI		M			
+117142	Mandeville Primary School	2X6MT9TB	919	3	11	Ms Amanda Godfrey				la-maintained-school:117142	PRI		M			2012-12-31
+117143	Bernards Heath Junior School	5T8JAQW9	919	7	11	Mrs Sian Kilpatrick				la-maintained-school:117143	PRI		M			
+117144	St Paul's Walden Primary School	2X6MXHA2	919	4	11	 Louise Cerqua				la-maintained-school:117144	PRI		M			
+117145	Colney Heath Junior Mixed Infant and Nursery School	2X6MTEC1	919	4	11	Mr Pete Rose				la-maintained-school:117145	PRI		M			
+117146	London Colney Primary & Nursery School	2X6MTBMW	919	3	11	Mrs Sarah Joyce				la-maintained-school:117146	PRI		M			
+117147	Sandon Junior Mixed and Infant School	2X6MXNX1	919	4	11	Mrs Margaret Gilbert				la-maintained-school:117147	PRI		M			
+117148	Sandridge School	2X6MTEVR	919	4	11	Miss Lisa Roberts				la-maintained-school:117148	PRI		M			
+117149	Fawbert and Barnard Infants' School	9B09WDC	919	3	7	Ms Angela Euesden				la-maintained-school:117149	PRI		M			
+117150	Shenley Primary School	9B1AHCZ	919	3	11	Ms Katy Longley				la-maintained-school:117150	PRI		M			
+117151	Letchmore Infants' and Nursery School	9C3QN7X	919	3	7	Mrs Roma Marshall				la-maintained-school:117151	PRI		M			
+117152	Fairlands Primary School and Nursery	9C3QN1A	919	3	11	Mr Robert Staples				la-maintained-school:117152	PRI		M			
+117153	Therfield First School	2X6MXNSQ	919	5	9	Mrs Tara McGovern				la-maintained-school:117153	PRI		M			
+117154	Walkern Primary School	2X6MXFT3	919	4	11	Mr Jonty Hall				la-maintained-school:117154	PRI		M			
+117155	The Orchard Primary School	2X6MYG70	919	3	11	Mr Paul Sutton				la-maintained-school:117155	PRI		M			
+117156	Central Primary School	5T8FR0MP	919	3	11	Mr John Mynott				la-maintained-school:117156	PRI		M			
+117157	Bushey and Oxhey Infant School	5T8FR2HA	919	5	7	Mrs Mary Ann Cooper				la-maintained-school:117157	PRI		M			
+117158	Chater Junior School	2X6MYDFF	919	7	11	Mr P McEntee				la-maintained-school:117158	PRI		M			
+117159	Chater Infant School	2X6MYDDS	919	3	7	 Amrit Bal-Richards				la-maintained-school:117159	PRI		M			
+117160	Field Junior School	2X6MYE01	919	7	11	Mrs Julie Henley-Washford				la-maintained-school:117160	PRI		M			
+117161	Watford Field School (Infant & Nursery)	5T8FR161	919	3	7	Mrs Angela Butcher				la-maintained-school:117161	PRI		M			
+117162	Parkgate Junior School	2X6MYFQH	919	7	11	Mrs Sarah Pipe				la-maintained-school:117162	PRI		M			
+117163	Parkgate Infants' and Nursery School	2X6MYFQM	919	3	7	Miss A E Lawrence				la-maintained-school:117163	PRI		M			
+117164	Garston Infants' School	9A2MY3R	919	5	7	Mrs J Sexton				la-maintained-school:117164	PRI		M			2005-08-31
+117165	Knutsford School	2X6MYFQJ	919	3	11	Miss Eileen Anderson				la-maintained-school:117165	PRI		M			
+117166	St Meryl School	2X6MYCWQ	919	3	11	Mrs Michele Geddes				la-maintained-school:117166	PRI		M			
+117167	Cassiobury Junior School	5T8FR15R	919	7	11	Miss Jenny Sherry				la-maintained-school:117167	PRI		M			
+117168	Kingsway Junior School	2X6MYGF8	919	7	11	Mr Darren Armoogum				la-maintained-school:117168	PRI		M			
+117169	Warren Dell Primary School	5T8FR6C3	919	2	11	Mrs Jenny Morley				la-maintained-school:117169	PRI		M			
+117170	Oxhey Wood Primary School	5T8FRCN0	919	3	11	Mrs Jenny Morley				la-maintained-school:117170	PRI		M			
+117171	Watton-at-Stone Primary and Nursery School	9B09WXE	919	2	11	Mrs Zoe Hussain				la-maintained-school:117171	PRI		M			
+117172	Peartree Primary School	2X6MTH0Y	919	5	11	Miss Clare Herbert				la-maintained-school:117172	PRI		M			
+117173	Blackthorn Junior School	2X6MTH0W	919	7	11	Mrs S Jennings				la-maintained-school:117173	PRI		M			2001-12-31
+117174	Templewood Primary School	5T8JHBRH	919	3	11	Miss Angharad Morris				la-maintained-school:117174	PRI		M			
+117175	Holwell Primary School	2X6MTH11	919	5	11	Mr Joe McIntyre				la-maintained-school:117175	PRI		M			
+117176	Widford School	9B09WXS	919	4	11	Mrs Diane Penn				la-maintained-school:117176	PRI		M			
+117177	Wymondley Junior Mixed and Infant School	2X6MXGZ4	919	4	11	Mrs Alison Emmerson				la-maintained-school:117177	PRI		M			
+117178	Tanners Wood Junior Mixed and Infant School	2X6MYKRX	919	3	11	Mrs Parv Qureshi				la-maintained-school:117178	PRI		M			
+117179	Havers Infant School		919	3	7	Mrs J J Evans				la-maintained-school:117179	PRI		M			2005-12-31
+117180	Hurst Drive Primary School	4D4SBR	919	4	11	Mr Chris O'Connor				la-maintained-school:117180	PRI		M			
+117181	Woodlands Primary School	9B1AJ1Y	919	3	11	Mrs PJ Woods				la-maintained-school:117181	PRI		M			
+117182	Summerswood Primary School	9B1AHM6	919	3	11	Miss Sarah Kneller				la-maintained-school:117182	PRI		M			
+117183	Kenilworth Primary School	9B1AHNW	919	3	11	Ms S Jayasuriya				la-maintained-school:117183	PRI		M			
+117184	Meryfield Primary School	9B1AJ14	919	3	11	Mrs Rosemarie Alexander				la-maintained-school:117184	PRI		M			
+117185	Salisbury Infants' School	5T8JHBZT	919	5	7	Mrs M Rimell				la-maintained-school:117185	PRI		M			1999-09-01
+117186	Icknield Infant and Nursery School	2X6MXM4M	919	3	7	Mrs J Egan				la-maintained-school:117186	PRI		M			
+117187	Bowmansgreen Primary School	5T8JAMAR	919	4	11	Ms Anna Lippa				la-maintained-school:117187	PRI		M			
+117188	Margaret Wix Primary School	5T8JAM3C	919	3	11	Mr Damien Johnston				la-maintained-school:117188	PRI		M			
+117189	Broom Barns Community Primary School	9C3QMW8	919	4	11	Mrs Jayne Currant				la-maintained-school:117189	PRI		M			
+117190	Lea Farm Junior School	9A2MY3R	919	7	11	Mrs J M Graham				la-maintained-school:117190	PRI		M			2005-08-31
+117191	Alban Wood Junior School	5T8FR162	919	7	11	Mr K Sampey				la-maintained-school:117191	PRI		M			2005-08-31
+117192	Little Furze Junior Mixed and Infant School	5T8FR6C5	919	3	11	Mr D G Dougans				la-maintained-school:117192	PRI		M			2004-12-16
+117193	Greenfields Primary School	2X6MYCZB	919	3	11	Mrs Helen Cook				la-maintained-school:117193	PRI		M			
+117194	Woodhall Primary School	5T8FR714	919	3	11	Mrs E Lesley Spence				la-maintained-school:117194	PRI		M			
+117195	Saffron Green Primary School	9B1AHQY	919	3	11	Mrs Linda Storey				la-maintained-school:117195	PRI		M			
+117196	Hazelgrove Primary School	2X6MTBHG	919	4	11	Mr J S Dunford				la-maintained-school:117196	PRI		M			2004-08-31
+117197	Hobletts Manor Infants' School	9A2N6M9	919	3	7	Mrs Wendy Hull				la-maintained-school:117197	PRI		M			
+117198	Chaulden Junior School	2X6MZR56	919	7	11	Ms Pam Stocks				la-maintained-school:117198	PRI		M			2013-04-30
+117199	Roebuck Junior School	9C3QNHH	919	7	11	Mr R K Jones				la-maintained-school:117199	PRI		M			2001-04-18
+117200	Bedwell Primary School	9C3QP13	919	4	11	Mrs J E Moore				la-maintained-school:117200	PRI		M			
+117201	Flamstead End Junior School	4D4PHZ	919	7	11	Mr Don Round				la-maintained-school:117201	PRI		M			2003-08-31
+117202	Chaulden Infants' and Nursery	9A2N7AH	919	3	7	Mrs Jacqueline Susan Hood				la-maintained-school:117202	PRI		M			
+117203	Haslewood Junior School	4D5EGC	919	7	11	Mr J Schmitt				la-maintained-school:117203	PRI		M			2002-12-31
+117204	Roebuck Infant School	9C3QNHH	919	3	7	Mrs M A Dodds				la-maintained-school:117204	PRI		M			2001-04-18
+117205	Peartree Spring Junior School	5T8FDF2Q	919	7	11	Mrs Teresa Skeggs				la-maintained-school:117205	PRI		M			2014-08-31
+117206	Peartree Spring Primary School	9ADG70Z	919	4	11	Mrs Teresa Skeggs				la-maintained-school:117206	PRI		M			
+117207	Longmeadow Junior School	5T8FDGYV	919	7	11	Mr T Longhurst				la-maintained-school:117207	PRI		M			2005-08-31
+117208	Longmeadow Infant and Nursery School	5T8FDGYV	919	3	7	Mrs J Wilson				la-maintained-school:117208	PRI		M			2005-08-31
+117209	Bandley Hill Junior School	9C3QPDF	919	7	11	  				la-maintained-school:117209	PRI		M			1998-03-20
+117210	Bandley Hill Infants' School	9C3QPDF	919	5	7	  				la-maintained-school:117210	PRI		M			1998-03-20
+117211	Roundwood Primary School	5T8JAR3E	919	3	11	Mrs Suzanne Webb				la-maintained-school:117211	PRI		M			
+117212	Wheatfields Junior Mixed School	5T8JAQYW	919	7	11	Mr Lyndon Evans				la-maintained-school:117212	PRI		M			
+117213	Thumbswood Infant School	2X6MTH0X	919	5	7	Mr P J Steven				la-maintained-school:117213	PRI		M			2001-12-31
+117214	Chambersbury Primary School	2X6MVA2W	919	3	11	Mr Desmond Taylor				la-maintained-school:117214	PRI		M			
+117215	Broadfield Junior School	5T8JQEN7	919	7	11	Mr Matthew Heasman				la-maintained-school:117215	PRI		M			2007-12-31
+117216	Broadfield Infants' School	2X6MV4MW	919	3	7	Mrs Jane Prior				la-maintained-school:117216	PRI		M			2007-12-31
+117217	Windermere Primary School	2X6MTAYM	919	5	11	Mrs Davina Raftery				la-maintained-school:117217	PRI		M			
+117218	Anstey First School	9B1RAP4	919	2	9	Mrs Amy Myers				la-maintained-school:117218	PRI		M			
+117219	Monksmead School	9B1AHNH	919	2	11	Mrs Cathy Elsley				la-maintained-school:117219	PRI		M			
+117220	Howe Dell Primary School	9AE9DVC	919	3	11	Mrs Debra Massey				la-maintained-school:117220	PRI		M			
+117221	Almond Hill Junior School	5T8FDH6F	919	7	11	Mrs Judith Lovelock				la-maintained-school:117221	PRI		M			
+117222	Oakwood Primary School	2X6MTEAJ	919	4	11	Ms Zoe Buckley				la-maintained-school:117222	PRI		M			
+117223	Northfields Infants and Nursery School	2X6MXMBX	919	3	7	Miss Claire Logan				la-maintained-school:117223	PRI		M			
+117224	Purwell Primary School	5T8GM5YV	919	3	11	Mr Richard Cano				la-maintained-school:117224	PRI		M			
+117225	Killigrew Junior School	5T8JAQST	919	7	11	Mrs Tracy Mylotte				la-maintained-school:117225	PRI		M			2008-08-31
+117226	Camps Hill Community Primary School	9C3QPE3	919	2	11	Mrs Emma Flawn				la-maintained-school:117226	PRI		M			
+117227	Harwood Hill Junior Mixed Infant and Nursery School	5T8JHBHC	919	3	11	Miss Yvette Page				la-maintained-school:117227	PRI		M			
+117228	Fair Field Junior School	9B1AHFC	919	7	11	Mr Matt Johnson				la-maintained-school:117228	PRI		M			2015-03-31
+117229	Creswick Primary and Nursery School	9AE9DWC	919	4	11	Mrs Fay Brett				la-maintained-school:117229	PRI		M			
+117230	Thorley Hill Primary School	2X6MTKB4	919	3	11	Mrs Kim Perez				la-maintained-school:117230	PRI		M			
+117231	Micklem Primary School	2X6MTSD9	919	3	11	Miss Elizabeth Ormonde				la-maintained-school:117231	PRI		M			
+117232	Mayfield Infants' School and Nursery	4D5476	919	3	7	Mrs Brenda Mitchell				la-maintained-school:117232	PRI		M			2010-08-31
+117233	Brookland Junior School	4D559A	919	7	11	Mr Gavin Douglas				la-maintained-school:117233	PRI		M			
+117234	The Reddings Primary School	2X6MVA2V	919	3	11	Miss Tracy Prickett				la-maintained-school:117234	PRI		M			
+117235	How Wood Primary and Nursery School	5T8JAQT4	919	3	11	Mrs Cynthia Rowe				la-maintained-school:117235	PRI		M			
+117236	Redbourn Infants' and Nursery School	9AQQSA1	919	3	7	Mrs Jane C Byrne				la-maintained-school:117236	PRI		M			
+117237	Lodge Farm Junior Mixed School	9C3QPF8	919	7	11	Mrs L Stinchcombe				la-maintained-school:117237	PRI		M			2000-04-30
+117238	Lodge Farm Infants' School	9C3QPF8	919	3	7	Mrs C Rodbard				la-maintained-school:117238	PRI		M			2000-04-30
+117239	Rossgate Primary School	2X6MTSE6	919	3	11	Mrs Margaret Priggs				la-maintained-school:117239	PRI		M			2008-08-31
+117240	Skyswood Primary & Nursery School	2X6MTEVX	919	3	11	Mr Robert Bridle				la-maintained-school:117240	PRI		M			
+117241	Martindale Primary and Nursery School	2X6MTSDA	919	3	11	Mrs Jill Litchfield				la-maintained-school:117241	PRI		M			2008-08-31
+117242	Bushey Manor Junior School	9B1AK1Q	919	7	11	Miss Kate Fiddler				la-maintained-school:117242	PRI		M			
+117243	Goffs Oak Primary & Nursery School	4D4RPT	919	3	11	Ms Michelle Matthews				la-maintained-school:117243	PRI		M			
+117244	Summercroft Junior School	9B09V9Y	919	7	11	Mr Michael Smith				la-maintained-school:117244	PRI		M			2005-12-31
+117245	Eastbury Farm Primary School	5T8FRA25	919	3	11	Mrs Baljit Ahluwalia				la-maintained-school:117245	PRI		M			
+117246	Burydale Junior School	9C3QNZ0	919	7	11	Miss L Hodgson				la-maintained-school:117246	PRI		M			2005-08-31
+117247	Shephall Green Infant and Nursery School	5T8FDGVQ	919	3	7	Ms Lee Rieksts				la-maintained-school:117247	PRI		M			2005-08-31
+117248	Bedmond Village Primary and Nursery School	5T8FR7WQ	919	3	11	Mrs Emma Woollon				la-maintained-school:117248	PRI		M			
+117249	Gade Valley Primary School	2X6MZ9HS	919	3	11	Mr Daniel Barron				la-maintained-school:117249	PRI		M			
+117250	Cunningham Hill Junior School	5T8JAKE5	919	7	11	Ms J Elbourne-Cload				la-maintained-school:117250	PRI		M			
+117251	Pin Green Primary School and Nursery	9C3QNNT	919	4	11	Ms Carole Sangster				la-maintained-school:117251	PRI		M			2005-08-31
+117252	Homerswood Primary and Nursery School	5T8JHBMF	919	3	11	Mrs Debbie Shirley				la-maintained-school:117252	PRI		M			
+117253	Whitehill Junior School	2X6MXHN9	919	7	11	Mr Steve Mills				la-maintained-school:117253	PRI		M			
+117254	Westfield Primary School and Nursery	5T8JQF0C	919	3	11	Mrs Suzanne Stace				la-maintained-school:117254	PRI		M			
+117255	Downfield Primary School	4D50X6	919	2	11	Miss Sarah Goldsmith				la-maintained-school:117255	PRI		M			
+117256	Pixies Hill Primary School	2X6MTSD7	919	4	11	Mr Martin Smith				la-maintained-school:117256	PRI		M			
+117257	Rowans Primary School	2X6MTGAS	919	3	11	Mrs Joanne Reed				la-maintained-school:117257	PRI		M			
+117258	The Grove Junior School	2X6MTEXS	919	7	11	Ms Maggie Clifford				la-maintained-school:117258	PRI		M			
+117259	Pixmore Junior School	2X6MXJY8	919	7	11	Mrs Alex Evans				la-maintained-school:117259	PRI		M			
+117260	Swing Gate Infant School and Nursery	2X6MVB3M	919	3	7	Mrs Francesca Gallagher				la-maintained-school:117260	PRI		M			
+117261	Oaklands Primary School	2X6MTFVS	919	5	11	Mrs Julie Petitt				la-maintained-school:117261	PRI		M			
+117262	Flamstead End Infant and Nursery School	4D4PHY	919	3	7	Mrs S A Killey				la-maintained-school:117262	PRI		M			2003-08-31
+117263	Hollybush Primary School	9B09VVZ	919	3	11	Mr Alan Brown				la-maintained-school:117263	PRI		M			
+117264	Oughtonhead Junior School	5T8GM5Z3	919	7	11	Mrs A Kibby				la-maintained-school:117264	PRI		M			2001-09-01
+117265	Oughtonhead Infants' School	5T8GM5Z3	919	3	7	Mrs D Hallett				la-maintained-school:117265	PRI		M			2001-09-01
+117266	Maple Cross Junior Mixed Infant and Nursery School	5T8FR8QR	919	4	11	Mr Duncan Roberts				la-maintained-school:117266	PRI		M			
+117267	Killigrew Infant and Nursery School	5T8JAQST	919	3	7	Miss Tracy Mylotte				la-maintained-school:117267	PRI		M			2008-08-31
+117268	Wheatfields Infants' and Nursery School	9AQQQ70	919	3	7	Mrs Jane Whitehurst				la-maintained-school:117268	PRI		M			
+117269	Moss Bury Primary School and Nursery	9C3QP1W	919	3	11	Mr Gareth Linwood				la-maintained-school:117269	PRI		M			
+117270	Westfield Community Primary School	4D5C6Q	919	5	11	Mrs Diane Ashmore				la-maintained-school:117270	PRI		M			
+117271	Priors Wood Primary School	2X6MXAJ9	919	3	11	Mrs Rebecca Collins				la-maintained-school:117271	PRI		M			
+117272	Brookland Infant and Nursery School	4D5THA	919	3	7	Mrs Alison Atkinson				la-maintained-school:117272	PRI		M			
+117273	Summercroft Infant and Nursery School	9B09V9Y	919	3	7	Miss C Evans				la-maintained-school:117273	PRI		M			2005-12-31
+117274	Goldfield Infants' and Nursery School	5T8JQEW6	919	3	7	Mrs Debbie Stevens				la-maintained-school:117274	PRI		M			
+117275	Tower Primary School	9B09WW3	919	2	11	Mrs Joanne Lyness				la-maintained-school:117275	PRI		M			
+117276	Greenway Primary and Nursery School	2X6MVBEG	919	3	11	Mrs Katharine Ellwood				la-maintained-school:117276	PRI		M			
+117277	Thorn Grove Primary School	2X6MTM1G	919	3	11	Mr Pete Luck				la-maintained-school:117277	PRI		M			
+117278	Icknield Walk First School	2X6MXNF3	919	3	9	Mrs Jane Sherwood				la-maintained-school:117278	PRI		M			
+117279	Cunningham Hill Infant School	9AQQSA0	919	5	7	Mrs Charlotte Cooper				la-maintained-school:117279	PRI		M			
+117280	Reedings Junior School	9B09WC0	919	7	11	Mrs Laura Webber				la-maintained-school:117280	PRI		M			
+117281	The Grove Infant and Nursery School	2X6MTF03	919	3	7	Ms Anna Archer				la-maintained-school:117281	PRI		M			
+117282	The Hammond Primary School	5T8JQEQF	919	5	11	Ms Gail Porterfield				la-maintained-school:117282	PRI		M			2011-07-31
+117283	Kings Langley Primary School	5T8JQEXY	919	3	11	Mrs Paula Harris				la-maintained-school:117283	PRI		M			
+117284	Forres Primary School	4D5JF9	919	5	11	Mrs Susan Camp				la-maintained-school:117284	PRI		M			
+117285	Martins Wood Primary School	2X6MX9VD	919	2	11	Mr Tom Evans				la-maintained-school:117285	PRI		M			
+117286	Dundale Primary School and Nursery	2X6MZ9Y6	919	3	11	Mr Simon King				la-maintained-school:117286	PRI		M			
+117287	Crabtree Junior School	2X6MTFQN	919	7	11	Mr Ian Pattrick				la-maintained-school:117287	PRI		M			2014-03-31
+117288	Redbourn Junior School	2X6MTDTD	919	7	11	Mr Nathan Hairon				la-maintained-school:117288	PRI		M			
+117289	Arnett Hills Junior Mixed and Infant School	5T8FR8CN	919	4	11	Miss T Ali				la-maintained-school:117289	PRI		M			
+117290	Holywell Primary School	5T8FR0E4	919	3	11	Mr Coert Van Straaten				la-maintained-school:117290	PRI		M			
+117291	The Firs Junior School	2X6MTKCB	919	7	11	Mrs M C Thurley				la-maintained-school:117291	PRI		M			2005-12-31
+117292	Trotts Hill Primary and Nursery School	9C3QNTR	919	4	11	Miss Colette Pidgeon				la-maintained-school:117292	PRI		M			
+117293	Cassiobury Infant and Nursery School	9CPSB9K	919	3	7	Mrs Emma Edwards				la-maintained-school:117293	PRI		M			
+117294	Panshanger Primary School	2X6MTGAT	919	3	11	Mrs Sarah Holt				la-maintained-school:117294	PRI		M			
+117295	Bovingdon Infants' School	2X6MZ9CG	919	5	7	  				la-maintained-school:117295	PRI		M			1998-09-01
+117296	Bournehall Primary School	9B1AJVS	919	4	11	Mrs Jill Litchfield				la-maintained-school:117296	PRI		M			
+117297	Mill Mead Primary School	9B09W4W	919	3	11	Mrs Sue Nesbitt-Larking				la-maintained-school:117297	PRI		M			
+117298	Maple Primary School	5T8JAQW1	919	4	11	Mr Timothy Bowen				la-maintained-school:117298	PRI		M			
+117299	Round Diamond Primary School	9APZHJM	919	3	11	Mrs Zoe Phillips				la-maintained-school:117299	PRI		M			
+117300	Hartsbourne Primary School	9B1AK05	919	4	11	Mrs Valerie Hudson				la-maintained-school:117300	PRI		M			
+117301	Beech Hyde Primary School and Nursery	5T8JAR6K	919	3	11	Miss Hazel Millard				la-maintained-school:117301	PRI		M			
+117302	Andrews Lane Primary School	4D4Q89	919	3	11	Mrs Emma Devally				la-maintained-school:117302	PRI		M			
+117303	Newberries Primary School	9B1AHFF	919	4	11	Ms Ness Peters				la-maintained-school:117303	PRI		M			
+117304	Rickmansworth Park Junior Mixed and Infant School	5T8FR92K	919	5	11	Mrs Peta Dyke				la-maintained-school:117304	PRI		M			
+117305	Mandeville Primary School	2X6MT9TB	919	3	11	Miss Kara Hales				la-maintained-school:117305	PRI		M			
+117306	Giles Junior School	5T8FDH1E	919	7	11	Mrs Heather Davies				la-maintained-school:117306	PRI		M			
+117307	The Cranbourne Primary School	4D5MF5	919	4	11	Mrs Rachel Semark				la-maintained-school:117307	PRI		M			2016-08-31
+117308	Bromet Primary School	2X6MYCN6	919	5	11	Mrs Maria Pace				la-maintained-school:117308	PRI		M			
+117309	Millfield First and Nursery School	2X6MXNXS	919	3	9	Mrs Kathy Willett				la-maintained-school:117309	PRI		M			
+117310	Hillmead Primary School	9B09Q1V	919	3	11	Mrs S L Keefe				la-maintained-school:117310	PRI		M			
+117311	Nascot Wood Junior School	5T8FR16E	919	7	11	Mrs Christina Singh				la-maintained-school:117311	PRI		M			
+117312	Crabtree Infants' School	2X6MTFQ9	919	5	7	Mrs Jane Whitehurst				la-maintained-school:117312	PRI		M			2014-03-31
+117313	The Ryde School	5T8JHC95	919	3	11	Mrs Sue Thompson				la-maintained-school:117313	PRI		M			
+117314	William Ransom Primary School	5T8GM5Z0	919	4	11	Mrs Mary Driver				la-maintained-school:117314	PRI		M			
+117315	Prae Wood Primary School	2X6MTD7F	919	3	11	Mrs Jackie Stephenson				la-maintained-school:117315	PRI		M			
+117316	The Giles Infant and Nursery School	9C3QP5S	919	3	7	Mrs Rouane Mendel				la-maintained-school:117316	PRI		M			
+117317	Kingsway Infants' School	5T8FR163	919	5	7	Mrs Caroline Tristram-Walmsley				la-maintained-school:117317	PRI		M			
+117318	Alban Wood Infant and Nursery School	2X6MYGZD	919	3	7	Mrs Y Davis				la-maintained-school:117318	PRI		M			2005-08-31
+117319	Kingshill Infant School	5T8HG06K	919	3	7	Mrs Catherine Reemer				la-maintained-school:117319	PRI		M			
+117320	Laurance Haines School	5T8FR3MT	919	3	11	Mr James Roach				la-maintained-school:117320	PRI		M			2016-10-31
+117321	Woodside Primary School	4D4KHF	919	4	11	Dr Keith Richmond				la-maintained-school:117321	PRI		M			
+117322	Woolenwick Junior School	9C3QMJX	919	7	11	Mr Mike Crabtree				la-maintained-school:117322	PRI		M			
+117323	Woolenwick Infant and Nursery School	5T8FDH83	919	3	7	Ms Usha Dhorajiwala				la-maintained-school:117323	PRI		M			
+117324	Leavesden JMI School	2X6MYGZE	919	3	11	Mrs Victoria Lyon				la-maintained-school:117324	PRI		M			
+117325	Springmead Primary School	5T8JHB1W	919	3	11	Miss Jennifer Moles				la-maintained-school:117325	PRI		M			
+117326	Longlands Primary School and Nursery	4D56ZK	919	3	11	Ms Lee-Ann Britten				la-maintained-school:117326	PRI		M			
+117327	The Lea Primary School and Nursery	5T8JAMXC	919	3	11	Mrs Sharon Swinson				la-maintained-school:117327	PRI		M			
+117328	Wheatcroft Primary School	2X6MXBM8	919	3	11	Mr Alisdair Skinner				la-maintained-school:117328	PRI		M			
+117329	Mary Exton Primary School	5T8GM5YW	919	5	11	Mrs Lisa Hayes				la-maintained-school:117329	PRI		M			
+117330	Lordship Farm Primary School	9C3H4EB	919	3	11	Mr Ben Parry				la-maintained-school:117330	PRI		M			
+117331	Studlands Rise First School	2X6MXNSX	919	3	9	Miss Alison Doke				la-maintained-school:117331	PRI		M			
+117332	Roman Way First School	2X6MXNAN	919	3	9	Mrs Emma Edwards				la-maintained-school:117332	PRI		M			
+117333	Lime Walk Primary School	2X6MVAGM	919	3	11	Mr Robert Hutchings				la-maintained-school:117333	PRI		M			
+117334	Fairfields Primary School and Nursery	4D4Q88	919	3	11	Mr Giovanni Gaidoni				la-maintained-school:117334	PRI		M			
+117335	Aycliffe Drive Primary School	2X6MV52E	919	3	11	Mrs Maria Green				la-maintained-school:117335	PRI		M			
+117336	Holtsmere End Junior School	2X6MV5B1	919	7	11	Mrs Emma McGuigan				la-maintained-school:117336	PRI		M			
+117337	Samuel Lucas Junior Mixed and Infant School	9ADWWZ9	919	4	11	Mrs Tracy Thomas				la-maintained-school:117337	PRI		M			
+117338	Roselands Primary School	4D5CE2	919	5	11	Mrs J Carson				la-maintained-school:117338	PRI		M			2016-08-31
+117339	Cherry Tree Primary School	5T8FR0ZN	919	3	11	Ms Jessie Bruce				la-maintained-school:117339	PRI		M			
+117340	Coates Way JMI and Nursery School	9A2MY90	919	3	11	Mr Steven Wells				la-maintained-school:117340	PRI		M			
+117341	Grove Road Primary School	2X6MV8D9	919	3	11	Miss Sharon Sanderson				la-maintained-school:117341	PRI		M			
+117342	High Beeches Primary School	5T8JAR5S	919	5	11	Ms Sara Lawrence				la-maintained-school:117342	PRI		M			
+117343	Barncroft Primary School	5T8JQH12	919	3	11	Mr Geoff Allen				la-maintained-school:117343	PRI		M			2008-08-31
+117344	Jupiter Drive Junior Mixed and Infant School	2X6MV4WB	919	5	11	Mrs Margie Knight				la-maintained-school:117344	PRI		M			2008-08-31
+117345	Stonehill School	2X6MXMC2	919	3	11	Mrs Elaine Close				la-maintained-school:117345	PRI		M			
+117346	Richard Whittington Primary School	2X6MTKGY	919	3	11	Mr A K Kern				la-maintained-school:117346	PRI		M			
+117347	Mount Pleasant Lane Junior Mixed and Infant School and Nursery	5T8JAMHS	919	3	11	Mr John Dibdin				la-maintained-school:117347	PRI		M			
+117348	Watchlytes Junior Mixed Infant and Nursery School	2X6MTGVX	919	3	11	Mr Andrew Farrugia				la-maintained-school:117348	PRI		M			
+117349	Brockswood Primary School	9A2N4RC	919	3	11	Mrs Gayle Voigt				la-maintained-school:117349	PRI		M			
+117350	Lannock Primary School	9C3H64A	919	3	11	Mrs Carol Pratt				la-maintained-school:117350	PRI		M			2009-08-31
+117351	Ryelands Primary School	4D5QYQ	919	5	11	Miss Fay Holness				la-maintained-school:117351	PRI		M			2007-08-31
+117352	Ashtree Primary School and Nursery	9C3QPDM	919	3	11	 Elizabeth Lewis				la-maintained-school:117352	PRI		M			
+117353	Sheredes Primary School	4D5BFS	919	3	11	Mrs Mary Childs				la-maintained-school:117353	PRI		M			
+117354	Radburn Primary School	2X6MXKK5	919	3	11	Mrs Wendy Dellar				la-maintained-school:117354	PRI		M			2012-08-31
+117355	Applecroft School	2X6MTHMA	919	3	11	Mrs Vicky Parsey				la-maintained-school:117355	PRI		M			2012-02-29
+117356	Ley Park Primary School	4D59VX	919	3	11	Mr Julian Thomas				la-maintained-school:117356	PRI		M			2008-08-31
+117357	Five Oaks Primary and Nursery School	2X6MTBF0	919	3	11	Mr A Boxer				la-maintained-school:117357	PRI		M			2004-08-31
+117358	Wood End School	2X6MTFBZ	919	4	11	Mr Richard Boulton				la-maintained-school:117358	PRI		M			
+117359	Eastbrook Primary School	2X6MV58T	919	5	11	Mr Geoff Allen				la-maintained-school:117359	PRI		M			2008-08-31
+117360	Meriden Primary School	5T8FR15X	919	3	11	Mrs R Mattison				la-maintained-school:117360	PRI		M			2005-08-31
+117361	Bengeo Primary School	9B09W62	919	3	11	Mrs Julie Starkiss				la-maintained-school:117361	PRI		M			
+117362	Stream Woods Junior Mixed Infant and Nursery School	5T8JHCD2	919	3	11	Mrs Beverley Garwood				la-maintained-school:117362	PRI		M			2007-08-31
+117363	Morgans Primary School & Nursery	9B09KZQ	919	3	11	Mrs Alis Rocca				la-maintained-school:117363	PRI		M			
+117364	The Leys Primary and Nursery School	2X6MX9R5	919	3	11	Ms Leigh Humphries				la-maintained-school:117364	PRI		M			
+117365	Belswains Primary School	2X6MVAEA	919	3	11	Mr Michael Fearnhead				la-maintained-school:117365	PRI		M			
+117366	Bonneygrove Primary School	4D4MDG	919	3	11	Mrs Anne Gorolini				la-maintained-school:117366	PRI		M			
+117367	Burleigh Primary School	4D4WFP	919	4	11	Mr Nick Norman				la-maintained-school:117367	PRI		M			
+117368	Hobbs Hill Wood Primary School	2X6MVA3W	919	3	11	Mr Richard Haynes				la-maintained-school:117368	PRI		M			
+117369	Cranborne Primary School	9AE03PB	919	3	11	Mr Charles Alan Cocker				la-maintained-school:117369	PRI		M			
+117370	Ladbrooke Junior Mixed and Infant School	9B1AKBC	919	3	11	Miss T Webster				la-maintained-school:117370	PRI		M			
+117371	Oakmere Primary School	9B1AJKB	919	3	11	Mrs Elizabeth Haynes				la-maintained-school:117371	PRI		M			
+117372	Sunny Bank Junior School	9AE03NR	919	7	11	Mr K Hooper				la-maintained-school:117372	PRI		M			1999-08-31
+117373	Sunny Bank Infants' School	9AE03NR	919	3	7	Mr  Hooper				la-maintained-school:117373	PRI		M			1999-08-31
+117374	Nascot Wood Infant and Nursery School	5T8FR0J2	919	3	7	Ms Pam Scragg				la-maintained-school:117374	PRI		M			
+117375	The Pines Junior Mixed and Infant School	2X6MXBM9	919	4	11	Mr M J K Marshall				la-maintained-school:117375	PRI		M			2003-08-31
+117376	Hartsfield Junior Mixed and Infant School	9C3H4K7	919	4	11	Mrs Philippa Smith				la-maintained-school:117376	PRI		M			
+117377	Holtsmere End Infant and Nursery School	2X6MV5B2	919	3	7	Mrs Nicola O'Connell				la-maintained-school:117377	PRI		M			
+117378	Commonswood Primary & Nursery School	2X6MTH6E	919	4	11	Mrs Gillian Seymour				la-maintained-school:117378	PRI		M			
+117379	Millbrook School	4D4TB6	919	4	11	Mrs Ruth Bamlett				la-maintained-school:117379	PRI		M			
+117380	Manor Fields Primary School	2X6MTKPQ	919	3	11	Ms Tina Jarman				la-maintained-school:117380	PRI		M			
+117381	Bellgate Primary School	5T8JQF4Y	919	4	11	Mr Andy Whelan				la-maintained-school:117381	PRI		M			2008-08-31
+117382	Aldbury Church of England Primary School	2X6MV8DA	919	4	11	Mrs Natasha Chiswell	C22		CE32	la-maintained-school:117382	PRI		M			
+117383	St John's Church of England Infant and Nursery School	9B1AHEP	919	3	7	Mrs Alice Aharon	C22		CE32	la-maintained-school:117383	PRI		M			
+117384	St Mary's Infants' School	9APZMWE	919	5	7	 Claire Gunn	C22		CE32	la-maintained-school:117384	PRI		M			
+117385	St Mary's Junior Mixed School	2X6MXMZZ	919	7	11	Mrs Patricia Jenkins	C22		CE32	la-maintained-school:117385	PRI		M			
+117386	Barley Church of England Voluntary Controlled First School	2X6MXNGE	919	5	9	 Margaret Davies-Mckeon	C22		CE32	la-maintained-school:117386	PRI		M			
+117387	Bayford Church of England Voluntary Controlled Primary School	2X6MXBTA	919	3	11	Mr Jonathan Preston	C22		CE32	la-maintained-school:117387	PRI		M			
+117388	Tonwell St Mary's Church of England Primary School	2X6MXAD5	919	3	11	Mrs Sarah Bridgman	C22		CE32	la-maintained-school:117388	PRI		M			
+117389	Benington Church of England Primary School	9B09TXM	919	4	11	Mrs J Stevens	C22		CE32	la-maintained-school:117389	PRI		M			
+117390	Layston Church of England First School	9B09N7S	919	5	9	Mrs Myra Bloomfield	C22		CE32	la-maintained-school:117390	PRI		M			
+117391	Ashfield Junior School	9B1AJY4	919	7	11	Mrs Carolyn Dalziel				la-maintained-school:117391	PRI		M			
+117392	Codicote Church of England Primary School	2X6MXHA4	919	3	11	Mrs Liz Pollard	C22		CE32	la-maintained-school:117392	PRI		M			
+117393	Essendon CofE (VC) Primary School	2X6MTHWN	919	3	11	Mrs Charlotte Tudway	C22		CE32	la-maintained-school:117393	PRI		M			
+117394	Furneux Pelham Church of England School	9B1RA9H	919	4	11	Mrs Brigid Dyson	C22		CE32	la-maintained-school:117394	PRI		M			
+117395	Graveley Primary School	2X6MXGZ5	919	4	11	Mrs Lisa Massey	C22		CE32	la-maintained-school:117395	PRI		M			
+117396	Ponsbourne St Mary's Church of England Primary School	2X6MXBT5	919	4	11	Mrs Dorothy Marlow	C22		CE32	la-maintained-school:117396	PRI		M			
+117397	Hertford St Andrew CofE Primary School	9B09VSP	919	3	11	Mrs Lyn Stark	C22		CE32	la-maintained-school:117397	PRI		M			
+117398	High Wych Church of England Primary School	9B1RA9Z	919	3	11	Mrs Mandy West	C22		CE32	la-maintained-school:117398	PRI		M			
+117399	St Paul's Voluntary Controlled Church of England Infants' School	4D5EGC	919	5	7	Mrs Ca Eames	C22		CE32	la-maintained-school:117399	PRI		M			2002-12-31
+117400	Wormley Primary School	4D59VX	919	3	11	Mrs Tracy Gaiteri	C22		CE32	la-maintained-school:117400	PRI		M			
+117401	Ickleford Primary School	9C3H9EJ	919	4	11	Mrs S Dury	C22		CE32	la-maintained-school:117401	PRI		M			
+117402	Little Munden Church of England Voluntary Controlled Primary School	9B1N3BC	919	3	11	Mrs Marina Breeze	C22		CE32	la-maintained-school:117402	PRI		M			
+117403	Preston Primary School	9C3H4EC	919	4	11	Miss Vicky Lunniss	C22		CE32	la-maintained-school:117403	PRI		M			
+117404	Sarratt Church of England Primary School	5T8FRA17	919	4	11	Mrs Pippa Bremner	C22		CE32	la-maintained-school:117404	PRI		M			
+117405	Spellbrook Primary School	9B09PAV	919	3	11	Mrs Gill Vise	C22		CE32	la-maintained-school:117405	PRI		M			
+117406	Roger De Clare First CofE School	9B09WFN	919	3	9	Mrs L Woods	C22		CE32	la-maintained-school:117406	PRI		M			
+117407	St Andrew's Church of England Voluntary Controlled Primary School	9B09WH6	919	3	11	Mrs Shirley Arnold	C22		CE32	la-maintained-school:117407	PRI		M			
+117408	Thundridge Church of England Primary School	2X6MXADA	919	3	11	 Paula Greatrex	C22		CE32	la-maintained-school:117408	PRI		M			
+117409	St Mary's Voluntary Controlled Church of England Junior School	2X6MXA4K	919	7	11	Mr Andy Cosslett	C22		CE32	la-maintained-school:117409	PRI		M			
+117410	St Catherine's Church of England Primary School	9B09WT8	919	3	11	 Hazel Wing	C22		CE32	la-maintained-school:117410	PRI		M			
+117411	Musley Infant School	2X6MXADK	919	5	7	Mrs P A Staras	C22		CE32	la-maintained-school:117411	PRI		M			2003-08-31
+117412	Wareside Church of England Primary School	9B09XT0	919	2	11	Mrs Wendy-May Foster	C22		CE32	la-maintained-school:117412	PRI		M			
+117413	Weston Primary School	9C3H8X2	919	3	11	Mr Geoff Holmes	C22		CE32	la-maintained-school:117413	PRI		M			
+117414	Potten End CofE Primary School	5T8JQEX2	919	3	11	Mr Andrew Morris	C22		CE32	la-maintained-school:117414	PRI		M			
+117415	Dewhurst St Mary CofE Primary School	4D5QVQ	919	5	11	Mrs Susan Wilcox	C22		CE32	la-maintained-school:117415	PRI		M			
+117416	Leverstock Green Church of England Primary School	2X6MV4PH	919	3	11	Mrs Victoria Burgess	C22		CE32	la-maintained-school:117416	PRI		M			
+117417	St Paul's Church of England Primary School, Langleybury	9A1STCM	919	3	11	Mrs Sarah Winter	C22		CE32	la-maintained-school:117417	PRI		M			
+117418	Nash Mills Church of England Primary School	5T8JQ82D	919	3	11	 Rosemary Washford Mower	C22		CE32	la-maintained-school:117418	PRI		M			
+117419	Albury Church of England Voluntary Aided Primary School	2X6MXA42	919	2	11	Mr James Howard	C22		CE32	la-maintained-school:117419	PRI		M			
+117420	Ardeley St Lawrence Church of England Voluntary Aided Primary School	9B1RA8S	919	3	11	Mrs Jenny Dingley	C22		CE32	la-maintained-school:117420	PRI		M			
+117421	Aston St Mary's Church of England Aided Primary School	9B09TW7	919	4	11	Mrs Julie Winwood	C22		CE32	la-maintained-school:117421	PRI		M			
+117422	Barkway VA Church of England First School	9C3H55T	919	5	9	 Sharon Brown	C22		CE32	la-maintained-school:117422	PRI		M			
+117423	Victoria Church of England Infant and Nursery School	5T8JQ7K1	919	3	7	Mrs Zoe Kernohan-Neely	C22		CE32	la-maintained-school:117423	PRI		M			
+117424	St Mary's CofE Primary School, Northchurch	5T8JQGB2	919	3	11	Miss Vanessa Hunt	C22		CE32	la-maintained-school:117424	PRI		M			
+117425	St Joseph's Catholic Primary School	9B09V4B	919	3	11	Mr Peter Coldwell	C67		RC01	la-maintained-school:117425	PRI		M			
+117426	St Michael's Church of England Primary School	2X6MTKB7	919	3	11	Mrs Lisa Dale	C22		CE32	la-maintained-school:117426	PRI		M			
+117427	St Clement's Church of England Voluntary Aided Junior School	4D55NA	919	7	11	Miss Sam Sweetman	C22		CE32	la-maintained-school:117427	PRI		M			2010-08-31
+117428	Holy Trinity Church of England Primary School	4D4TAK	919	4	11	Miss Sarah Chaloner	C22		CE32	la-maintained-school:117428	PRI		M			
+117429	St Joseph's Catholic Primary School	4D51HB	919	3	11	Mr Tony Gorton	C67		RC01	la-maintained-school:117429	PRI		M			
+117430	All Saints Church of England Voluntary Aided Primary School, Datchworth	9B09VQ6	919	5	11	Mr S Whiteland	C22		CE32	la-maintained-school:117430	PRI		M			
+117431	St Nicholas Elstree Church of England VA Primary School	9B1AHZ8	919	3	11	 Kate Johnston-Grant	C22		CE32	la-maintained-school:117431	PRI		M			
+117432	St John the Baptist Voluntary Aided Church of England Primary School	9B09VQM	919	4	11	Miss Lydia Hunt	C22		CE32	la-maintained-school:117432	PRI		M			
+117433	Great Gaddesden Church of England Primary School	9A2N3ZG	919	4	11	Mrs Nikki Comer	C22		CE32	la-maintained-school:117433	PRI		M			
+117434	St Nicholas CofE VA Primary School	5T8JAR4F	919	4	11	Ms Rizelle Crouch	C22		CE32	la-maintained-school:117434	PRI		M			
+117435	St John's Voluntary Aided Church of England Primary School, Lemsford	5T8JHC7Q	919	4	11	Mrs Mandy Evans	C22		CE32	la-maintained-school:117435	PRI		M			
+117436	St Joseph's Catholic Primary School	9B09KVV	919	3	11	Mr Ian Kendal	C67		RC01	la-maintained-school:117436	PRI		M			
+117437	Broxbourne CofE Primary School	4D5AD2	919	3	11	Mr Paul Miller	C22		CE32	la-maintained-school:117437	PRI		M			
+117438	St Augustine Roman Catholic Primary School	4D5FRY	919	3	11	Mrs Gillian Napier	C67		RC01	la-maintained-school:117438	PRI		M			
+117439	Hormead Church of England (VA) First School	9B1N45D	919	3	9	Mr Philip Asher	C22		CE32	la-maintained-school:117439	PRI		M			
+117440	St Ippolyts Church of England Aided Primary School	2X6MXGZ6	919	5	11	 Rachel Peddie	C22		CE32	la-maintained-school:117440	PRI		M			
+117441	St Paul's Church of England Voluntary Aided Primary School, Chipperfield	2X6MYKF6	919	3	11	Miss Caroline Moore	C22		CE32	la-maintained-school:117441	PRI		M			
+117442	Norton St Nicholas CofE (VA) Primary School	2X6MXJXW	919	3	11	Mr Stephen Cowdery	C22		CE32	la-maintained-school:117442	PRI		M			
+117443	Little Gaddesden Church of England Voluntary Aided Primary School	2X6MVAPK	919	4	11	Mrs Charis Geoghegan	C22		CE32	la-maintained-school:117443	PRI		M			
+117444	St Andrew's CofE Primary School and Nursery	9B09WAV	919	3	11	Mrs Judy King	C22		CE32	la-maintained-school:117444	PRI		M			
+117445	Offley Endowed Primary School	9C3HAY7	919	4	11	Mrs Anne Peck	C22		CE32	la-maintained-school:117445	PRI		M			
+117446	Cockernhoe Endowed CofE Primary School	9C3H7Z4	919	3	11	Mr Simon Philby	C22		CE32	la-maintained-school:117446	PRI		M			
+117447	St Mary's Church of England Primary School, Rickmansworth	5T8FR94D	919	3	11	Mr Aaron Wanford	C22		CE32	la-maintained-school:117447	PRI		M			
+117448	St Peter's Church of England Voluntary Aided Primary School	2X6MYHQ6	919	4	11	Ms Philippa Golding	C22		CE32	la-maintained-school:117448	PRI		M			
+117449	The Abbey Church of England Voluntary Aided Primary School, St Albans	5T8JAEJ1	919	4	11	Miss Emma Fenn	C22		CE32	la-maintained-school:117449	PRI		M			
+117450	St Alban and St Stephen Roman Catholic Infant and Nursery School	5T8JAH43	919	3	7	Mrs Bernadette Dempsey	C67		RC01	la-maintained-school:117450	PRI		M			
+117451	St Michael's Church of England Voluntary Aided Primary School, St Albans	9A1REK6	919	5	11	Mrs Alison Rafferty	C22		CE32	la-maintained-school:117451	PRI		M			
+117452	Park Street Church of England Voluntary Aided Primary School	5T8JAHE1	919	3	11	Mrs Tina Facer	C22		CE32	la-maintained-school:117452	PRI		M			
+117453	Puller Memorial, Church of England, Voluntary Aided Primary School	9B1RB29	919	3	11	Mrs Tracy Keddie	C22		CE32	la-maintained-school:117453	PRI		M			
+117454	St Thomas of Canterbury Roman Catholic Primary School	9B09WFA	919	3	11	Mrs Michelle Keating	C67		RC01	la-maintained-school:117454	PRI		M			
+117455	Stapleford Primary School		919	2	11	Mr James Shillito	C22		CE32	la-maintained-school:117455	PRI		M			
+117456	St Nicholas CofE (VA) Primary School and Nursery	9C3QNK2	919	3	11	Mrs Sarah Stevens	C22		CE32	la-maintained-school:117456	PRI		M			
+117457	Tewin Cowper Church of England Voluntary Aided Primary School	2X6MTFVR	919	4	11	Mrs Alison Simpson	C22		CE32	la-maintained-school:117457	PRI		M			
+117458	Bishop Wood Church of England Junior School, Tring	2X6MV8D8	919	7	11	Mrs L Hardman	C22		CE32	la-maintained-school:117458	PRI		M			
+117459	Long Marston VA Church of England Primary School	5T8JQGSM	919	5	11	Mrs Clare South	C22		CE32	la-maintained-school:117459	PRI		M			
+117460	St John's CofE Primary School	5T8JHAGW	919	3	11	Mr R A Price	C22		CE32	la-maintained-school:117460	PRI		M			
+117461	St Michael's Woolmer Green CofE VA Primary School	5T8JHCKE	919	4	11	Mr Brendan Mallon	C22		CE32	la-maintained-school:117461	PRI		M			
+117462	St Helen's Church of England Primary School	2X6MTEJG	919	4	11	Mr Jamie Brown	C22		CE32	la-maintained-school:117462	PRI		M			
+117463	St Bartholomew's Church of England Voluntary Aided Primary School, Wigginton	5T8JQEXV	919	4	11	Mrs Sally Roycroft	C22		CE32	la-maintained-school:117463	PRI		M			
+117464	Our Lady Roman Catholic Primary School	5T8JHBYW	919	4	11	 Catherine Corr	C67		RC01	la-maintained-school:117464	PRI		M			
+117465	St Joseph Catholic Primary School	5T8FR5R8	919	3	11	Mrs Linda Payne	C67		RC01	la-maintained-school:117465	PRI		M			
+117466	St Teresa Roman Catholic Primary School	9B1AHH8	919	3	11	Ms Teresa McBride	C67		RC01	la-maintained-school:117466	PRI		M			
+117467	St Andrew's Church of England Voluntary Aided Primary School, Hitchin	5T8GM5Z1	919	4	11	Ms Deborah Fenn	C22		CE32	la-maintained-school:117467	PRI		M			
+117468	St Cuthbert Mayne Catholic Junior School	5T8JQ7VV	919	7	11	Mrs Bernadette Quinn	C67		RC01	la-maintained-school:117468	PRI		M			
+117469	St Philip Howard Catholic Primary School	2X6MTBE4	919	4	11	Mrs Mairead Waugh	C67		RC01	la-maintained-school:117469	PRI		M			
+117470	St Adrian Roman Catholic Primary School	5T8JAQT5	919	3	11	Mrs Yvonne Hawkes	C67		RC01	la-maintained-school:117470	PRI		M			
+117471	Saint Albert the Great Catholic Primary School	5T8JQE5F	919	3	11	Mrs Kathryn Little	C67		RC01	la-maintained-school:117471	PRI		M			
+117472	All Saints Church of England Primary School and Nursery, Bishop's Stortford	2X6MTM1E	919	3	11	Miss Heidi Otranen	C22		CE32	la-maintained-school:117472	PRI		M			
+117473	Christ Church CofE (VA) Primary School and Nursery, Ware	2X6MXAE3	919	3	11	Mrs Ania Vaughan	C22		CE32	la-maintained-school:117473	PRI		M			
+117474	St Margaret Clitherow Roman Catholic Primary School	9C3QNHJ	919	3	11	Mr Jonathan White	C67		RC01	la-maintained-school:117474	PRI		M			
+117475	St John Catholic Primary School	5T8FR8CM	919	4	11	Mr Peter Sweeney	C67		RC01	la-maintained-school:117475	PRI		M			
+117476	Our Lady Roman Catholic Primary School	9C3H984	919	5	11	Mrs Susan Brown	C67		RC01	la-maintained-school:117476	PRI		M			2012-06-30
+117477	St Thomas More Roman Catholic Primary School	2X6MXKNC	919	3	11	Mrs Mary Hewitson	C67		RC01	la-maintained-school:117477	PRI		M			2012-06-30
+117478	St Dominic Catholic Primary School	5T8JAR3X	919	3	11	Mrs Elizabeth O'brien	C67		RC01	la-maintained-school:117478	PRI		M			
+117479	St Thomas More Roman Catholic Voluntary Aided Primary School	2X6MVBEF	919	3	11	Miss Isabel Cerasale	C67		RC01	la-maintained-school:117479	PRI		M			
+117480	St John Fisher Roman Catholic Primary School	5T8JAK3D	919	4	11	Mrs Laura Flitton	C67		RC01	la-maintained-school:117480	PRI		M			
+117481	The Holy Family Catholic Primary School	5T8HFFSD	919	3	11	Ms Ginnette Stevens	C67		RC01	la-maintained-school:117481	PRI		M			
+117482	Countess Anne Voluntary Aided Church of England Primary School, Hatfield	5T8JH8CZ	919	5	11	Mr David Lodge	C22		CE32	la-maintained-school:117482	PRI		M			2013-09-30
+117483	St Cross Catholic Primary School	4D5EF8	919	5	11	Mrs Kathryn Hall	C67		RC01	la-maintained-school:117483	PRI		M			
+117484	St Rose's Catholic Infants School	2X6MTS96	919	3	7	Mrs Rebecca Tregear	C67		RC01	la-maintained-school:117484	PRI		M			
+117485	Divine Saviour Roman Catholic Primary School	5T8FRBGB	919	3	11	Mr Stephen Wheatley	C67		RC01	la-maintained-school:117485	PRI		M			
+117486	Holy Rood Catholic Junior School	9A95YCZ	919	7	11	Ms E Ward	C67		RC01	la-maintained-school:117486	PRI		M			2006-08-31
+117487	St John Roman Catholic Primary School	9ADX0CA	919	3	11	Ms Alex Hanou	C67		RC01	la-maintained-school:117487	PRI		M			2012-06-30
+117488	Sacred Heart Catholic Primary School and Nursery	9B1AJXK	919	3	11	Mrs Carolyn Hatch	C67		RC01	la-maintained-school:117488	PRI		M			
+117489	Saint Bernadette Catholic Primary School	5T8GM26F	919	4	11	Mrs Elisabeth Barton	C67		RC01	la-maintained-school:117489	PRI		M			
+117490	Welwyn St Mary's Church of England Voluntary Aided Primary School	2X6MTG51	919	4	11	Mrs Mary Westley	C22		CE32	la-maintained-school:117490	PRI		M			
+117491	Saint Alban and St Stephen Catholic Junior School	5T8JAH43	919	7	11	Mr C D Soyka	C67		RC01	la-maintained-school:117491	PRI		M			
+117492	St Paul's Catholic Primary School	4D4Q8A	919	3	11	Mrs Yvonne Devereux	C67		RC01	la-maintained-school:117492	PRI		M			
+117493	Sacred Heart Catholic Primary School	9B1AJXK	919	4	11	Mrs Michelle Fusi	C67		RC01	la-maintained-school:117493	PRI		M			
+117494	Holy Rood RC Infants' School	9A95YCZ	919	3	7	Mrs M T Woodcock	C67		RC01	la-maintained-school:117494	PRI		M			2006-08-31
+117495	St Anthony's Catholic Primary School	5T8FR0DR	919	3	11	Mrs Pauline Wilson	C67		RC01	la-maintained-school:117495	PRI		M			
+117496	Pope Paul Catholic Primary School	9B1AJKK	919	4	11	Mrs Liz Heymoz	C67		RC01	la-maintained-school:117496	PRI		M			
+117497	St Mary's Church of England Primary School	2X6MTHYM	919	4	11	Mrs Vicky Humbles	C22		CE32	la-maintained-school:117497	PRI		M			
+117498	Saint Vincent de Paul Catholic Primary School	9B0E1TM	919	4	11	 Peter Keane	C67		RC01	la-maintained-school:117498	PRI		M			
+117499	The Priory School	9C3H7F5	919	11	18	Mr Geraint Edwards				la-maintained-school:117499	SEC		M			
+117500	The Hemel Hempstead School	5T8JQ7X5	919	11	18	Mr Patrick Harty				la-maintained-school:117500	SEC		M			
+117501	Richard Hale School	9B09VXK	919	11	18	Mr Stephen Neate				la-maintained-school:117501	SEC		B			2013-06-30
+117502	Hitchin Boys' School	2X6MXHSD	919	11	18	Mr Martin Brown				la-maintained-school:117502	SEC		B			2012-12-31
+117503	Hitchin Girls' School	2X6MXHBD	919	11	18	Mrs Frances Manning				la-maintained-school:117503	SEC		G			2011-08-16
+117504	Fearnhill School	9C3H9D6	919	11	18	Ms Elizabeth Ellis				la-maintained-school:117504	SEC		M			
+117505	Verulam School	5T8FVP7Q	919	11	18	Mr David Kellaway				la-maintained-school:117505	SEC		B			2011-07-31
+117506	Presdales School	2X6MXAZE	919	11	18	Mrs Janine Robinson				la-maintained-school:117506	SEC		G			2012-03-31
+117507	Stanborough School	2X6MTHCA	919	11	18	Mr Peter J Brown				la-maintained-school:117507	SEC		M			2012-01-31
+117508	Langleybury School	9A1STGM	919	11	18	  				la-maintained-school:117508	SEC		M			1996-09-01
+117509	The Knights Templar School	2X6MXN06	919	11	18	Mr Andrew Pickering				la-maintained-school:117509	SEC		M			2011-03-31
+117510	The Hillside School	9B1AHNG	919	13	18	Mr T E Westrip				la-maintained-school:117510	SEC		M			2000-08-31
+117511	Sir John Lawes School	2X6MTFDH	919	11	18	Ms Claire Robins				la-maintained-school:117511	SEC		M			2011-07-31
+117512	Adeyfield School	2X6MV4HS	919	11	18	Mr Scott Martin				la-maintained-school:117512	SEC		M			
+117513	Norton School	9APZDCT	919	11	18	Ms  Roberts				la-maintained-school:117513	SEC		M			2002-08-31
+117514	Beaumont School	2X6MTE5Z	919	11	18	Mrs Elizabeth Hitch				la-maintained-school:117514	SEC		M			2012-06-30
+117515	Barclay School	2X6N0357	919	11	18	Ms Jacqui O'Connor				la-maintained-school:117515	SEC		M			
+117516	Hawksmoor School	9AE03ZN	919	13	18	Mr P G Tompkins				la-maintained-school:117516	SEC		M			2000-08-31
+117517	The Heathcote School	2X6MXG43	919	11	18	Mr Edward Joseph Gaynor				la-maintained-school:117517	SEC		M			2012-08-31
+117518	Barnwell School	2X6MXG42	919	11	18	Mr A Fitzpatrick				la-maintained-school:117518	SEC		M			
+117519	Simon Balle School	2X6MXBT7	919	11	18	Mrs Alison Saunders				la-maintained-school:117519	SEC		M			2013-10-31
+117520	Roundwood Park School	2X6MTFB6	919	11	18	Mr Alan Henshall				la-maintained-school:117520	SEC		M			2011-07-31
+117521	Lyndhurst Middle School	9B1AKC2	919	9	13	Mr M Howell				la-maintained-school:117521	MDS		M			2001-08-31
+117522	Francis Combe School and Community College	9AQ026H	919	11	18	Miss Nicky Williams				la-maintained-school:117522	SEC		M			2009-08-31
+117523	Longdean School	2X6MV9YH	919	11	18	Mr Rhodri Bryant				la-maintained-school:117523	SEC		M			2011-07-31
+117524	St Albans Girls' School	2X6MTDMM	919	11	18	Mrs Margaret Chapman				la-maintained-school:117524	SEC		G			2011-08-31
+117525	Sir Frederic Osborn School	2X6MTGFN	919	11	18	Mr Jed Whelan				la-maintained-school:117525	SEC		M			
+117526	Kings Langley School	5T8JQHE1	919	11	18	Mr Gary Lewis				la-maintained-school:117526	SEC		M			2012-11-30
+117527	Bishop's Hatfield Girls' School	2X6MTBBS	919	11	18	Ms Theodora Nickson				la-maintained-school:117527	SEC		G			2011-12-31
+117528	The Cavendish School	2X6MTSE5	919	11	18	Mrs Sarah Lansley				la-maintained-school:117528	SEC		M			
+117529	The Broxbourne School	4D5AAK	919	11	18	Mr M F Titchmarsh				la-maintained-school:117529	SEC		M			2010-12-31
+117530	The Nobel School	9C3QPF9	919	11	18	Mr Martyn Henson				la-maintained-school:117530	SEC		M			
+117531	Turnford School	4D547M	919	11	18	Mrs Joanne Gant				la-maintained-school:117531	SEC		M			2015-08-31
+117532	Westfield Community Technology College	2X6MYE5R	919	11	18	Ms Emma Aylesbury				la-maintained-school:117532	SEC		M			2013-08-31
+117533	Collenswood School	9C3QPAP	919	11	18	Dr Jenny Francis				la-maintained-school:117533	SEC		M			2006-08-31
+117534	Marriotts School	9C3QRXM	919	11	18	Ms Bethany Honnor				la-maintained-school:117534	SEC		M			
+117535	The Sele School	2X6MXCRP	919	11	18	Mr Nick Binder				la-maintained-school:117535	SEC		M			2012-07-31
+117536	Monk's Walk School	5T8JH9XV	919	11	18	Mrs Kate Smith				la-maintained-school:117536	SEC		M			2012-08-31
+117537	The Highfield School	2X6MXKNB	919	11	18	Mr Ian Morris				la-maintained-school:117537	SEC		M			
+117538	Sheredes School	4D5BSY	919	11	18	Mr Ced De La Croix				la-maintained-school:117538	SEC		M			2016-08-31
+117539	Meridian School	2X6MXNC2	919	13	18	Dr M Firth				la-maintained-school:117539	SEC		M			2011-10-31
+117540	Freman College	2X6MXP1R	919	13	18	Ms Helen Loughran				la-maintained-school:117540	SEC		M			2011-07-31
+117541	Bridgewater Primary School	5T8JQEGB	919	4	11	Mrs Caren Doodson				la-maintained-school:117541	PRI		M			
+117542	The Greneway School	2X6MXNC1	919	9	13	Mrs Sai Kennedy				la-maintained-school:117542	MDS		M			2011-10-31
+117543	Ralph Sadleir Middle School	9B09WFM	919	9	13	Mrs E Hinton				la-maintained-school:117543	MDS		M			2013-09-30
+117544	Furzehill Middle School	9B1AHM5	919	9	13	Mr J P Fryer				la-maintained-school:117544	MDS		M			2001-08-31
+117545	Roysia Middle School	2X6MXNAP	919	9	13	Mr Peter Fielden				la-maintained-school:117545	MDS		M			2011-10-31
+117546	Sir John Newsom School	2X6MTH64	919	11	18	  				la-maintained-school:117546	SEC		M			1998-08-31
+117547	Onslow St Audrey's School	2X6MTBBK	919	11	18	Mr Paul Meredith				la-maintained-school:117547	SEC		M			2011-12-31
+117548	Sandringham School	5T8JAHHX	919	11	18	Mr Alan Gray				la-maintained-school:117548	SEC		M			2011-03-31
+117549	Birchwood High School	9B09QS4	919	11	18	Mr Chris Ingate				la-maintained-school:117549	SEC		M			2011-10-31
+117550	The Thomas Alleyne School	9C3QN4X	919	11	18	Mr Mark Lewis				la-maintained-school:117550	SEC		M			2013-08-31
+117551	The Chauncy School	2X6MXAD9	919	11	18	Mr Dennis O'sullivan				la-maintained-school:117551	SEC		M			2011-07-31
+117552	The Astley Cooper School	2X6MV56T	919	11	18	Mr Edward Gaynor				la-maintained-school:117552	SEC		M			
+117553	Tring School	2X6MV863	919	11	18	Mrs Julia Wynd	C22		CE32	la-maintained-school:117553	SEC		M			2012-06-30
+117554	Edwinstree Church of England Middle School	2X6MXNXN	919	9	13	Mrs J Gant	C22		CE32	la-maintained-school:117554	MDS		M			
+117555	Townsend CofE School	5T8JAHPF	919	11	18	Mr A Wellbeloved	C22		CE32	la-maintained-school:117555	SEC		M			
+117556	St George's School	2X6N02Y7	919	11	18	Mr Norman Hoare	C1			la-maintained-school:117556	SEC		M			2012-06-30
+117557	John F Kennedy Catholic School	2X6MTSAV	919	11	18	Mr Paul Neves	C67		RC01	la-maintained-school:117557	SEC		M			
+117558	Loreto College	2X6MTA14	919	11	18	Mrs Maire Lynch	C67		RC01	la-maintained-school:117558	SEC		G			2012-04-30
+117559	The Thomas Coram Church of England School	5T8JQHHF	919	7	11	Mr Rob Halls	C22		CE32	la-maintained-school:117559	PRI		M			
+117560	St Mary Roman Catholic Primary School	2X6MXNF8	919	3	11	Mr Robert Dunbar	C67		RC01	la-maintained-school:117560	PRI		M			2012-06-30
+117561	Christ Church Church of England School	5T8FR9KA	919	3	11	Mr Duncan Gauld	C22		CE32	la-maintained-school:117561	PRI		M			2013-03-31
+117562	Parkside Community Primary School	9B1AHGK	919	3	11	Mr Steven Perrin				la-maintained-school:117562	PRI		M			
+117563	Hertingfordbury Cowper Primary School	9B09W9Z	919	4	11	Mrs Alison Richards	C22		CE32	la-maintained-school:117563	PRI		M			
+117564	St Giles' CofE Primary School	9B1AJ33	919	4	11	Mrs Susan Ridge	C22		CE32	la-maintained-school:117564	PRI		M			
+117565	Cuffley School	2X6MTNZM	919	3	11	Mrs Wendy Heyes				la-maintained-school:117565	PRI		M			
+117566	The Wroxham School	9B1AJKR	919	4	11	Mrs Alison Peacock				la-maintained-school:117566	PRI		M			2012-05-31
+117567	Little Heath Primary School	5T8JHCF1	919	3	11	Mrs Kim Custis				la-maintained-school:117567	PRI		M			
+117568	Little Reddings Primary School	9B1AJVM	919	3	11	Mrs H M Maddox				la-maintained-school:117568	PRI		M			2012-01-31
+117569	Northaw Church of England Primary School	5T8JH99K	919	3	11	Mrs Shirley Whales	C22		CE32	la-maintained-school:117569	PRI		M			
+117570	Brookmans Park Primary School	2X6MTJ65	919	4	11	Mrs Aileen Davies				la-maintained-school:117570	PRI		M			
+117571	St Catherine of Siena Catholic Primary School	5T8FR6JX	919	4	11	Ms P Curran	C67		RC01	la-maintained-school:117571	PRI		M			2012-06-30
+117572	Rickmansworth School	2X6MYHSM	919	11	18	Dr Stephen Burton				la-maintained-school:117572	SEC		M			2011-03-31
+117573	Watford Grammar School for Boys	5T8FR167	919	11	18	Mr M Post	C22			la-maintained-school:117573	SEC		B			2010-08-31
+117574	Francis Bacon School	2X6MTAPX	919	11	18	Mr Matthew Gauthier				la-maintained-school:117574	SEC		M			2012-08-31
+117575	Watford Grammar School for Girls	5T8FR333	919	11	18	Mrs H Hyde	C22			la-maintained-school:117575	SEC		G			2010-08-31
+117576	Parmiter's School	2X6MYGZH	919	11	18	Mr Nick Daymond				la-maintained-school:117576	SEC		M			2011-06-30
+117577	The Bishop's Stortford High School	2X6MTK6F	919	11	18	Mr Dale Reeve				la-maintained-school:117577	SEC		B			
+117578	Ashlyns School	5T8GAB7X	919	11	18	Mr James Shapland				la-maintained-school:117578	SEC		M			
+117579	Dame Alice Owen's School	9B1AJKN	919	11	18	Doctor A J Davison				la-maintained-school:117579	SEC		M			2011-03-31
+117580	Bushey Meads School	9B1AK1T	919	11	18	Mr Keith Douglas				la-maintained-school:117580	SEC		M			2012-01-31
+117581	Bushey Hall School	9B1AJXE	919	11	18	Mr Graham Yapp				la-maintained-school:117581	SEC		M			2009-08-31
+117582	Queens' School	9AE04NH	919	11	18	Mr Terence James				la-maintained-school:117582	SEC		M			2011-06-30
+117583	Mount Grace School	9AE051S	919	11	18	Mr Peter Baker				la-maintained-school:117583	SEC		M			2011-07-31
+117584	Nicholas Breakspear Catholic School	2X6MTE5Y	919	11	18	Mr Phil Jakszta	C67		RC01	la-maintained-school:117584	SEC		M			2012-02-29
+117585	The John Henry Newman Catholic School	9C3QMQ7	919	11	18	Mr Michael Kelly	C67		RC01	la-maintained-school:117585	SEC		M			2012-02-29
+117586	Marlborough School	2X6MT9S6	919	11	18	Ms Annie Thomson				la-maintained-school:117586	SEC		M			2012-03-31
+117587	Goffs School	4D4ME9	919	11	18	Mrs Alison Garner				la-maintained-school:117587	SEC		M			2011-09-30
+117588	The Leventhorpe School	2X6MTJCP	919	11	18	Mr Jonathan Locke				la-maintained-school:117588	SEC		M			2011-07-31
+117589	Saint Michael's Catholic High School	5T8FR6GF	919	11	18	Mr John Murphy	C67		RC01	la-maintained-school:117589	SEC		M			2012-02-29
+117590	Saint Joan of Arc Catholic School	2X6MSZSZ	919	11	18	Mr Peter Sweeney	C67		RC01	la-maintained-school:117590	SEC		M			2012-02-29
+117591	Chancellor's School	2X6MTHZS	919	11	18	Mr David Croston				la-maintained-school:117591	SEC		M			
+117592	The Hertfordshire & Essex High School and Science College	2X6MZTDB	919	11	18	Mrs Cathy Tooze				la-maintained-school:117592	SEC		G			2014-03-31
+117593	St Clement Danes School	2X6MYJWD	919	11	18	Dr Josephine Valentine				la-maintained-school:117593	SEC		M			2011-06-30
+117594	St Mary's Catholic School	2X6MTJQC	919	11	18	Mr A Celano	C67		RC01	la-maintained-school:117594	SEC		M			
+117595	St Mary's Church of England High School (VA)	4D5Z7N	919	11	18	Ms Stephanie Benbow	C22		CE32	la-maintained-school:117595	SEC		M			2012-06-30
+117596	Cheshunt School	4D4TEG	919	11	18	Mr Andy Stainton				la-maintained-school:117596	SEC		M			
+117597	The John Warner School	4D5J74	919	11	18	Mr D J Kennedy				la-maintained-school:117597	SEC		M			2011-03-31
+117598	Hockerill Anglo-European College	9B09QK4	919	11	18	Mr Simon Dennis				la-maintained-school:117598	SEC		M			2011-01-31
+117599	Holmshill School	9AE03ZM	919	9	13	Mr C Wright				la-maintained-school:117599	MDS		M			2001-08-31
+117600	Abbot's Hill School	2X6MZSBC	919	3	16	Mrs E Thomas		C22		school-type:11			G		1941-01-01	
+117601	Edge Grove School	9AD5D5B	919	3	13	Mr Ben Evans		C1		school-type:11			M		1938-01-01	
+117602	The Aldenham Foundation	9B1AK1W	919	3	19	Mr J C Fowler	C22	C22		school-type:11			M		1910-01-01	
+117603	Berkhamsted School for Girls	2X6MVB5T	919	3	19	  		C22		school-type:11			G			1996-12-06
+117604	Berkhamsted School	9A2N5H3	919	3	19	Mr M S Steed	C4;C1	C1		school-type:11			M		1902-01-01	
+117605	Bishop's Stortford College	2X6MZT6T	919	4	18	Mr Jeremy Gladwin		C1		school-type:11			M		1907-01-01	
+117606	St Margaret's School	9B1AJXQ	919	4	18	Mrs Rose Hardy		C22		school-type:11			G		1918-01-01	
+117607	Haileybury and Imperial Service College	9B0A2RT	919	11	18	Mr J Davies	C22	C22		school-type:11			M		1920-01-01	
+117608	Aldwickbury School	2X6MTEZM	919	4	13	Mr V W Hales		C22		school-type:11			B		1950-01-01	
+117609	Queenswood School	2X6MTHW3	919	11	18	Mrs Joanna Cameron	C49	C49		school-type:11			G		1919-01-01	
+117610	Westbrook Hay Prep School	5T8FVQ4M	919	3	14	Mr K D Young		C22		school-type:11			M		1920-01-01	
+117611	Lockers Park School	2X6MTRZW	919	5	14	Mr Christopher Wilson	C22	C22		school-type:11			B		1919-01-01	
+117612	St Christopher School	2X6MSN3M	919	3	19	Mr Richard Palmer		K20a;C1c		school-type:11			M		1929-01-01	
+117613	St Francis College	2X6MXKN9	919	3	18	Mrs Bronwen Goulding	C1	C1		school-type:11			G		1947-01-01	
+117614	Princess Helena College	9C3HAE9	919	11	18	Mrs Sue Wallace-Woodroffe	C22	C1		school-type:11			G		1919-01-01	
+117615	Radlett Preparatory School	9AD5AX0	919	4	11	Mr G White				school-type:11			M		1950-01-01	
+117616	Merchant Taylors' School	5T8FRA72	919	11	18	Mr S Everson		C22		school-type:11			B		1927-01-01	
+117617	St Albans High School for Girls	2X6MTA18	919	4	18	Mrs Jenny Brown	C4	C1		school-type:11			G		1908-01-01	
+117618	Tring Park School for the Performing Arts	5T8JQE17	919	8	18	Mr Stefan Anderson				school-type:11			M		1949-01-01	
+117619	Northfield School	5T8FR0HC	919	2	19	  		C22		school-type:11			G			1997-08-19
+117620	Beechwood Park School	5T8JQ7WB	919	3	13	Mr Edward Balfour		C22;C1		school-type:11			M		1930-01-01	
+117621	Heath Mount School	9B09XVA	919	3	13	Mr Chris Gillam		C1		school-type:11			M		1921-01-01	
+117622	Sherrardswood School	5T8JHE7M	919	3	19	Dr Markus Bernhardt				school-type:11			M		1950-01-01	
+117623	Egerton-Rothesay School	2X6MVBCY	919	6	19	Mr Colin Parker	C1	C1		school-type:11			M		1956-01-01	
+117624	St Hilda's School	9B1AJV4	919	2	11	Mrs T Handford		K20a;C1c		school-type:11			M		1957-10-18	
+117625	Westwood School	9B1AK06	919	5	6	Mrs J I Hill				school-type:11			M		1957-10-21	2009-07-09
+117626	Harpenden Preparatory School	2X6MTF8X	919	5	10	Mrs E Broughton				school-type:11			M		1958-03-05	2005-07-15
+117627	St Hilda's School	9B1AJV4	919	3	11	Mr Daniel Sayers		C22		school-type:11			G		1957-10-15	
+117628	Duncombe School	9B09W8M	919	2	11	Mr J Phelan		C22		school-type:11			M		1957-11-13	
+117629	St Joseph's in the Park	9B1N3RZ	919	3	11	Mr Douglas Brown		K20a;C1c		school-type:11			M		1957-10-15	
+117630	Kingshott School	9C3H9WD	919	3	13	Mr Mark Seymour				school-type:11			M		1951-10-30	
+117631	Rudolf Steiner School	2X6MYKBT	919	3	18	 Tina Hobday				school-type:11			M		1957-10-18	
+117632	The Barn School	2X6MX9XX	919	2	8	Mrs M M Renny		C67		school-type:11			M			1998-08-18
+117633	St Edmund's College	9B09SPZ	919	3	19	Mr Paulo Duran	C67	C67		school-type:11			M		1952-01-01	
+117634	Hart House School	9AD5D5B	919	2	7	  		C67		school-type:11			M			1999-03-22
+117635	Charlotte House Preparatory School	2X6MYJ52	919	3	11	Miss P Woodcock		C1		school-type:11			G		1957-01-01	
+117636	York House School	2X6MYJ7Z	919	3	13	Mr J Gray		C1		school-type:11			M		1956-01-01	
+117637	Homewood Independent School	5T8JAQSS	919	5	6	Mrs A Zeina				school-type:11			M		1957-10-22	2006-07-07
+117638	St Columba's College	2X6MTCZY	919	4	18	Mr David Buxton	C67	C67		school-type:11			B		1957-12-06	
+117639	Francis House Preparatory School	2X6MZ9W3	919	3	11	Mrs H Stanton-Tonner				school-type:11			M		1957-10-17	2014-12-12
+117640	Stanborough Secondary School	2X6N040E	919	11	18	Mrs Loraine Dixon	C73	C73		school-type:11			M		1957-12-03	
+117641	Royal Masonic School for Girls	5T8FR936	919	4	18	Ms D Rose				school-type:11			G		1935-01-01	
+117642	St Francis College	9C3H2ZP	919	3	12	Mrs  Dorothy Macginty		C1		school-type:11			M		1947-01-01	2012-04-30
+117643	Lochinver House School	9B1AJKE	919	4	13	Mr Ben Walker		C22		school-type:11			B		1952-01-01	
+117644	Stormont School	9B1AJMG	919	4	11	Mrs Sharon Martin				school-type:11			G		1944-01-01	
+117645	St Columba's Preparatory School	5T8JAQ7V	919	5	10	Mr E F Brown		C67		school-type:11			B		1966-10-28	2005-02-02
+117646	Radlett Lodge School	2X6MYN7R	919	4	19	Miss Jo Galloway				school-type:10			M		1974-09-30	
+117647	St Albans School	5T8JAGTK	919	11	19	Mr Jonathan Gillespie	C1;C1c	C1		school-type:11			B		1980-09-30	
+117648	Haberdashers' Aske's Boys' School	9B1AHHC	919	5	18	Mr P B Hamilton				school-type:11			B		1980-09-30	
+117649	Haberdashers' Aske's School for Girls	9B1AGR6	919	4	18	Miss B A O'Connor		C1		school-type:11			G		1980-09-30	
+117650	The King's School	5T8JAREK	919	4	16	Mr C Case	C1	C1		school-type:11			M		1982-09-14	
+117651	Merchant Taylors' Prep School	5T8FR93A	919	3	13	Dr Karen McNerney	C1	C1		school-type:11			B		1922-01-01	
+117652	Radlett Nursery and Infant School	9B1AH7W	919	5	6	Mrs J Briggs				school-type:11			M		1983-06-21	2005-09-01
+117653	Berkhamsted Pre-Prep School	2X6MVB6A	919	3	7	 Karen O'connor				school-type:11			M		1985-04-29	
+117654	Bhaktivedanta Manor School	9B1AK1Z	919	4	11	Mrs Wendy Harrison	D1	D1		school-type:11			M		1985-05-16	
+117656	Haresfoot Senior School	2X6MVAY2	919	11	17	Ms L Stuart				school-type:11			M			2000-10-17
+117657	Immanuel College	9AD52PD	919	4	19	Mr Charles Dormer	F1	F1		school-type:11			M		1990-10-31	
+117658	Manor Lodge School	9B1AHEB	919	3	11	Mr Gil Dunn				school-type:11			M		1992-02-04	
+117659	Warrax House School	2X6ME1FT	919	11	16	Ms Sally Glossap				school-type:10			M		1992-02-03	2006-03-31
+117660	High Elms Manor School	5T8FRBHC	919	1	11	Mrs Sheila O'Neill				school-type:11			M		1992-05-07	
+117661	South Lodge School	5T8FNG55	919	12	17	Miss M Sales		C22		school-type:11			G			1999-12-22
+117662	Longwood School	9B1AJXV	919	3	11	Mrs Claire May		K20a;C1c		school-type:11			M		1994-07-26	
+117663	Epping House School	9B09QVD	919	7	12	  				la-maintained-school:117663			M			1997-07-25
+117664	Pinewood School	2X6MZT45	919	11	16	Mr Adrian Lloyd				la-maintained-school:117664			M			2014-08-31
+117665	St Elizabeth's School	9B09NGR	919	5	19	Mrs Samantha Steinke-Sanderson				school-type:8			M			
+117666	Knightsfield School	5T8JHA3Z	919	10	18	Mrs Lucille Leith				la-maintained-school:117666			M			2012-07-31
+117667	Garston Manor School	5T8FR09X	919	11	16	Miss Christine deGraft-Hanson				la-maintained-school:117667			M			
+117668	Boxmoor House School	9A2N551	919	11	16	Mr J R Hooper				la-maintained-school:117668			B			2006-03-31
+117669	The Valley School	5T8FDH0D	919	11	16	Mrs Corina Foster				la-maintained-school:117669			M			
+117670	Colnbrook School	2X6MYD37	919	4	11	Ms Kerry Harris				la-maintained-school:117670			M			
+117671	St Luke's School	2X6MTDT8	919	9	16	Mr Paul Johnson				la-maintained-school:117671			M			
+117672	The Collett School	2X6MTS3N	919	4	16	Mr Stephen Hoult-Allen				la-maintained-school:117672			M			
+117673	Hailey Hall School	4D5CKW	919	11	16	Mrs Heather Boardman				la-maintained-school:117673			B			2015-08-31
+117674	Batchwood School	2X6MTDG1	919	11	16	Mr Miraz Triggs				la-maintained-school:117674			M			
+117675	The Hyde School		919	4	12	  				la-maintained-school:117675			M			1995-09-01
+117676	Middleton School	2X6MXBAD	919	4	11	Mrs Donna Jolly				la-maintained-school:117676			M			
+117677	Great Brookmead School	9AE059D	919	5	11	  				la-maintained-school:117677			M			1995-08-31
+117678	Hilltop School	5T8FDGKZ	919	5	11	  				la-maintained-school:117678			B			1996-08-31
+117679	Lonsdale School	9C3QRXM	919	3	18	Mrs Annemari Ottridge				la-maintained-school:117679			M			
+117680	Lakeside School	2X6MTHMB	919	2	19	Mrs Judith Chamberlain				la-maintained-school:117680			M			
+117681	Breakspeare School	2X6MYKRW	919	2	19	Ms Merja Paakkonen				la-maintained-school:117681			M			
+117682	Woodfield School	2X6MV9YK	919	3	19	Mrs Gill Waceba				la-maintained-school:117682			M			
+117683	Watling View School	2X6MT9W3	919	2	19	Ms Pauline B Atkins				la-maintained-school:117683			M			
+117684	Amwell View School	9B1N31S	919	2	19	Mrs J S Liversage				la-maintained-school:117684			M			
+117685	Heathlands School	2X6MTDHE	919	3	16	Mrs Deborah Jones-Stevens				la-maintained-school:117685			M			
+117686	Falconer School	9B1AJXG	919	11	16	Mr Jonathan Kemp				la-maintained-school:117686			B			
+117687	High Wick School	5T8FDH08	919	6	11	  				la-maintained-school:117687			M			1996-08-31
+117688	The Edward Jenner Hospital School	9AQQR2W	919	12	16	Mr M R Ingham				la-maintained-school:117688			M			1999-10-18
+117689	Woolgrove School	2X6MXKK6	919	4	12	Mrs Bridget Walton				la-maintained-school:117689			M			2012-03-31
+117690	Greenside School	9C3QNZ4	919	2	19	Mr Dave Victor				la-maintained-school:117690			M			
+117691	Meadow Wood School	9AE04RC	919	3	11	Ms Elizabeth Stratton				la-maintained-school:117691			M			
+127416	Holy Rood Catholic Primary School	9A95YCZ	919	3	11	Mr Stephen Wheatley	C67		RC01	la-maintained-school:127416	PRI		M		2006-09-01	
+127633	The Chrysalis School for Autism	9C3H328	919	5	16	Mrs Elizabeth Dun				school-type:10			M		2005-07-14	2011-03-26
+129109	Highfield Nursery School	9B09WJ3	919			  				la-maintained-school:129109	NUR					1988-08-31
+129110	Burleigh Junior School	4D4WFP	919	7	11	  				la-maintained-school:129110	PRI		M			1994-12-31
+129111	Belswains Junior School	2X6MVAE9	919	7	11	  				la-maintained-school:129111	PRI		M			1993-12-31
+129112	Morgans Walk Junior Mixed School	9B09KZQ	919	7	11	  				la-maintained-school:129112	PRI		M			1992-12-31
+129113	Mount Pleasant Lane Junior School	5T8JAMHS	919	7	11	  				la-maintained-school:129113	PRI		M			1989-08-31
+129114	Leavesden Green Junior Mixed School	2X6MYGZE	919	7	11	  				la-maintained-school:129114	PRI		M			1992-08-31
+129115	Hobbs Hill Wood Junior School	2X6MVA3W	919	7	11	  				la-maintained-school:129115	PRI		M			1995-08-31
+129116	Belswains Infants' School	5T8GM4PH	919	4	7	  				la-maintained-school:129116	PRI		M			1993-12-31
+129117	Hobbs Hill Wood Infants' School	2X6MVA3W	919	3	7	  				la-maintained-school:129117	PRI		M			1995-08-31
+129118	Bengeo Junior School	9APR87M	919	7	11	  				la-maintained-school:129118	PRI		M			1992-08-31
+129119	Bonneygrove Junior School	4D4MDG	919	7	11	  				la-maintained-school:129119	PRI		M			1993-12-31
+129120	Broad Oaks Junior Mixed School		919			  				la-maintained-school:129120	PRI					1991-08-31
+129121	Bishops Wood Infant School	5T8JHCC6	919			  				la-maintained-school:129121	PRI					1991-08-31
+129122	Bellgate Junior Mixed School	5T8JQF4Y	919	7	11	  				la-maintained-school:129122	PRI		M			1987-12-31
+129123	Meriden Junior School	5T8FR15X	919	7	11	  				la-maintained-school:129123	PRI		M			1992-08-31
+129124	St Stephen's Infant School		919			  				la-maintained-school:129124	PRI					1989-08-31
+129125	Millwards Junior Mixed School	5T8JHCD0	919	7	11	  				la-maintained-school:129125	PRI		M			1992-08-31
+129126	The Downs Infant School	5T8JHCD2	919	5	7	  				la-maintained-school:129126	PRI		M			1992-08-31
+129127	Bellgate Infant School	5T8JQF4Y	919	5	7	  				la-maintained-school:129127	PRI		M			1987-12-31
+129128	Meriden Infant School	5T8FR15X	919	5	7	  				la-maintained-school:129128	PRI		M			1992-08-31
+129129	Bonneygrove Infants' School	4D4MDG	919	4	7	  				la-maintained-school:129129	PRI		M			1993-12-31
+129130	Wood End Junior Mixed School	2X6MTFBZ	919	7	11	  				la-maintained-school:129130	PRI		M			1991-08-31
+129131	Chalk Dell Infant School	2X6MXBPQ	919	5	7	  				la-maintained-school:129131	PRI		M			1992-12-31
+129132	Bengeo Infant School	9B09W62	919	5	7	  				la-maintained-school:129132	PRI		M			1992-08-31
+129133	Grangewood Infants' School	4D5TD3	919	4	7	  				la-maintained-school:129133	PRI		M			1994-12-31
+129134	Cranbourne Junior School	4D5MF5	919	7	11	  				la-maintained-school:129134	PRI		M			1990-08-31
+129135	Dundale Infant School		919			  				la-maintained-school:129135	PRI					1988-08-31
+129136	Cranbourne Infant School	4D5MF5	919	5	7	  				la-maintained-school:129136	PRI		M			1990-08-31
+129137	Leavesden Green Infant School	2X6MYGZE	919	5	7	  				la-maintained-school:129137	PRI		M			1992-08-31
+129138	Wood End Infant School	2X6MTFBZ	919	5	7	  				la-maintained-school:129138	PRI		M			1991-08-31
+129139	Laurance Haines Infant School	5T8FR3MT	919			  				la-maintained-school:129139	PRI					1988-08-31
+129140	Eastbrook Junior School	2X6MV58T	919	7	11	  				la-maintained-school:129140	PRI		M			1991-08-31
+129141	Ley Park Junior School	4D59VX	919	7	11	  				la-maintained-school:129141	PRI		M			1991-08-31
+129142	Eastbrook Infant and Nursery School	2X6MV5B0	919	5	7	  				la-maintained-school:129142	PRI		M			1991-08-31
+129143	Wellfield Wood Junior School	2X6MX9R5	919	7	11	  				la-maintained-school:129143	PRI		M			1993-03-31
+129144	Grove Road Junior School	2X6MV8D9	919	7	11	  				la-maintained-school:129144	PRI		M			1992-12-31
+129145	Wellfield Wood Infant School	2X6MX9R5	919	5	7	  				la-maintained-school:129145	PRI		M			1993-03-31
+129146	Ley Park Infant School	4D59VX	919	5	7	  				la-maintained-school:129146	PRI		M			1991-08-31
+129147	Cottered VC Primary School		919	5	9	  				la-maintained-school:129147	PRI		M			1992-12-31
+129148	Westmill First School		919			  				la-maintained-school:129148	PRI					1989-08-31
+129149	Sir John Southworth RC Junior Mixed and Infant School		919			  				la-maintained-school:129149	PRI					1990-08-31
+129150	Pope Pius XII RC Primary School		919			  				la-maintained-school:129150	PRI					1990-08-31
+129151	Maragaret Dane School		919			  				la-maintained-school:129151	SEC					1990-08-31
+129152	Hadham Hall School	9B1RC7K	919			  				la-maintained-school:129152	SEC					1990-08-31
+129153	Hitchin School		919			  				la-maintained-school:129153	SEC					1988-08-31
+129154	Durrants School		919	11	18	  				la-maintained-school:129154	SEC		M			1991-08-31
+129155	Sir James Altham School		919			  				la-maintained-school:129155	SEC					1989-08-31
+129156	Hatfield School	5T8JHCG0	919			  				la-maintained-school:129156	SEC					1990-08-31
+129157	Thomas Alleynes School		919			  				la-maintained-school:129157	SEC					1989-08-31
+129158	Bowes Lyon High School		919			  				la-maintained-school:129158	SEC					1988-08-31
+129159	The Marshalwick School	5T8JAHHX	919	11	18	  				la-maintained-school:129159	SEC		M			1988-08-31
+129160	The Willian School	2X6MXKK5	919	11	18	  				la-maintained-school:129160	SEC		M			1991-08-31
+129161	Francis Bacon School	2X6MTAPX	919			  				la-maintained-school:129161	SEC					1990-08-31
+129162	Halsey School	9A2N789	919			  				la-maintained-school:129162	SEC					1988-08-31
+129163	The Mountbatten School	2X6MS6GV	919	11	18	  				la-maintained-school:129163	SEC		M			1991-08-31
+129164	Wheathampstead School	2X6MTEGK	919	11	18	  				la-maintained-school:129164	SEC		M			1988-08-31
+129165	Stevenage Girls' School		919			  				la-maintained-school:129165	SEC					1989-08-31
+129166	The Augustus Smith School		919			  				la-maintained-school:129166	SEC					1988-08-31
+129167	Bishopslea School		919			  				la-maintained-school:129167	SEC					1988-08-31
+129168	Cardinal Bourne School		919			  				la-maintained-school:129168	SEC					1988-08-31
+129169	Thomas Bourne CofE Middle School	2X6MVBCY	919			  				la-maintained-school:129169	MDS					1988-08-31
+129170	Roasry Priory High School	9B1AJW2	919			  				school-type:11						1988-07-08
+129171	Lyndale School	2X6N02M5	919	3	17	  				school-type:11			M			1994-01-06
+129172	Sherrardswood Junior School	5T8JHE7M	919			  				school-type:11					1950-01-01	2006-08-31
+129173	Rosary Priory Preparatory School	9B1AJW2	919			  				school-type:11						1988-07-08
+129174	Pamela Gardens School	2X6MDBK5	919			  				school-type:11						1991-01-09
+129176	Marlin Montessori School	9AEAAJW	919			  				school-type:11						1991-10-20
+129177	Stanborough Secondary School	2X6N040E	919			  				school-type:11					1950-01-01	2006-08-31
+129178	Broxbournebury School	4D5TCX	919			  				la-maintained-school:129178						1990-08-31
+129179	Chorleywood College		919	11	19	  				la-maintained-school:129179			G			1987-07-31
+129180	Elmfield School	5T8HFFQF	919	10	16	  				la-maintained-school:129180			M			1987-07-31
+129181	Hangers Wood School	5T8FR6C5	919	3	12	  				la-maintained-school:129181			M			1994-09-01
+129182	Brandles School	2X6MXMZX	919	11	13	  				la-maintained-school:129182			B			1990-09-30
+129183	Greenside School	9C3QNZ4	919			  				la-maintained-school:129183						1989-03-31
+129184	Harperbury Hospital School	2X6MYN1B	919			  				la-maintained-school:129184						1993-12-31
+129185	Springfield School	2X6N0380	919	3	19	  				la-maintained-school:129185			M			1993-12-31
+129186	Home Field School	9C3QNZ4	919	3	18	  				la-maintained-school:129186			M			1989-03-31
+130160	Summercroft Primary School	9B09V9Y	919	3	11	Mr Michael Smith				la-maintained-school:130160	PRI		M		2006-01-01	2011-08-31
+130338	Norfolk Lodge School Ltd	9B1AJM8	919	5	10	Mrs Mary Wales				school-type:11			M		1996-03-13	2009-08-31
+130344	North Area Pupil Referral Unit	9APZQ0C	919	5	16	Mrs Julie Vernon-Hamilton				la-maintained-school:130344			M		1995-09-01	
+130347	Hertford, Ware and Bishop's Stortford Area Pupil Referral Unit	9APR8VN	919	5	16	Mr Christopher Millard				la-maintained-school:130347			M		1995-09-01	2009-08-31
+130348	The Park Education Support Centre	9B1AK5M	919	5	16	Mrs J Porter				la-maintained-school:130348			M		1995-09-01	
+130349	South West Area Pupil Referral Unit	2X6MYG0S	919	5	16	Mrs Susan Howe				la-maintained-school:130349			M		1995-09-01	
+130355	Buntingford Area Pupil Referral Unit	2X6MXNXN	919	5	18	Mr M Knowles				la-maintained-school:130355			M		1996-04-01	1998-01-01
+130356	The Links Education Support Centre	5T8JAGKZ	919	5	16	Miss Tracey Healy				la-maintained-school:130356			M		1995-09-01	2013-01-31
+130359	Stevenage Education Support Centre	9C3QPE6	919	11	14	Ms Anne-Marie O'sullivan				la-maintained-school:130359			M		1995-09-01	
+130362	Southfield School	9CQJT5Q	919	4	11	Ms Libby Duggan				la-maintained-school:130362			M		1995-09-01	
+130363	Shepherd Montessori School	5T8FR93G	919	5	5	  				school-type:11			M		1996-05-02	1996-09-18
+130720	West Herts College	5T8FR0G2	919	16	99	Ms Gill Worgan				school-type:18	16P		M			
+130721	North Hertfordshire College	2X6MXKN8	919	16	99	Mr Matt Hamnett				school-type:18	16P		M			
+130722	Hertford Regional College	9B09WV0	919	16	99	Mr Andy Forbes				school-type:18	16P		M			
+130723	Oaklands College	5T8JASBR	919	16	99	Ms Zoe Hancock				school-type:18	16P		M			
+131060	Brandles School	2X6MXMZX	919	11	16	Mr David Andrew Vickery				la-maintained-school:131060			B		1993-10-25	
+131100	Dacorum Education Support Centre	2X6MV4HA	919	5	16	Ms Sara Lalis				la-maintained-school:131100			M		1995-09-01	
+131188	Bovingdon Primary School	2X6MV9XY	919	3	11	Mr Martin Mangan				la-maintained-school:131188	PRI		M		1998-09-01	2011-06-30
+131319	Haywood Grove School	2X6MV5B0	919	5	11	Mrs Catherine Smith				la-maintained-school:131319			M		1996-02-20	
+131456	Clore Shalom School	9B1AK53	919	3	11	Mr Ian Pattrick	F1			la-maintained-school:131456	PRI		M		1999-09-01	
+131503	Larwood School	2X6MX9RF	919	5	11	Mr S Trimble				la-maintained-school:131503			M			2016-10-31
+131505	Featherstone Wood Primary School	9C3QPDF	919	3	11	Miss Louise Shuttleworth				la-maintained-school:131505	PRI		M		1998-09-01	
+131651	Hertsmere Jewish Primary School	9B1AHEF	919	1	5	Mrs M Bazak		F1		school-type:11			M			1999-09-22
+131955	Hertsmere Jewish Primary School	9B1AHEF	919	3	11	Mr Steven Isaacs	F1			la-maintained-school:131955	PRI		M		1999-09-01	
+131971	Hertswood School	9AE03ZP	919	11	18	Mrs Jan Palmer Sayer				la-maintained-school:131971	SEC		M		2000-09-01	2012-08-31
+132015	St Elizabeth's College (The Congregation of the Daughters of the Cross of the Liege)	9B09NGR	919	19	25	Ms Kathy Cox	C67			school-type:32	16P		M		2006-06-20	
+132091	Lodge Farm Primary School	9C3QPF8	919	3	11	Miss Helen Turner				la-maintained-school:132091	PRI		M		2000-09-01	
+132105	Birchwood Avenue Primary School	9AE9CV7	919	5	11	Mrs Joanna DI-Bella				la-maintained-school:132105	PRI		M		2000-04-13	
+132118	Sunny Bank Primary School	9AE03NR	919	3	11	Mr K M Hooper				la-maintained-school:132118	PRI		M		1999-09-01	2008-08-31
+133065	Grove Road Infant School	2X6MV8D9	919	5	7	  				la-maintained-school:133065	PRI		M			2001-03-29
+133134	South Lodge School	5T8FNG55	919	11	17	  				school-type:11			G			1993-06-21
+133263	Roebuck Primary School and Nursery	9C3QNHH	919	3	11	Mr R Fordham				la-maintained-school:133263	PRI		M		2001-04-18	
+133295	Integrated Services Programme	2X6MM9N0	919	1	16	  				school-type:11			M		2001-03-26	2001-07-26
+133323	Oughton Primary and Nursery School	5T8GM5Z3	919	3	11	Mrs Lisa Clayton				la-maintained-school:133323	PRI		M		2001-09-01	
+133488	Swallow Dell Primary and Nursery School	9AE9CV8	919	2	11	Mrs Clare Hollingsworth				la-maintained-school:133488	PRI		M		2002-01-01	
+133738	Redemption Academy	9C3QPNH	919	3	18	Mrs S J Neale	C1	C1		school-type:11			M		2002-07-26	2015-07-16
+133773	St Catherine's Hoddesdon CofE Primary School	4D5FST	919	4	11	Mrs Amanda Staiano			CE32	la-maintained-school:133773	PRI		M		2003-01-01	
+133783	University of Hertfordshire	2X6MTBJ3	919			Professor Quintin McKellar				school-type:29			M			
+133917	Littlebury Resource Centre	4D5QVY	919	11	16	Mr D J Stacey				school-type:27			M		2000-09-01	2004-05-17
+133975	Muriel Green Nursery School	2X6MTDDH	919	3	5	Mrs Karen Ashton				la-maintained-school:133975	NUR		M		2001-01-01	
+134087	St Albans Independent College	2X6MT9QA	919	14	19	Mr Assim Jemal				school-type:11			M		2003-01-20	
+134197	Flamstead End Primary and Nursery School	4D4PHY	919	3	11	Mrs S Killey				la-maintained-school:134197	PRI		M		2003-09-01	2013-03-31
+134488	Littlebury Resource Centre	4D5QVY	919	11	16	  		C1		school-type:11			M		2003-08-29	2004-09-29
+134682	Windhill School	2X6MTKCB	919	3	11	Mrs Philippa Moore				la-maintained-school:134682	PRI		M		2006-01-01	2015-02-28
+134684	Berrygrove Primary and Nursery School	9A95Y4M	919	3	11	Mr Christopher Kronda				la-maintained-school:134684	PRI		M		2005-09-02	2012-08-31
+134685	Alban Wood Primary School and Nursery	2X6MYGZD	919	3	11	Mrs Rachel Kirk				la-maintained-school:134685	PRI		M		2005-09-02	
+134716	De Havilland Primary School	2X6MTBF0	919	3	11	 Andrew Peck				la-maintained-school:134716	PRI		M		2004-09-01	
+134786	Village Montessori	9A2N6TH	919	4	11	Mrs Amanda Kemp	C1			school-type:11			M		2004-09-01	2007-03-30
+134933	International Stanborough School	2X6N040E	919	11	18	Mrs Lorraine Dixon				school-type:11			M		2005-02-10	
+134985	Yavneh College	9AE03VX	919	11	18	Dr Dena Coleman	F1			la-maintained-school:134985	SEC		M		2006-09-01	2011-06-30
+135083	Longmeadow Primary School	5T8FDGYV	919	3	11	Miss Anne Heywood				la-maintained-school:135083	PRI		M		2005-09-01	
+135084	Shephalbury Park Primary School	9C3QNZ0	919	3	11	Ms Chelsea Atkins				la-maintained-school:135084	PRI		M		2005-09-01	
+135221	Maple Grove Primary School	2X6MV58T	919	3	11	Mr Geoffrey Allen				la-maintained-school:135221	PRI		M		2008-09-01	
+135222	Yewtree Primary School	5T8JQF4Y	919	3	11	Miss Faye Ewen				la-maintained-school:135222	PRI		M		2008-09-01	
+135223	Oak View Primary and Nursery School	2X6MTBEZ	919	3	11	Mrs Yvonne Davis				la-maintained-school:135223	PRI		M		2007-09-01	
+135224	Galley Hill Primary School and Nursery	2X6MTSE6	919	3	11	Mrs Emily Birch				la-maintained-school:135224	PRI		M		2008-09-01	
+135339	Broadfield Primary School	5T8JQEN7	919	3	11	Mrs Christine Hall				la-maintained-school:135339	PRI		M		2008-01-01	
+135402	Education and Youth Services (Herts)	5T8FDDY5	919	14	18	Mr Matthew Harvey				school-type:10			M		2007-09-05	2016-02-29
+135528	Killigrew Primary and Nursery School	5T8JAQST	919	3	11	Miss Tracy Mylotte				la-maintained-school:135528	PRI		M		2008-09-01	
+135553	Focus School - Cheshunt Primary Campus		919	7	11	Mrs Janice Tew-Cragg	C61	C1		school-type:11			M		2008-04-22	2014-10-22
+135560	Worldshapers Academy	9AQK0HS	919	13	16	Dr Arno Steen Andreasen	C1	C1		school-type:10			M		2008-04-24	2014-07-24
+135596	Stanborough Primary School	5T8FR15Q	919	3	11	Mrs K Hanson		C73		school-type:11			M		1957-12-03	
+135876	Francis Combe Academy	9AQ026H	919	11	18	Ms Debbie Warwick				academy-school:135876	SEC		M		2009-09-01	
+135890	Rivers Education Support Centre	4D5GPC	919	11	16	Mrs Janet Bourne				la-maintained-school:135890			M		2009-09-01	
+135938	The Bushey Academy	9B1AJXE	919	11	18	Mr Andrew Hemmings				academy-school:135938	SEC		M		2009-09-01	
+136024	Churchfield CofE VA Primary	4D609B	919	3	11	 Katharine Hardwick	C22		CE32	la-maintained-school:136024	PRI		M		2010-09-01	
+136247	Roman Fields	9A2N551	919	11	18	Mr Trevor Orchard				la-maintained-school:136247			M		2010-11-01	
+136276	Watford Grammar School for Boys	5T8FR167	919	11	18	 Ian Cooksey	C22			academy-school:136276	SEC		B		2010-09-01	
+136289	Watford Grammar School for Girls	5T8FR333	919	11	18	Mrs Clare Wagner	C22			academy-school:136289	SEC		G		2010-09-01	
+136396	The Broxbourne School	4D59W3	919	11	18	Ms Paula Humphreys				academy-school:136396	SEC		M		2011-01-01	
+136482	Hockerill Anglo-European College	9B09QK4	919	11	18	Mr Richard Markham				academy-school:136482	SEC		M		2011-02-01	
+136554	Dame Alice Owen's School	9B1AJKN	919	11	18	 Hannah Nemko				academy-school:136554	SEC		M		2011-04-01	
+136606	Rickmansworth School	2X6MYHSM	919	11	18	Mr Keith Douglas				academy-school:136606	SEC		M		2011-04-01	
+136607	The John Warner School	4D5J74	919	11	18	Mr David Kennedy				academy-school:136607	SEC		M		2011-04-01	
+136608	The Knights Templar School	2X6MXN06	919	11	18	Mr Tim Litchfield				academy-school:136608	SEC		M		2011-04-01	
+136609	Sandringham School	5T8JAHHX	919	11	18	Mr Alan Gray				academy-school:136609	SEC		M		2011-04-01	
+136857	Bovingdon Primary Academy	2X6MV9XY	919	3	11	Mrs Shereen Breslin				academy-school:136857	PRI		M		2011-07-01	
+136877	Queens' School	9AE04NH	919	11	18	Mr Jonathan Morrell				academy-school:136877	SEC		M		2011-07-01	
+136899	Parmiter's School	2X6MYGZH	919	11	18	Mr Nick Daymond				academy-school:136899	SEC		M		2011-07-01	
+136901	St Clement Danes School	2X6MYJWD	919	11	18	Dr Josephine Valentine				academy-school:136901	SEC		M		2011-07-01	
+136922	Yavneh College	9AE03VX	919	11	18	Mr Spencer Lewis	F1			academy-school:136922	SEC		M		2011-07-01	
+136973	Roundwood Park School	2X6MTFB6	919	11	18	Mr Alan Henshall				academy-school:136973	SEC		M		2011-08-01	
+137002	Freman College	2X6MXP1R	919	13	18	Ms Helen Loughran				academy-school:137002	SEC		M		2011-08-01	
+137038	Verulam School	5T8FVP7Q	919	11	18	Mr Paul Ramsey				academy-school:137038	SEC		B		2011-08-01	
+137090	The Chauncy School	2X6MXAD9	919	11	18	Mr Dennis O'Sullivan				academy-school:137090	SEC		M		2011-08-01	
+137110	Longdean School	2X6MV9YH	919	11	18	 Graham Cunningham				academy-school:137110	SEC		M		2011-08-01	
+137156	Leventhorpe	2X6MTJCP	919	11	18	Mr Jonathan Locke				academy-school:137156	SEC		M		2011-08-01	
+137224	Mount Grace School	9AE051S	919	11	18	Mr Peter Baker				academy-school:137224	SEC		M		2011-08-01	
+137238	Hammond Academy	5T8JQEQF	919	3	11	Mrs Laura Gregory				academy-school:137238	PRI		M		2011-08-01	
+137270	Sir John Lawes School	2X6MTFDH	919	11	18	 Claire Robins				academy-school:137270	SEC		M		2011-08-01	
+137288	Hitchin Girls' School	2X6MXHBD	919	11	18	Mrs F Manning				academy-school:137288	SEC		G		2011-08-17	
+137339	St Albans Girls' School	2X6MTDMM	919	11	18	Mrs Margaret Chapman				academy-school:137339	SEC		G		2011-09-01	
+137351	Summercroft Primary School	9B09V9Y	919	3	11	Mrs Carole Hinstridge				academy-school:137351	PRI		M		2011-09-01	
+137532	Goffs School	4D4ME9	919	11	18	Ms Alison Garner				academy-school:137532	SEC		M		2011-10-01	
+137637	Birchwood High School	9B09QS4	919	11	18	Mr Chris Ingate				academy-school:137637	SEC		M		2011-11-01	
+137656	Meridian School	2X6MXNC2	919	13	18	Miss Kim Horner				academy-school:137656	SEC		M		2011-11-01	
+137657	Roysia Middle School	2X6MXNAP	919	9	13	Miss Zoe Linington				academy-school:137657	MDS		M		2011-11-01	
+137658	The Greneway School	2X6MXNC1	919	9	13	Mrs Laura Rawlings				academy-school:137658	MDS		M		2011-11-01	
+137757	Bishop's Hatfield Girls' School	2X6MTBBS	919	11	18	 Theodora Nickson				academy-school:137757	SEC		G		2012-01-01	
+137792	Onslow St Audrey's School	2X6MTBBK	919	11	18	 Michael Harpham				academy-school:137792	SEC		M		2012-01-01	
+137847	Stanborough School	2X6MTHCA	919	11	18	Mr Peter Brown				academy-school:137847	SEC		M		2012-02-01	
+137861	Little Reddings Primary School	9B1AJVM	919	3	11	Miss C Simmonds				academy-school:137861	PRI		M		2012-02-01	
+137872	Bushey Meads School	9B1AK1T	919	11	18	 Jeremy Turner				academy-school:137872	SEC		M		2012-02-01	
+137895	The John Henry Newman Catholic School	9C3QMQ7	919	11	18	Mr C Mathew	C67		RC01	academy-school:137895	SEC		M		2012-03-01	
+137914	Saint Joan of Arc Catholic School	2X6MSZSZ	919	11	18	Mr Peter Sweeney	C67		RC01	academy-school:137914	SEC		M		2012-03-01	
+137922	Saint Michael's Catholic High School	5T8FR6GF	919	11	18	 Edward Conway	C67		RC01	academy-school:137922	SEC		M		2012-03-01	
+137938	Nicholas Breakspear Catholic School	2X6MTE5Y	919	11	18	Mr Declan Linnane	C67		RC01	academy-school:137938	SEC		M		2012-03-01	
+137943	Applecroft School	2X6MTHMA	919	3	11	Ms Lisa Withe				academy-school:137943	PRI		M		2012-03-01	
+137985	Presdales School	2X6MXAZE	919	11	18	Mr Matthew Warren				academy-school:137985	SEC		G		2012-04-01	
+137997	Woolgrove School, Special Needs Academy	2X6MXKK6	919	4	12	Mrs Lisa Hall				academy-school:137997			M		2012-04-01	
+138042	The Marlborough Science Academy	2X6MT9S6	919	11	18	Ms Annie Thomson				academy-school:138042	SEC		M		2012-04-01	
+138106	Loreto College	2X6MTA14	919	11	18	Mrs Marie Lynch	C67		RC01	academy-school:138106	SEC		G		2012-05-01	
+138201	Hatfield Community Free School	5T8JHC00	919	4	11	 Sue Attard				academy-school:138201	PRI		M		2012-09-01	
+138205	Fleetville Junior School	5T8JAG03	919	7	11	Mrs Androulla Peek				academy-school:138205	PRI		M		2012-06-01	
+138206	Fleetville Infant and Nursery School	2X6MTAHR	919	3	7	Mrs Alex Lindley				academy-school:138206	PRI		M		2012-06-01	
+138215	The Wroxham School	9B1AJKR	919	4	11	Mrs Alison Peacock				academy-school:138215	PRI		M		2012-06-01	
+138225	The Da Vinci Studio School of Science and Engineering	9C3QSD8	919	14	19	 Mark Lewis				academy-school:138225	SEC		M		2012-09-03	
+138231	Alban City School	5T8GN26J	919	5	11	 Janet Goddard				academy-school:138231	PRI		M		2012-09-01	
+138286	Beaumont School	2X6MTE5Z	919	11	18	Mrs Elizabeth Hitch				academy-school:138286	SEC		M		2012-07-01	
+138288	St Catherine of Siena Catholic Primary School	5T8FR6JX	919	4	11	Ms Nicola Kane	C67		RC01	academy-school:138288	PRI		M		2012-07-01	
+138292	St Mary Roman Catholic Primary School	2X6MXNF8	919	3	11	Mrs Julia Pearce	C67		RC01	academy-school:138292	PRI		M		2012-07-01	
+138316	St John Roman Catholic Primary School	9C3H55Z	919	3	11	Ms A Hanou	C67		RC01	academy-school:138316	PRI		M		2012-07-01	
+138322	Our Lady Catholic Primary School	9C3H984	919	5	11	Mrs S Brown	C67		RC01	academy-school:138322	PRI		M		2012-07-01	
+138352	Tring School	2X6MV863	919	11	18	 Susanna Collings	C22		CE32	academy-school:138352	SEC		M		2012-07-01	
+138354	St Thomas More Roman Catholic Primary School	2X6MXKNC	919	3	11	Mrs Jane Perry	C67		RC01	academy-school:138354	PRI		M		2012-07-01	
+138356	St George's School	2X6N02Y7	919	11	18	Mr Raymond McGovern	C1			academy-school:138356	SEC		M		2012-07-01	
+138360	St Mary's Church of England High School (VA)	4D5Z7N	919	11	18	Ms Stephanie Benbow	C22		CE32	academy-school:138360	SEC		M		2012-07-01	
+138389	Garden City Academy	2X6MXKK5	919	3	11	 Linda Meredith				academy-school:138389	PRI		M		2012-09-01	
+138484	The Sele School	2X6MXCRP	919	11	18	 Neil Dunn				academy-school:138484	SEC		M		2012-08-01	
+138485	Knightsfield School	5T8JHA3Z	919	10	18	 Lucille Leith				academy-school:138485			M		2012-08-01	
+138507	The Grove Academy	9A95Y4M	919	3	11	Mr Philip Gray				academy-school:138507	PRI		M		2012-09-01	
+138539	Northgate Primary School	2X6MTK10	919	3	11	Mrs Louisa Hotson				academy-school:138539	PRI		M		2012-08-01	
+138561	Harpenden Free School	9CSKJEK	919	4	11	Mrs Lisa Davies				academy-school:138561	PRI		M		2012-09-01	2016-08-31
+138582	Samuel Ryder Academy	2X6MTAPX	919	4	19	Mr Matt Gauthier				academy-school:138582	ALL		M		2012-09-01	
+138632	Monk's Walk School	5T8JH9XV	919	11	18	 Kate Smith				academy-school:138632	SEC		M		2012-09-01	
+138747	Hertswood Academy	9AE03ZP	919	11	18	 Peter Gillett				academy-school:138747	SEC		M		2012-09-01	
+139036	Kings Langley School	5T8JQHE1	919	11	18	Mr Gary Lewis				academy-school:139036	SEC		M		2012-12-01	
+139154	Hitchin Boys' School	2X6MXHSD	919	11	18	 Martin Brown				academy-school:139154	SEC		B		2013-01-01	
+139159	Mandeville Primary School	2X6MT9TB	919	3	11	Mrs Cathy Longhurst				academy-school:139159	PRI		M		2013-01-01	
+139197	Links Academy	5T8JAGKZ	919	5	16	 David Allen				academy-school:139197			M		2013-02-01	
+139416	The Elstree UTC	9AE09FM	919	14	19	Mr Chris Mitchell				academy-school:139416	SEC		M		2013-09-01	
+139507	Christ Church Chorleywood CofE School	5T8FR9KA	919	3	11	Mr Duncan Gauld	C22		CE32	academy-school:139507	PRI		M		2013-04-01	
+139545	Flamstead End School	4D4PHZ	919	2	11	Mrs Susan Killey				academy-school:139545	PRI		M		2013-04-01	
+139550	Chaulden Junior School	2X6MZR56	919	7	11	Mrs Moira White				academy-school:139550	PRI		M		2013-05-01	
+139662	The Reach Free School	9CQACQQ	919	11	18	Mr Richard Booth				academy-school:139662	SEC		M		2013-09-02	
+139835	Rhodes Farm School	2X6MTHY9	919	8	18	Mrs Karen El-Shirbini				school-type:11			M		2013-06-27	
+139873	Richard Hale School	9B09VXK	919	11	18	Mr Stephen Neate				academy-school:139873	SEC		B		2013-07-01	
+139902	The Da Vinci Studio School of Creative Enterprise	2X6MXKNA	919	14	19	 Mark Lewis				academy-school:139902	SEC		M		2013-09-02	
+140037	The Thomas Alleyne School	9C3QN4X	919	11	18	Mr Mark Lewis				academy-school:140037	SEC		M		2013-09-01	
+140049	Westfield Academy	2X6MYE5R	919	11	18	Mr Tim Body				academy-school:140049	SEC		M		2013-09-01	
+140238	Countess Anne Church of England School	5T8JH8CZ	919	5	11	 David Lodge	C22		CE32	academy-school:140238	PRI		M		2013-10-01	
+140249	Ralph Sadleir School	9B09WFM	919	9	13	 Dominic Spong				academy-school:140249	MDS		M		2013-10-01	
+140294	Simon Balle All-Through School	2X6MXBT7	919	4	18	Ms Alison Saunders				academy-school:140294	ALL		M		2013-11-01	
+140611	Wilshere-Dacre Junior Academy	9C3H8GG	919	7	11	Mrs Sarah Smith				academy-school:140611	PRI		M		2014-03-01	
+140707	Crabtree Infants' School	2X6MTFQ9	919	5	7	Mrs Sally Pattrick				academy-school:140707	PRI		M		2014-04-01	
+140708	Crabtree Junior School	2X6MTFQN	919	7	11	Mr Ian Pattrick				academy-school:140708	PRI		M		2014-04-01	
+140786	The Hertfordshire & Essex High School and Science College	2X6MZTDB	919	11	18	 Cathy Tooze				academy-school:140786	SEC		G		2014-04-01	
+140954	Lanchester Community Free School	9CPSCCP	919	4	11	 Helen Lockham				academy-school:140954	PRI		M		2014-09-01	
+140955	Jupiter Community Free School	2X6MV4WB	919	4	11	 Sue Attard				academy-school:140955	PRI		M		2014-09-01	
+140956	Ascot Road Community Free School	9CPSCH5	919	4	11	Mrs Helen Lockham				academy-school:140956	PRI		M		2014-09-01	
+141004	The Watford UTC	9CPSCN0	919	14	19	Ms Emma Loveland				academy-school:141004	SEC		M		2014-09-01	
+141251	Pinewood School	2X6MZT45	919	11	16	 David McGachen				academy-school:141251			M		2014-09-01	
+141851	Windhill21	2X6MTKCB	919	3	11	 Phillippa Moore				academy-school:141851	PRI		M		2015-03-01	
+141898	Fair Field Junior School	9B1AHFC	919	7	11	 Matt Johnson				academy-school:141898	PRI		M		2015-04-01	
+142051	Haileybury Turnford	4D547M	919	11	18	Mr Robin Newman				academy-school:142051	SEC		M		2015-09-01	
+142221	Watford St John's Church of England Primary School	2X6MKQRD	919	4	11	Mrs Helen Langeveld	C22;C1	C22		academy-school:142221	PRI		M		2016-09-07	
+142257	Hailey Hall School	4D5CKW	919	11	16	 P Flint				academy-school:142257			B		2015-09-01	
+142413	Garden City Montessori School	2X6MXM92	919	2	12	  				school-type:11			M		2015-09-22	
+142862	Yavneh Primary School	9B1AHNG	919	4	11	Mrs Caroline Field	F7			academy-school:142862	PRI		M		2016-09-01	
+143131	Robert Barclay Academy	4D5BSY	919	11	18	Mr Ced De La Croix				academy-school:143131	SEC		M		2016-09-01	
+143409	Roselands Primary School	4D5CE2	919	5	11	Mrs J Carson				academy-school:143409	PRI		M		2016-09-01	
+143410	The Cranbourne Primary School	4D5MF5	919	4	11	Mrs Rachel Semark				academy-school:143410	PRI		M		2016-09-01	
+143603	Laurance Haines School		919	3	11	Mr James Roach				academy-school:143603	PRI		M		2016-11-01	
+143604	Larwood School		919	5	11	Mr S Trimble				academy-school:143604			M		2016-11-01	
+143648	Harpenden Free School		919	4	11	Mrs Lisa Davies				academy-school:143648	PRI				2016-09-01	


### PR DESCRIPTION
- Introduce `organisation` curie field to `school-eng`.
- Use `organisation` field to link from a record in the `school-eng` register to the applicable `academy-school` or `la-maintained-school` record when appropriate.
- If neither academy or LA maintained, can default to linking to school-type field for now.